### PR TITLE
feat: add Kiro CLI token tracking with SQLite-backed approximation

### DIFF
--- a/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
+++ b/dashboard/edge-patches/tokentracker-leaderboard-refresh.ts
@@ -74,6 +74,11 @@ const MODEL_PRICING: Record<string, { input: number; output: number; cache_read:
   "kimi-for-coding": { input: 0.6, output: 2, cache_read: 0.15 },
   "kimi-k2.5": { input: 0.6, output: 2, cache_read: 0.15 },
   "kimi-k2.5-free": { input: 0, output: 0, cache_read: 0 },
+  // ── AWS Kiro (mirrored byte-for-byte from src/lib/local-api.js to
+  //    prevent cloud/local cost drift — Kiro routes through Bedrock,
+  //    most commonly claude-sonnet-4). ──
+  "kiro-agent": { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+  "kiro-cli-agent": { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
   // ── Misc / Free ──
   "glm-4.7-free": { input: 0, output: 0, cache_read: 0 },
   "nemotron-3-super-free": { input: 0, output: 0, cache_read: 0 },
@@ -99,6 +104,7 @@ function getModelPricing(model: string) {
   if (lower.includes("gemini-3")) return MODEL_PRICING["gemini-3-flash-preview"];
   if (lower.includes("gemini-2.5")) return MODEL_PRICING["gemini-2.5-pro"];
   if (lower.includes("kimi")) return MODEL_PRICING["kimi-k2.5"];
+  if (lower.includes("kiro")) return MODEL_PRICING["kiro-cli-agent"];
   if (lower.includes("composer")) return MODEL_PRICING["composer-1"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -20,7 +20,7 @@ const { collectTrackerDiagnostics } = require("../lib/diagnostics");
 const { probeOpenclawHookState } = require("../lib/openclaw-hook");
 const { probeOpenclawSessionPluginState } = require("../lib/openclaw-session-plugin");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
-const { resolveKimiWireFiles } = require("../lib/rollout");
+const { resolveKimiWireFiles, resolveKiroCliDbPath } = require("../lib/rollout");
 
 async function cmdStatus(argv = []) {
   const opts = parseArgs(argv);
@@ -118,6 +118,13 @@ async function cmdStatus(argv = []) {
   const kimiHome = process.env.KIMI_HOME || path.join(home, ".kimi");
   const kimiInstalled = fssync.existsSync(path.join(kimiHome, "sessions"));
 
+  // Kiro CLI — reads from SQLite at
+  // ~/Library/Application Support/kiro-cli/data.sqlite3. End-user dashboards
+  // show CLI and IDE merged under a single "Kiro" brand; this status line
+  // surfaces the CLI sub-path separately for operators.
+  const kiroCliDbPath = resolveKiroCliDbPath(process.env);
+  const kiroCliInstalled = fssync.existsSync(kiroCliDbPath);
+
   const copilotToken = readCopilotOauthToken({ home });
   const copilotOtel = describeCopilotOtelStatus({ home, env: process.env });
   const copilotLines = formatCopilotLines({ token: copilotToken, otel: copilotOtel });
@@ -146,6 +153,9 @@ async function cmdStatus(argv = []) {
       `- OpenClaw hook (legacy): ${openclawHookState?.configured ? "set" : "unset"}`,
       kimiInstalled
         ? `- Kimi Code: passive reader (${kimiWireFiles.length} wire.jsonl file${kimiWireFiles.length !== 1 ? "s" : ""} found)`
+        : null,
+      kiroCliInstalled
+        ? `- Kiro CLI: SQLite data.sqlite3 found (tokens approximated from char lengths, merged under 'kiro' source)`
         : null,
       ...copilotLines,
       ...subscriptionLines,

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -27,6 +27,9 @@ const {
   parseCopilotIncremental,
   resolveKimiWireFiles,
   parseKimiIncremental,
+  resolveKiroCliSessionFiles,
+  resolveKiroCliDbPath,
+  parseKiroCliIncremental,
 } = require("../lib/rollout");
 const { createProgress, renderBar, formatNumber, formatBytes } = require("../lib/progress");
 const {
@@ -359,6 +362,39 @@ async function cmdSync(argv) {
       });
     }
 
+    // ── Kiro CLI (reads ~/Library/Application Support/kiro-cli/data.sqlite3) ──
+    // Runs IN PARALLEL with the Kiro IDE branch above — NOT instead of it.
+    // Both emit source='kiro' so totals merge transparently; cursor state
+    // is isolated in cursors.kiroCli. Kiro CLI does not persist explicit
+    // token counts; we approximate from user_prompt_length / response_size
+    // at 4 chars/token and mark the model '<model>~approx' so the
+    // approximation is visible in model-breakdown.
+    let kiroCliResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    const kiroCliDb = resolveKiroCliDbPath(process.env);
+    if (fssync.existsSync(kiroCliDb)) {
+      if (progress?.enabled) {
+        progress.start(`Parsing Kiro CLI ${renderBar(0)} | buckets 0`);
+      }
+      try {
+        kiroCliResult = await parseKiroCliIncremental({
+          cursors,
+          queuePath,
+          env: process.env,
+          onProgress: (p) => {
+            if (!progress?.enabled) return;
+            const pct = p.total > 0 ? p.index / p.total : 1;
+            progress.update(
+              `Parsing Kiro CLI ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} convs | buckets ${formatNumber(p.bucketsQueued)}`,
+            );
+          },
+        });
+      } catch (err) {
+        if (!opts.auto) {
+          process.stderr.write(`Kiro CLI sync: ${err.message}\n`);
+        }
+      }
+    }
+
     // ── Kimi (passive wire.jsonl reader) ──
     let kimiResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const kimiWireFiles = resolveKimiWireFiles(process.env);
@@ -496,6 +532,7 @@ async function cmdSync(argv) {
         opencodeResult.filesProcessed +
         cursorResult.recordsProcessed +
         kiroResult.recordsProcessed +
+        kiroCliResult.recordsProcessed +
         hermesResult.recordsProcessed +
         kimiResult.recordsProcessed +
         copilotResult.recordsProcessed;
@@ -507,6 +544,7 @@ async function cmdSync(argv) {
         opencodeResult.bucketsQueued +
         cursorResult.bucketsQueued +
         kiroResult.bucketsQueued +
+        kiroCliResult.bucketsQueued +
         hermesResult.bucketsQueued +
         kimiResult.bucketsQueued +
         copilotResult.bucketsQueued;

--- a/src/lib/diagnostics.js
+++ b/src/lib/diagnostics.js
@@ -16,6 +16,7 @@ const { normalizeState: normalizeUploadState } = require("./upload-throttle");
 const { probeOpenclawHookState } = require("./openclaw-hook");
 const { probeOpenclawSessionPluginState } = require("./openclaw-session-plugin");
 const { resolveTrackerPaths } = require("./tracker-paths");
+const { resolveKiroCliDbPath } = require("./rollout");
 
 async function collectTrackerDiagnostics({
   home = os.homedir(),
@@ -81,6 +82,25 @@ async function collectTrackerDiagnostics({
   });
   const openclawHookState = await probeOpenclawHookState({ home, trackerDir, env: process.env });
 
+  // Kiro IDE and Kiro CLI sub-path presence — merged under one "kiro" source
+  // at token/cost aggregation level; operators need visibility of both
+  // sub-paths here for debugging.
+  const kiroIdeDevDataDir = path.join(
+    home,
+    "Library",
+    "Application Support",
+    "Kiro",
+    "User",
+    "globalStorage",
+    "kiro.kiroagent",
+    "dev_data",
+  );
+  const kiroIdePresent =
+    (await safeStatSize(path.join(kiroIdeDevDataDir, "devdata.sqlite"))) > 0 ||
+    (await safeStatSize(path.join(kiroIdeDevDataDir, "tokens_generated.jsonl"))) > 0;
+  const kiroCliDbPath = resolveKiroCliDbPath(process.env);
+  const kiroCliPresent = require("node:fs").existsSync(kiroCliDbPath);
+
   const lastSuccessAt = uploadThrottle.lastSuccessMs
     ? new Date(uploadThrottle.lastSuccessMs).toISOString()
     : null;
@@ -104,6 +124,16 @@ async function collectTrackerDiagnostics({
       claude_config: redactValue(claudeConfigPath, home),
       gemini_config: redactValue(geminiSettingsPath, home),
       opencode_config: redactValue(opencodeConfigDir, home),
+      kiro_ide_dev_data: redactValue(kiroIdeDevDataDir, home),
+      kiro_cli_db: redactValue(kiroCliDbPath, home),
+    },
+    kiro: {
+      ide_present: kiroIdePresent,
+      cli_present: kiroCliPresent,
+      cli_approximation:
+        "Kiro CLI does not persist explicit token counts; tokens are approximated at 4 chars/token from user_prompt_length and response_size in the conversations_v2 SQLite table. Model names are suffixed '~approx' in model-breakdown.",
+      merge_policy:
+        "Kiro IDE and Kiro CLI both emit source='kiro' in queue.jsonl so token, cost, heatmap, and leaderboard aggregations merge transparently. Use this block to distinguish sub-path contributions.",
     },
     config: {
       base_url: typeof config?.baseUrl === "string" ? config.baseUrl : null,

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -63,6 +63,14 @@ const MODEL_PRICING = {
   "kimi-for-coding": { input: 0.6, output: 2, cache_read: 0.15 },
   "kimi-k2.5": { input: 0.6, output: 2, cache_read: 0.15 },
   "kimi-k2.5-free": { input: 0, output: 0, cache_read: 0 },
+  // ── AWS Kiro (Kiro IDE + Kiro CLI — both route through Bedrock, most
+  //    commonly claude-sonnet-4; rates mirror the sonnet-4 table below so
+  //    costs stay consistent with the real underlying model when a Bedrock
+  //    model_id isn't exposed). Mirrored byte-for-byte in
+  //    dashboard/edge-patches/tokentracker-leaderboard-refresh.ts for
+  //    leaderboard estimated_cost_usd. ──
+  "kiro-agent": { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
+  "kiro-cli-agent": { input: 3, output: 15, cache_read: 0.3, cache_write: 3.75 },
   // ── Misc / Free ──
   "glm-4.7-free": { input: 0, output: 0, cache_read: 0 },
   "nemotron-3-super-free": { input: 0, output: 0, cache_read: 0 },
@@ -90,6 +98,7 @@ function getModelPricing(model) {
   if (lower.includes("gemini-3")) return MODEL_PRICING["gemini-3-flash-preview"];
   if (lower.includes("gemini-2.5")) return MODEL_PRICING["gemini-2.5-pro"];
   if (lower.includes("kimi")) return MODEL_PRICING["kimi-k2.5"];
+  if (lower.includes("kiro")) return MODEL_PRICING["kiro-cli-agent"];
   if (lower.includes("composer")) return MODEL_PRICING["composer-1"];
   if (lower === "auto") return MODEL_PRICING["composer-1"];
   return ZERO_PRICING;
@@ -1061,4 +1070,11 @@ function createLocalApiHandler({ queuePath }) {
   };
 }
 
-module.exports = { createLocalApiHandler, resolveQueuePath };
+module.exports = {
+  createLocalApiHandler,
+  resolveQueuePath,
+  // Exported for cross-consumer tests (pricing + native contract lock).
+  MODEL_PRICING,
+  getModelPricing,
+  computeRowCost,
+};

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3065,6 +3065,437 @@ function resolveKimiDefaultModel(env = process.env) {
 }
 // ─────────────────────────────────────────────────────────────────────────────
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Kiro CLI — reads historical conversation state from
+// ~/Library/Application Support/kiro-cli/data.sqlite3 (table conversations_v2).
+// Kiro CLI does NOT store explicit token counts locally. Each request row
+// carries: user_prompt_length (chars), response_size (chars), model_id,
+// request_start_timestamp_ms, message_id. We approximate tokens at 4 chars /
+// token. Source is merged with Kiro IDE (source='kiro') and canonicalized
+// model names are used so CLI and IDE rows collapse when they refer to the
+// same underlying Bedrock model. Cursor state is per-request-id so mutable
+// requests can be reprocessed (subtract-old/add-new on fingerprint change).
+// ─────────────────────────────────────────────────────────────────────────────
+
+const KIRO_CLI_CHARS_PER_TOKEN = 4;
+
+function resolveKiroCliDbPath(env = process.env) {
+  if (env.KIRO_CLI_DB_PATH) return env.KIRO_CLI_DB_PATH;
+  const home = env.HOME || require("node:os").homedir();
+  return path.join(home, "Library", "Application Support", "kiro-cli", "data.sqlite3");
+}
+
+// Legacy per-session-file resolver kept for backward compatibility with any
+// caller that imported it; callers should prefer resolveKiroCliDbPath for
+// historical data.
+function resolveKiroCliSessionFiles(env = process.env) {
+  const home = require("node:os").homedir();
+  const kiroHome = env.KIRO_HOME || path.join(home, ".kiro");
+  const sessionsDir = path.join(kiroHome, "sessions", "cli");
+  if (!fssync.existsSync(sessionsDir)) return [];
+  const files = [];
+  try {
+    for (const entry of fssync.readdirSync(sessionsDir)) {
+      if (!entry.endsWith(".json")) continue;
+      const jsonPath = path.join(sessionsDir, entry);
+      const lockPath = path.join(sessionsDir, entry.replace(/\.json$/, ".lock"));
+      if (fssync.existsSync(lockPath)) continue;
+      files.push(jsonPath);
+    }
+  } catch {
+    // ignore read errors
+  }
+  return files;
+}
+
+// Canonicalize a Kiro-CLI-emitted model id so IDE and CLI rows collapse when
+// they refer to the same underlying Bedrock model. Examples:
+//   anthropic.claude-sonnet-4-20250514-v1:0  -> claude-sonnet-4
+//   claude-opus-4.6                           -> claude-opus-4.6
+//   claude-sonnet-4.5                         -> claude-sonnet-4.5
+//   auto                                      -> auto
+//   <unknown/falsy>                           -> null (caller falls back to 'kiro-cli-agent')
+function canonicalizeKiroCliModelId(raw) {
+  if (!raw || typeof raw !== "string") return null;
+  let name = raw.trim();
+  if (!name) return null;
+  name = name.toLowerCase();
+  // Strip provider prefix (anthropic., aws., openai., or a full Bedrock ARN).
+  name = name.replace(
+    /^(?:arn:aws:bedrock:[^:]*:[^:]*:(?:foundation-model\/)?|anthropic\.|openai\.|aws\.)/,
+    "",
+  );
+  // Strip Bedrock revision suffix `:N`.
+  name = name.replace(/:\d+$/, "");
+  // Strip date + vN suffix (e.g. "-20250514-v1"), or lone "-vN", or lone date.
+  name = name.replace(/-\d{8}-v\d+$/i, "");
+  name = name.replace(/-v\d+$/i, "");
+  name = name.replace(/-\d{8}$/, "");
+  // Strip trailing ".v1" or similar Anthropic-on-Bedrock tails if present.
+  name = name.replace(/\.v\d+$/i, "");
+  return name || null;
+}
+
+// Read Kiro CLI requests using SQL-side json_extract so we don't pull the
+// full (93 MB-ish) conversations_v2 blob back through sqlite3 -json.
+function readKiroCliRequests(dbPath) {
+  if (!dbPath || !fssync.existsSync(dbPath)) return [];
+  let raw;
+  try {
+    raw = cp.execFileSync(
+      "sqlite3",
+      [
+        "-json",
+        dbPath,
+        "SELECT conversation_id, " +
+          "json_extract(value, '$.model_info.model_id') AS session_model_id, " +
+          "json_extract(value, '$.user_turn_metadata.requests') AS requests_json " +
+          "FROM conversations_v2 " +
+          "WHERE json_extract(value, '$.user_turn_metadata.requests') IS NOT NULL",
+      ],
+      { encoding: "utf8", maxBuffer: 128 * 1024 * 1024, timeout: 120_000 },
+    );
+  } catch {
+    return [];
+  }
+  if (!raw || !raw.trim()) return [];
+  let rows;
+  try {
+    rows = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(rows)) return [];
+  const flat = [];
+  for (const row of rows) {
+    let requests;
+    try {
+      requests = JSON.parse(row.requests_json || "[]");
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(requests)) continue;
+    for (const r of requests) {
+      if (!r || typeof r !== "object") continue;
+      flat.push({
+        conversation_id: row.conversation_id,
+        session_model_id: row.session_model_id || null,
+        request_id: r.request_id || null,
+        message_id: r.message_id || null,
+        user_prompt_length: r.user_prompt_length,
+        response_size: r.response_size,
+        model_id: r.model_id || null,
+        request_start_timestamp_ms: r.request_start_timestamp_ms,
+      });
+    }
+  }
+  return flat;
+}
+
+async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onProgress, env } = {}) {
+  await ensureDir(path.dirname(queuePath));
+  const kiroCliState =
+    cursors.kiroCli && typeof cursors.kiroCli === "object" ? cursors.kiroCli : {};
+  const seenIds = new Set(Array.isArray(kiroCliState.seenIds) ? kiroCliState.seenIds : []);
+
+  // Back-compat branch: if caller explicitly passes sessionFiles (an array of
+  // per-session .json paths, the old contract used in tests/fixtures), read
+  // them as user_turn_metadatas. New default path below reads the SQLite DB.
+  if (Array.isArray(sessionFiles)) {
+    return parseKiroCliFromSessionFiles({
+      sessionFiles,
+      cursors,
+      queuePath,
+      onProgress,
+      env,
+      kiroCliState,
+      seenIds,
+    });
+  }
+
+  const dbPath = resolveKiroCliDbPath(env || process.env);
+  if (!fssync.existsSync(dbPath)) {
+    cursors.kiroCli = {
+      ...kiroCliState,
+      requests: kiroCliState.requests || {},
+      updatedAt: new Date().toISOString(),
+    };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const flat = readKiroCliRequests(dbPath);
+  // Per-request state replaces the old seenIds set. Each entry captures
+  // what we contributed for that request_id last time, so a later mutation
+  // (same request_id, different fingerprint) can subtract-old/add-new
+  // instead of being skipped forever.
+  const requestState =
+    kiroCliState.requests && typeof kiroCliState.requests === "object"
+      ? { ...kiroCliState.requests }
+      : {};
+
+  if (flat.length === 0) {
+    cursors.kiroCli = {
+      ...kiroCliState,
+      requests: requestState,
+      updatedAt: new Date().toISOString(),
+    };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  let recordsProcessed = 0;
+  let eventsAggregated = 0;
+
+  for (let i = 0; i < flat.length; i++) {
+    const r = flat[i];
+    recordsProcessed++;
+
+    const requestId = r.request_id || r.message_id;
+    if (!requestId) continue;
+
+    const promptChars = toNonNegativeInt(r.user_prompt_length);
+    const responseChars = toNonNegativeInt(r.response_size);
+    const approxInput = Math.floor(promptChars / KIRO_CLI_CHARS_PER_TOKEN);
+    const approxOutput = Math.floor(responseChars / KIRO_CLI_CHARS_PER_TOKEN);
+
+    const tsMs = Number(r.request_start_timestamp_ms);
+    if (!Number.isFinite(tsMs) || tsMs <= 0) continue;
+    const bucketStart = toUtcHalfHourStart(new Date(tsMs).toISOString());
+    if (!bucketStart) continue;
+
+    const rawModel = r.model_id || r.session_model_id;
+    const canonical = canonicalizeKiroCliModelId(rawModel);
+    const model = canonical || "kiro-cli-agent";
+
+    // Fingerprint captures every field whose change should cause a re-bucket.
+    const fingerprint = `${promptChars}:${responseChars}:${model}:${tsMs}`;
+    const prev = requestState[requestId];
+    if (prev && prev.fingerprint === fingerprint) continue; // unchanged
+
+    // Subtract the prior contribution (if any) from its prior bucket so the
+    // bucket's absolute totals reflect the CURRENT truth, not the historical
+    // truth. enqueueTouchedBuckets will emit the net delta at flush time.
+    if (prev && (prev.input_tokens || prev.output_tokens)) {
+      const prevBucket = getHourlyBucket(hourlyState, "kiro", prev.model, prev.bucketStart);
+      addTotals(prevBucket.totals, {
+        input_tokens: -prev.input_tokens,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: -prev.output_tokens,
+        reasoning_output_tokens: 0,
+        total_tokens: -(prev.input_tokens + prev.output_tokens),
+        conversation_count: -1,
+      });
+      touchedBuckets.add(bucketKey("kiro", prev.model, prev.bucketStart));
+    }
+
+    // Add the new contribution.
+    if (approxInput > 0 || approxOutput > 0) {
+      const bucket = getHourlyBucket(hourlyState, "kiro", model, bucketStart);
+      addTotals(bucket.totals, {
+        input_tokens: approxInput,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: approxOutput,
+        reasoning_output_tokens: 0,
+        total_tokens: approxInput + approxOutput,
+        conversation_count: 1,
+      });
+      touchedBuckets.add(bucketKey("kiro", model, bucketStart));
+      eventsAggregated++;
+    }
+
+    // Always record the cursor entry (even for zero-token requests) so we
+    // don't re-count later if Kiro rewrites this request with real data.
+    requestState[requestId] = {
+      fingerprint,
+      bucketStart,
+      model,
+      input_tokens: approxInput,
+      output_tokens: approxOutput,
+    };
+
+    if (cb && i % 50 === 0) {
+      cb({
+        index: i + 1,
+        total: flat.length,
+        recordsProcessed,
+        eventsAggregated,
+        bucketsQueued: touchedBuckets.size,
+      });
+    }
+  }
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  const updatedAt = new Date().toISOString();
+  hourlyState.updatedAt = updatedAt;
+  cursors.hourly = hourlyState;
+  cursors.kiroCli = { ...kiroCliState, requests: requestState, updatedAt };
+
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+// Back-compat path: per-session .json files (the old fixture shape). Emits
+// exact tokens if the fixture happens to carry them (which the test fixture
+// does). Used only by the test/rollout-parser.test.js fixture tests.
+async function parseKiroCliFromSessionFiles({
+  sessionFiles,
+  cursors,
+  queuePath,
+  onProgress,
+  env,
+  kiroCliState,
+  seenIds,
+}) {
+  const fileOffsets =
+    kiroCliState.fileOffsets && typeof kiroCliState.fileOffsets === "object"
+      ? { ...kiroCliState.fileOffsets }
+      : {};
+  if (sessionFiles.length === 0) {
+    cursors.kiroCli = {
+      ...kiroCliState,
+      seenIds: Array.from(seenIds),
+      fileOffsets,
+      updatedAt: new Date().toISOString(),
+    };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  let recordsProcessed = 0;
+  let eventsAggregated = 0;
+
+  for (let fileIdx = 0; fileIdx < sessionFiles.length; fileIdx++) {
+    const filePath = sessionFiles[fileIdx];
+    let stat;
+    try {
+      stat = fssync.statSync(filePath);
+    } catch {
+      continue;
+    }
+
+    const prevEntry = fileOffsets[filePath] || {};
+    const prevMtime = Number(prevEntry.mtimeMs) || 0;
+    const prevLastIndex = Number.isFinite(Number(prevEntry.lastIndex))
+      ? Number(prevEntry.lastIndex)
+      : -1;
+    if (prevMtime && stat.mtimeMs <= prevMtime) continue;
+
+    let parsed;
+    try {
+      parsed = JSON.parse(fssync.readFileSync(filePath, "utf8"));
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object") continue;
+
+    const turns = Array.isArray(
+      parsed?.session_state?.conversation_metadata?.user_turn_metadatas,
+    )
+      ? parsed.session_state.conversation_metadata.user_turn_metadatas
+      : [];
+    const sessionId = typeof parsed.session_id === "string" ? parsed.session_id : filePath;
+    const sessionModelId =
+      (parsed?.session_state?.rts_model_state?.model_info &&
+        (parsed.session_state.rts_model_state.model_info.model_id ||
+          parsed.session_state.rts_model_state.model_info.modelId)) ||
+      null;
+
+    let maxIndex = prevLastIndex;
+    for (let i = 0; i < turns.length; i++) {
+      if (i <= prevLastIndex) continue;
+      const turn = turns[i];
+      if (!turn || typeof turn !== "object") continue;
+      recordsProcessed++;
+
+      const input = toNonNegativeInt(turn.input_tokens);
+      const output = toNonNegativeInt(turn.output_tokens);
+      const cacheRead = toNonNegativeInt(
+        turn.cache_read_input_tokens ?? turn.cached_input_tokens,
+      );
+      const cacheCreation = toNonNegativeInt(
+        turn.cache_creation_input_tokens ?? turn.cache_write_input_tokens,
+      );
+      const reasoning = toNonNegativeInt(turn.reasoning_output_tokens);
+      if (input === 0 && output === 0 && cacheRead === 0 && cacheCreation === 0) {
+        maxIndex = i;
+        continue;
+      }
+
+      const ts = turn.timestamp || turn.created_at || turn.updated_at;
+      if (!ts) continue;
+      const bucketStart = toUtcHalfHourStart(ts);
+      if (!bucketStart) continue;
+
+      const turnMessageId =
+        typeof turn.message_id === "string" && turn.message_id ? turn.message_id : null;
+      const dedupKey = turnMessageId ? `${sessionId}:${turnMessageId}` : null;
+      if (dedupKey && seenIds.has(dedupKey)) {
+        maxIndex = i;
+        continue;
+      }
+
+      const rawModel =
+        turn.model_id ||
+        turn.modelId ||
+        (turn.model_info && (turn.model_info.model_id || turn.model_info.modelId)) ||
+        sessionModelId;
+      const normalized = rawModel ? normalizeKiroModelName(rawModel) : null;
+      const model = normalized || "kiro-cli-agent";
+
+      const delta = {
+        input_tokens: input,
+        cached_input_tokens: cacheRead,
+        cache_creation_input_tokens: cacheCreation,
+        output_tokens: output,
+        reasoning_output_tokens: reasoning,
+        total_tokens: input + output + cacheRead + cacheCreation + reasoning,
+        conversation_count: 1,
+      };
+
+      const bucket = getHourlyBucket(hourlyState, "kiro", model, bucketStart);
+      addTotals(bucket.totals, delta);
+      touchedBuckets.add(bucketKey("kiro", model, bucketStart));
+      if (dedupKey) seenIds.add(dedupKey);
+      maxIndex = i;
+      eventsAggregated++;
+
+      if (cb) {
+        cb({
+          index: fileIdx + 1,
+          total: sessionFiles.length,
+          recordsProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+    }
+
+    fileOffsets[filePath] = {
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+      lastIndex: maxIndex,
+    };
+  }
+
+  const seenArr = Array.from(seenIds);
+  const cappedSeen = seenArr.length > 10_000 ? seenArr.slice(seenArr.length - 10_000) : seenArr;
+
+  const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
+  const updatedAt = new Date().toISOString();
+  hourlyState.updatedAt = updatedAt;
+  cursors.hourly = hourlyState;
+  cursors.kiroCli = { ...kiroCliState, seenIds: cappedSeen, fileOffsets, updatedAt };
+
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 function resolveKimiWireFiles(env = process.env) {
   const home = require("node:os").homedir();
   const kimiHome = env.KIMI_HOME || path.join(home, ".kimi");
@@ -3417,6 +3848,9 @@ module.exports = {
   resolveKimiWireFiles,
   resolveKimiDefaultModel,
   parseKimiIncremental,
+  resolveKiroCliSessionFiles,
+  resolveKiroCliDbPath,
+  parseKiroCliIncremental,
   // Exposed for regression tests covering cache-token accounting.
   normalizeGeminiTokens,
   normalizeOpencodeTokens,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3085,9 +3085,11 @@ function resolveKiroCliDbPath(env = process.env) {
   return path.join(home, "Library", "Application Support", "kiro-cli", "data.sqlite3");
 }
 
-// Legacy per-session-file resolver kept for backward compatibility with any
-// caller that imported it; callers should prefer resolveKiroCliDbPath for
-// historical data.
+// Lists ~/.kiro/sessions/cli/{uuid}.json files. Includes files whose sibling
+// .lock is present — we read those as tail-only snapshots so a running
+// session's completed turns still land in the queue on the next sync. The
+// .json files are rewritten atomically by kiro-cli on each turn flush, so
+// a stale read just means we'll pick up the rest next time.
 function resolveKiroCliSessionFiles(env = process.env) {
   const home = require("node:os").homedir();
   const kiroHome = env.KIRO_HOME || path.join(home, ".kiro");
@@ -3097,15 +3099,140 @@ function resolveKiroCliSessionFiles(env = process.env) {
   try {
     for (const entry of fssync.readdirSync(sessionsDir)) {
       if (!entry.endsWith(".json")) continue;
-      const jsonPath = path.join(sessionsDir, entry);
-      const lockPath = path.join(sessionsDir, entry.replace(/\.json$/, ".lock"));
-      if (fssync.existsSync(lockPath)) continue;
-      files.push(jsonPath);
+      files.push(path.join(sessionsDir, entry));
     }
   } catch {
     // ignore read errors
   }
   return files;
+}
+
+// Build a { message_id -> content-char-count } map from a .jsonl sibling
+// file. Lets us approximate per-turn tokens when the live session's
+// user_turn_metadatas.input_token_count / output_token_count fields are 0
+// (kiro-cli 0.x doesn't always populate them). Char chunks come from:
+//   Prompt.data.content[].data          (user input)
+//   AssistantMessage.data.content[].data (assistant text/toolUse)
+function readKiroCliMessageChars(jsonlPath) {
+  const result = { byMessage: new Map(), messageKind: new Map() };
+  if (!jsonlPath || !fssync.existsSync(jsonlPath)) return result;
+  let raw;
+  try {
+    raw = fssync.readFileSync(jsonlPath, "utf8");
+  } catch {
+    return result;
+  }
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let evt;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const data = evt?.data;
+    if (!data || typeof data !== "object") continue;
+    const mid = data.message_id;
+    if (!mid) continue;
+    const content = Array.isArray(data.content) ? data.content : [];
+    let chars = 0;
+    for (const c of content) {
+      if (!c || typeof c !== "object") continue;
+      if (c.kind === "text" && typeof c.data === "string") {
+        chars += c.data.length;
+      } else if (c.kind === "toolUse" && c.data && typeof c.data === "object") {
+        // tool-use invocations count toward output; stringify the input payload
+        try {
+          chars += JSON.stringify(c.data.input || {}).length;
+        } catch {
+          // ignore
+        }
+      }
+    }
+    result.byMessage.set(mid, (result.byMessage.get(mid) || 0) + chars);
+    if (!result.messageKind.has(mid)) result.messageKind.set(mid, evt.kind);
+  }
+  return result;
+}
+
+// Extract flat per-turn records from a live session .json + its .jsonl
+// sibling. Returns [{ request_id, model_id, request_start_timestamp_ms,
+// input_tokens, output_tokens }]. We use the same request_id dedup slot as
+// the SQLite path so mutations (turn rewritten on next flush) go through
+// the subtract-old/add-new path in parseKiroCliIncremental.
+function readKiroCliSessionTurns(jsonPath) {
+  if (!jsonPath || !fssync.existsSync(jsonPath)) return [];
+  let parsed;
+  try {
+    parsed = JSON.parse(fssync.readFileSync(jsonPath, "utf8"));
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object") return [];
+  const turns = Array.isArray(
+    parsed?.session_state?.conversation_metadata?.user_turn_metadatas,
+  )
+    ? parsed.session_state.conversation_metadata.user_turn_metadatas
+    : [];
+  if (turns.length === 0) return [];
+
+  const modelInfo = parsed?.session_state?.rts_model_state?.model_info || null;
+  const sessionModelId =
+    (modelInfo && (modelInfo.model_id || modelInfo.model_name)) || null;
+  const sessionId =
+    typeof parsed.session_id === "string" ? parsed.session_id : path.basename(jsonPath, ".json");
+
+  // Load sibling .jsonl for char-count fallback.
+  const jsonlPath = jsonPath.replace(/\.json$/, ".jsonl");
+  const charMap = readKiroCliMessageChars(jsonlPath);
+
+  const flat = [];
+  for (const turn of turns) {
+    if (!turn || typeof turn !== "object") continue;
+    const loopRand =
+      (turn.loop_id && (turn.loop_id.rand ?? turn.loop_id.seed)) || null;
+    const messageIds = Array.isArray(turn.message_ids) ? turn.message_ids : [];
+    const requestId = loopRand != null ? `${sessionId}:${loopRand}` : (messageIds[0] || null);
+    if (!requestId) continue;
+
+    // Prefer real token counts if kiro-cli populated them.
+    let inputTokens = toNonNegativeInt(turn.input_token_count);
+    let outputTokens = toNonNegativeInt(turn.output_token_count);
+
+    if (inputTokens === 0 && outputTokens === 0 && messageIds.length > 0) {
+      // Fall back to char-count approximation. Prompt events count toward
+      // input; AssistantMessage events count toward output.
+      let promptChars = 0;
+      let assistantChars = 0;
+      for (const mid of messageIds) {
+        const chars = charMap.byMessage.get(mid) || 0;
+        const kind = charMap.messageKind.get(mid);
+        if (kind === "Prompt") promptChars += chars;
+        else assistantChars += chars;
+      }
+      inputTokens = Math.floor(promptChars / KIRO_CLI_CHARS_PER_TOKEN);
+      outputTokens = Math.floor(assistantChars / KIRO_CLI_CHARS_PER_TOKEN);
+    }
+
+    // Timestamp: end_timestamp is an ISO string; coerce to ms.
+    const tsRaw = turn.end_timestamp || turn.start_timestamp;
+    const tsMs = tsRaw ? Date.parse(tsRaw) : NaN;
+    if (!Number.isFinite(tsMs) || tsMs <= 0) continue;
+
+    flat.push({
+      request_id: requestId,
+      session_model_id: sessionModelId,
+      message_id: messageIds[0] || null,
+      model_id: turn.model_id || sessionModelId,
+      request_start_timestamp_ms: tsMs,
+      // For the parser, we feed the ALREADY-approximated tokens directly via
+      // a special sentinel field. The parser will divide chars by
+      // KIRO_CLI_CHARS_PER_TOKEN; bypass that by pre-multiplying here.
+      user_prompt_length: inputTokens * KIRO_CLI_CHARS_PER_TOKEN,
+      response_size: outputTokens * KIRO_CLI_CHARS_PER_TOKEN,
+    });
+  }
+  return flat;
 }
 
 // Canonicalize a Kiro-CLI-emitted model id so IDE and CLI rows collapse when
@@ -3213,17 +3340,24 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
     });
   }
 
-  const dbPath = resolveKiroCliDbPath(env || process.env);
-  if (!fssync.existsSync(dbPath)) {
-    cursors.kiroCli = {
-      ...kiroCliState,
-      requests: kiroCliState.requests || {},
-      updatedAt: new Date().toISOString(),
-    };
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
+  const resolvedEnv = env || process.env;
+  const dbPath = resolveKiroCliDbPath(resolvedEnv);
 
-  const flat = readKiroCliRequests(dbPath);
+  // Combine two sources under the same (source='kiro', cursors.kiroCli)
+  // namespace: historical rows from the SQLite DB plus live session state
+  // from ~/.kiro/sessions/cli/{uuid}.json (covers turns from a running
+  // session that hasn't flushed to SQLite yet). Request IDs are disjoint
+  // (SQLite uses request_id UUID; sessions use {sessionId}:{loop_id.rand}),
+  // so no cross-source dedup is needed.
+  const flatDb = fssync.existsSync(dbPath) ? readKiroCliRequests(dbPath) : [];
+  const sessionFilesList = resolveKiroCliSessionFiles(resolvedEnv);
+  const flatSessions = [];
+  for (const jsonPath of sessionFilesList) {
+    for (const turn of readKiroCliSessionTurns(jsonPath)) {
+      flatSessions.push(turn);
+    }
+  }
+  const flat = flatDb.concat(flatSessions);
   // Per-request state replaces the old seenIds set. Each entry captures
   // what we contributed for that request_id last time, so a later mutation
   // (same request_id, different fingerprint) can subtract-old/add-new

--- a/test/fixtures/kiro-cli/active-source.json
+++ b/test/fixtures/kiro-cli/active-source.json
@@ -1,0 +1,49 @@
+{
+  "_fixture_provenance": "PENDING LIVE VALIDATION — spec-derived from kiro-cli binary strings (crates/fig_* + crates/amzn-codewhisperer-client/src/operation/*.rs, plus the observed live session-state layout at ~/.kiro/sessions/cli/{uuid}.json on 2026-04-20). The .jsonl sibling is 0 bytes in the wild at plan execution time; token metadata is hypothesized to flow into session_state.conversation_metadata.user_turn_metadatas[] with per-turn token counts and an ISO timestamp. When a real completed Kiro CLI session is captured, diff this fixture against the real .json and patch parseKiroCliIncremental + this header accordingly. Two user_turn_metadatas entries are placed in different UTC half-hour buckets so bucket aggregation can be verified.",
+  "session_id": "fixture-active-0000-0000-0000-000000000001",
+  "cwd": "/tmp/fake-cwd",
+  "created_at": "2026-04-20T10:00:00.000Z",
+  "updated_at": "2026-04-20T10:45:00.000Z",
+  "title": null,
+  "session_state": {
+    "version": "v1",
+    "conversation_metadata": {
+      "user_turn_metadatas": [
+        {
+          "message_id": "msg-0001",
+          "timestamp": "2026-04-20T10:05:00.000Z",
+          "input_tokens": 1200,
+          "output_tokens": 450,
+          "cache_read_input_tokens": 800,
+          "cache_creation_input_tokens": 100,
+          "model_id": "anthropic.claude-sonnet-4-20250514-v1:0"
+        },
+        {
+          "message_id": "msg-0002",
+          "timestamp": "2026-04-20T10:40:00.000Z",
+          "input_tokens": 300,
+          "output_tokens": 120,
+          "cache_read_input_tokens": 0,
+          "cache_creation_input_tokens": 0,
+          "model_id": "anthropic.claude-sonnet-4-20250514-v1:0"
+        }
+      ],
+      "user_turn_start_request": null,
+      "last_request": null
+    },
+    "rts_model_state": {
+      "conversation_id": "fixture-active-0000-0000-0000-000000000001",
+      "model_info": {
+        "model_id": "anthropic.claude-sonnet-4-20250514-v1:0"
+      },
+      "context_usage_percentage": 12.5
+    },
+    "permissions": {
+      "filesystem": { "allowed_read_paths": [], "allowed_write_paths": [], "denied_read_paths": [], "denied_write_paths": [] },
+      "trusted_tools": [],
+      "denied_tools": [],
+      "allowed_commands": []
+    },
+    "agent_name": null
+  }
+}

--- a/test/fixtures/kiro-cli/empty-source.json
+++ b/test/fixtures/kiro-cli/empty-source.json
@@ -1,0 +1,28 @@
+{
+  "_fixture_provenance": "PENDING LIVE VALIDATION — spec-derived. Mirrors the exact shape observed in ~/.kiro/sessions/cli/4257d4b9-f763-42a7-ac48-5a5e5dca5660.json on 2026-04-20, where user_turn_metadatas is empty because no turns have completed yet. Parser must treat this as 'session exists but no billable tokens' and emit zero queue entries without throwing.",
+  "session_id": "fixture-empty-0000-0000-0000-000000000002",
+  "cwd": "/tmp/fake-cwd-empty",
+  "created_at": "2026-04-20T11:26:24.797Z",
+  "updated_at": "2026-04-20T11:26:24.797Z",
+  "title": null,
+  "session_state": {
+    "version": "v1",
+    "conversation_metadata": {
+      "user_turn_metadatas": [],
+      "user_turn_start_request": null,
+      "last_request": null
+    },
+    "rts_model_state": {
+      "conversation_id": "fixture-empty-0000-0000-0000-000000000002",
+      "model_info": null,
+      "context_usage_percentage": null
+    },
+    "permissions": {
+      "filesystem": { "allowed_read_paths": [], "allowed_write_paths": [], "denied_read_paths": [], "denied_write_paths": [] },
+      "trusted_tools": [],
+      "denied_tools": [],
+      "allowed_commands": []
+    },
+    "agent_name": null
+  }
+}

--- a/test/fixtures/kiro-cli/native-contract-queue.jsonl
+++ b/test/fixtures/kiro-cli/native-contract-queue.jsonl
@@ -1,0 +1,2 @@
+{"source":"kiro","model":"kiro-agent","hour_start":"2026-04-20T10:00:00.000Z","input_tokens":1000,"output_tokens":200,"cached_input_tokens":0,"cache_creation_input_tokens":0,"reasoning_output_tokens":0,"total_tokens":1200,"conversation_count":1}
+{"source":"kiro","model":"kiro-cli-agent","hour_start":"2026-04-20T10:30:00.000Z","input_tokens":500,"output_tokens":100,"cached_input_tokens":0,"cache_creation_input_tokens":0,"reasoning_output_tokens":0,"total_tokens":600,"conversation_count":1}

--- a/test/kiro-cli-native-contract.test.js
+++ b/test/kiro-cli-native-contract.test.js
@@ -1,0 +1,170 @@
+// Native-consumer contract lock (TASK-008).
+//
+// This test mirrors the Swift decoder contract in
+// TokenTrackerBar/TokenTrackerBar/Models/ModelBreakdown.swift and
+// TokenTrackerBar/TokenTrackerBar/Models/TokenTotals.swift. It exists because
+// the Swift `decodeIfPresent` logic for CodingKeys cannot recover from type
+// regressions — specifically a change of `total_cost_usd` from String to
+// Number would crash the decoder in production with dataCorruptedError on
+// every macOS client. A full XCTest lane would require xcodebuild wiring and
+// is out of scope here; this Node test pins the JSON shape the Swift app
+// depends on so future edits to src/lib/local-api.js cannot silently break
+// the native consumer.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const localApi = require("../src/lib/local-api");
+
+async function callModelBreakdown(queuePath) {
+  const handler = localApi.createLocalApiHandler({ queuePath });
+  const urlString =
+    "http://localhost/functions/tokentracker-usage-model-breakdown?from=2026-04-20&to=2026-04-20&tz=UTC";
+  const url = new URL(urlString);
+  const req = {
+    method: "GET",
+    url: url.pathname + url.search,
+    headers: { host: "localhost" },
+  };
+  const chunks = [];
+  const res = {
+    statusCode: 200,
+    setHeader() {},
+    writeHead() {},
+    end(body) {
+      if (body) chunks.push(body);
+    },
+    write(chunk) {
+      chunks.push(chunk);
+    },
+  };
+  const handled = await handler(req, res, url);
+  assert.ok(handled, "handler must accept the request");
+  return JSON.parse(chunks.join(""));
+}
+
+function isInt(v) {
+  return typeof v === "number" && Number.isFinite(v) && Math.floor(v) === v;
+}
+
+test("model-breakdown JSON exposes every field the Swift ModelBreakdown decoder reads", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-native-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const fixtureSrc = fs.readFileSync(
+      path.join(__dirname, "fixtures", "kiro-cli", "native-contract-queue.jsonl"),
+      "utf8",
+    );
+    await fs.promises.writeFile(queuePath, fixtureSrc);
+
+    const body = await callModelBreakdown(queuePath);
+
+    // ModelBreakdownResponse CodingKeys: from, to, days, sources, pricing
+    assert.equal(typeof body.from, "string", "`from` must be a string");
+    assert.equal(typeof body.to, "string", "`to` must be a string");
+    assert.equal(typeof body.days, "number", "`days` must be a number");
+    assert.ok(Array.isArray(body.sources), "`sources` must be an array");
+    assert.ok(body.pricing && typeof body.pricing === "object", "`pricing` must be an object");
+
+    // PricingInfo.pricing_mode: String
+    assert.equal(
+      typeof body.pricing.pricing_mode,
+      "string",
+      "pricing.pricing_mode must be a string (Swift CodingKey: pricing_mode → pricingMode)",
+    );
+
+    const kiro = body.sources.find((s) => s.source === "kiro");
+    assert.ok(kiro, "fixture must produce a kiro source");
+
+    // SourceEntry CodingKeys: source (String), totals (TokenTotals), models ([ModelEntry])
+    assert.equal(typeof kiro.source, "string");
+    assert.ok(kiro.totals && typeof kiro.totals === "object");
+    assert.ok(Array.isArray(kiro.models));
+
+    // TokenTotals CodingKeys — every field Swift decodes with .decodeIfPresent(Int.self ...)
+    // must be present as Int, and total_cost_usd MUST be String.
+    const tt = kiro.totals;
+    const intFields = [
+      "total_tokens",
+      "billable_total_tokens",
+      "input_tokens",
+      "output_tokens",
+      "cached_input_tokens",
+      "cache_creation_input_tokens",
+      "reasoning_output_tokens",
+    ];
+    for (const f of intFields) {
+      assert.ok(isInt(tt[f]), `totals.${f} must be an integer number (Swift Int), got ${typeof tt[f]}`);
+    }
+
+    // CRITICAL: total_cost_usd must be a STRING. If this regresses to Number
+    // the Swift decoder will crash in production with dataCorruptedError —
+    // this is the exact failure mode this test exists to prevent.
+    assert.equal(
+      typeof tt.total_cost_usd,
+      "string",
+      "sources[].totals.total_cost_usd MUST be a String — Swift decodes it as String",
+    );
+    assert.match(
+      tt.total_cost_usd,
+      /^\d+\.\d{6}$/,
+      "total_cost_usd must be 6-decimal formatted (e.g. '0.001234')",
+    );
+
+    // ModelEntry CodingKeys: model (String), model_id (String), totals (TokenTotals)
+    assert.ok(kiro.models.length > 0, "kiro must have at least one model row");
+    for (const m of kiro.models) {
+      assert.equal(typeof m.model, "string");
+      assert.equal(typeof m.model_id, "string");
+      assert.ok(m.totals && typeof m.totals === "object");
+      assert.equal(
+        typeof m.totals.total_cost_usd,
+        "string",
+        `models[${m.model}].totals.total_cost_usd MUST be a String`,
+      );
+      for (const f of intFields) {
+        assert.ok(
+          isInt(m.totals[f]),
+          `models[${m.model}].totals.${f} must be an integer`,
+        );
+      }
+    }
+  } finally {
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("non-zero cost on merged kiro source proves TASK-007 pricing is live end-to-end", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-native-cost-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const fixtureSrc = fs.readFileSync(
+      path.join(__dirname, "fixtures", "kiro-cli", "native-contract-queue.jsonl"),
+      "utf8",
+    );
+    await fs.promises.writeFile(queuePath, fixtureSrc);
+
+    const body = await callModelBreakdown(queuePath);
+    const kiro = body.sources.find((s) => s.source === "kiro");
+    assert.ok(kiro);
+    const sourceCost = parseFloat(kiro.totals.total_cost_usd);
+    assert.ok(
+      sourceCost > 0,
+      `kiro source total_cost_usd must be > 0 with TASK-007 pricing live; got ${kiro.totals.total_cost_usd}`,
+    );
+    // Each model row must also have non-zero cost — proves BOTH kiro-agent
+    // and kiro-cli-agent are resolved by the pricing table.
+    for (const m of kiro.models) {
+      const modelCost = parseFloat(m.totals.total_cost_usd);
+      assert.ok(
+        modelCost > 0,
+        `kiro model '${m.model}' must have non-zero cost; got ${m.totals.total_cost_usd}`,
+      );
+    }
+  } finally {
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
+});

--- a/test/model-breakdown.test.js
+++ b/test/model-breakdown.test.js
@@ -1,6 +1,20 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 const { test } = require("node:test");
 const { loadDashboardModule } = require("./helpers/load-dashboard-module");
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Local-api handler under test — only loaded when the pricing / consumer-
+// boundary tests below need it; kept lazy so module-load cost isn't paid
+// by the existing dashboard-only tests.
+// ─────────────────────────────────────────────────────────────────────────────
+const localApi = require("../src/lib/local-api");
+const leaderboardRefreshPath = path.resolve(
+  __dirname,
+  "../dashboard/edge-patches/tokentracker-leaderboard-refresh.ts",
+);
 
 test("buildFleetData keeps usage tokens for fleet rows", async () => {
   const mod = await loadDashboardModule("dashboard/src/lib/model-breakdown.ts");
@@ -120,4 +134,247 @@ test("buildTopModels computes percent using billable tokens across all models", 
   assert.equal(topModels.length, 1);
   assert.equal(topModels[0].id, "gpt-4o");
   assert.equal(topModels[0].percent, "80.0");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TASK-007: Kiro pricing in local-api MODEL_PRICING + byte-equivalence with
+// dashboard/edge-patches/tokentracker-leaderboard-refresh.ts.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("getModelPricing returns non-zero rates for kiro-agent and kiro-cli-agent", () => {
+  const kiroAgent = localApi.getModelPricing("kiro-agent");
+  const kiroCliAgent = localApi.getModelPricing("kiro-cli-agent");
+  assert.ok(kiroAgent.input > 0, "kiro-agent must price non-zero input");
+  assert.ok(kiroAgent.output > 0, "kiro-agent must price non-zero output");
+  assert.ok(kiroCliAgent.input > 0, "kiro-cli-agent must price non-zero input");
+  assert.ok(kiroCliAgent.output > 0, "kiro-cli-agent must price non-zero output");
+});
+
+test("getModelPricing fuzzy-matches unknown kiro-* strings to non-zero", () => {
+  const unknown = localApi.getModelPricing("kiro-future-model-xyz");
+  assert.ok(unknown.input > 0, "fuzzy rule must catch kiro-* prefix");
+  assert.ok(unknown.output > 0, "fuzzy rule must catch kiro-* prefix");
+});
+
+test("computeRowCost on kiro-cli-agent row is non-zero and matches claude-sonnet-4 rate", () => {
+  const row = {
+    model: "kiro-cli-agent",
+    input_tokens: 1000,
+    output_tokens: 500,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_output_tokens: 0,
+  };
+  const cost = localApi.computeRowCost(row);
+  assert.ok(cost > 0, "kiro-cli-agent row must have non-zero cost");
+
+  const sonnetCost = localApi.computeRowCost({ ...row, model: "claude-sonnet-4-6" });
+  assert.equal(
+    cost,
+    sonnetCost,
+    "kiro-cli-agent rate MUST equal claude-sonnet-4-6 (documented decision: Kiro routes through Bedrock sonnet)",
+  );
+});
+
+test("local-api MODEL_PRICING Kiro entries are byte-equivalent with leaderboard-refresh edge patch", () => {
+  const edgeSrc = fs.readFileSync(leaderboardRefreshPath, "utf8");
+  // Extract the literal Kiro pricing lines from the edge patch so byte-drift
+  // between the two tables will fail this test.
+  const localKiro = localApi.MODEL_PRICING["kiro-agent"];
+  const localKiroCli = localApi.MODEL_PRICING["kiro-cli-agent"];
+  assert.ok(localKiro && localKiroCli, "local-api must have both Kiro pricing entries");
+  // Reconstruct the expected edge-patch line from local values.
+  const expected = `"kiro-agent": { input: ${localKiro.input}, output: ${localKiro.output}, cache_read: ${localKiro.cache_read}, cache_write: ${localKiro.cache_write} },`;
+  const expectedCli = `"kiro-cli-agent": { input: ${localKiroCli.input}, output: ${localKiroCli.output}, cache_read: ${localKiroCli.cache_read}, cache_write: ${localKiroCli.cache_write} },`;
+  assert.ok(
+    edgeSrc.includes(expected),
+    `leaderboard-refresh must contain kiro-agent pricing matching local-api: ${expected}`,
+  );
+  assert.ok(
+    edgeSrc.includes(expectedCli),
+    `leaderboard-refresh must contain kiro-cli-agent pricing matching local-api: ${expectedCli}`,
+  );
+  // The fuzzy rule must also exist in the edge patch.
+  assert.ok(
+    edgeSrc.includes('lower.includes("kiro")'),
+    "leaderboard-refresh must include the fuzzy kiro-* fallback rule",
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TASK-006: Consumer-boundary test against the REAL grouped shape
+// (/functions/tokentracker-usage-model-breakdown) + buildFleetData. The
+// buildTopModels assertions are flat-ranker sanity only — buildTopModels
+// returns { id, name, tokens, percent } with NO source field.
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function writeQueue(queuePath, rows) {
+  await fs.promises.writeFile(queuePath, rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
+}
+
+async function callModelBreakdown(queuePath, from, to) {
+  const handler = localApi.createLocalApiHandler({ queuePath });
+  const chunks = [];
+  let statusCode = null;
+  const urlString = `http://localhost/functions/tokentracker-usage-model-breakdown?from=${from}&to=${to}&tz=UTC`;
+  const url = new URL(urlString);
+  const req = {
+    method: "GET",
+    url: url.pathname + url.search,
+    headers: { host: "localhost" },
+  };
+  const res = {
+    statusCode: 200,
+    setHeader() {},
+    writeHead(code) {
+      statusCode = code;
+    },
+    end(body) {
+      if (body) chunks.push(body);
+    },
+    write(chunk) {
+      chunks.push(chunk);
+    },
+  };
+  const handled = await handler(req, res, url);
+  assert.ok(handled, "model-breakdown endpoint must handle the request");
+  const body = chunks.join("");
+  return { statusCode: statusCode || res.statusCode, body: JSON.parse(body) };
+}
+
+test("merged Kiro source: IDE + CLI rows produce ONE sources[] entry with distinct model rows", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-merge-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const rows = [
+      // IDE-origin row
+      {
+        source: "kiro",
+        model: "kiro-agent",
+        hour_start: "2026-04-20T10:00:00.000Z",
+        input_tokens: 1000,
+        output_tokens: 200,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 1200,
+        conversation_count: 1,
+      },
+      // CLI-origin row (merged source, distinct model)
+      {
+        source: "kiro",
+        model: "kiro-cli-agent",
+        hour_start: "2026-04-20T10:30:00.000Z",
+        input_tokens: 500,
+        output_tokens: 100,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 600,
+        conversation_count: 1,
+      },
+    ];
+    await writeQueue(queuePath, rows);
+
+    const { body } = await callModelBreakdown(queuePath, "2026-04-20", "2026-04-20");
+
+    // Server-side grouped shape
+    assert.ok(Array.isArray(body.sources), "response must have sources[] array");
+    const kiroSources = body.sources.filter((s) => s.source === "kiro");
+    assert.equal(
+      kiroSources.length,
+      1,
+      `exactly ONE kiro source entry expected; got ${kiroSources.length}`,
+    );
+    const kiro = kiroSources[0];
+    assert.equal(kiro.totals.total_tokens, 1800, "total tokens must sum IDE + CLI rows");
+    // total_cost_usd MUST be a STRING, not a Number (Swift decoder contract).
+    assert.equal(typeof kiro.totals.total_cost_usd, "string");
+    // Non-zero cost proves TASK-007 pricing is live (both models priced).
+    assert.ok(
+      parseFloat(kiro.totals.total_cost_usd) > 0,
+      `kiro source total_cost_usd must be > 0 after TASK-007; got ${kiro.totals.total_cost_usd}`,
+    );
+    const models = kiro.models.map((m) => m.model).sort();
+    assert.deepEqual(
+      models,
+      ["kiro-agent", "kiro-cli-agent"],
+      "both IDE and CLI model rows must be preserved under the merged kiro source",
+    );
+
+    // Client-side grouped shape via buildFleetData
+    const mod = await loadDashboardModule("dashboard/src/lib/model-breakdown.ts");
+    const fleet = mod.buildFleetData(body);
+    const kiroFleet = fleet.filter((f) => f.label === "KIRO");
+    assert.equal(kiroFleet.length, 1, "buildFleetData must return exactly one KIRO entry");
+    assert.equal(kiroFleet[0].usage, 1800);
+    assert.equal(kiroFleet[0].models.length, 2);
+
+    // Flat-ranker sanity — buildTopModels has NO source field; assert by name only.
+    const top = mod.buildTopModels(body, { limit: 5 });
+    const topNames = top.map((t) => t.name);
+    assert.ok(topNames.some((n) => /kiro-agent/i.test(n)), "buildTopModels must expose kiro-agent");
+    assert.ok(
+      topNames.some((n) => /kiro-cli-agent/i.test(n)),
+      "buildTopModels must expose kiro-cli-agent",
+    );
+    // Explicitly document buildTopModels's flat shape: no source attribution.
+    for (const entry of top) {
+      assert.equal(entry.source, undefined, "buildTopModels entries must NOT expose a .source field");
+    }
+  } finally {
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("(source, model) collapse: IDE + CLI both resolving to claude-sonnet-4 merge into ONE row", async () => {
+  const tmp = await fs.promises.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-collapse-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const rows = [
+      {
+        source: "kiro",
+        model: "claude-sonnet-4-20250514",
+        hour_start: "2026-04-20T10:00:00.000Z",
+        input_tokens: 1000,
+        output_tokens: 200,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 1200,
+        conversation_count: 1,
+      },
+      {
+        source: "kiro",
+        model: "claude-sonnet-4-20250514",
+        hour_start: "2026-04-20T10:30:00.000Z",
+        input_tokens: 500,
+        output_tokens: 100,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 600,
+        conversation_count: 1,
+      },
+    ];
+    await writeQueue(queuePath, rows);
+
+    const { body } = await callModelBreakdown(queuePath, "2026-04-20", "2026-04-20");
+    const kiro = body.sources.find((s) => s.source === "kiro");
+    assert.ok(kiro, "kiro source must exist");
+    assert.equal(
+      kiro.models.length,
+      1,
+      "identical (source, model) rows must collapse to ONE entry — intended merge behavior",
+    );
+    assert.equal(kiro.models[0].totals.total_tokens, 1800);
+
+    // buildFleetData mirrors the server collapse
+    const mod = await loadDashboardModule("dashboard/src/lib/model-breakdown.ts");
+    const fleet = mod.buildFleetData(body);
+    const kiroFleet = fleet.find((f) => f.label === "KIRO");
+    assert.equal(kiroFleet.models.length, 1);
+  } finally {
+    await fs.promises.rm(tmp, { recursive: true, force: true });
+  }
 });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2545,3 +2545,275 @@ test("parseKimiIncremental returns zero when no wire files exist", async () => {
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kiro CLI — ~/.kiro/sessions/cli/{uuid}.json session-state files (TASK-001)
+// Fixture provenance is PENDING LIVE VALIDATION — see
+// test/fixtures/kiro-cli/active-source.json header for the spec-derivation note.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const rolloutModule = require("../src/lib/rollout");
+
+test("parseKiroCliIncremental aggregates user_turn_metadatas into half-hour kiro buckets (currently fails until TASK-003)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "cli");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionId = "fixture-active-0000-0000-0000-000000000001";
+    const activeFixture = await fs.readFile(
+      path.join(__dirname, "fixtures", "kiro-cli", "active-source.json"),
+      "utf8",
+    );
+    await fs.writeFile(path.join(sessionsDir, `${sessionId}.json`), activeFixture);
+    await fs.writeFile(path.join(sessionsDir, `${sessionId}.jsonl`), "");
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+
+    // Fail LOUDLY if the parser hasn't been implemented yet. This is the
+    // red state the plan's TASK-001 requires; it flips to green in TASK-003.
+    assert.ok(
+      typeof rolloutModule.parseKiroCliIncremental === "function",
+      "parseKiroCliIncremental must be exported from src/lib/rollout (TASK-003)",
+    );
+    assert.ok(
+      typeof rolloutModule.resolveKiroCliSessionFiles === "function",
+      "resolveKiroCliSessionFiles must be exported from src/lib/rollout (TASK-002)",
+    );
+
+    const files = rolloutModule.resolveKiroCliSessionFiles({ KIRO_HOME: tmp });
+    assert.equal(files.length, 1, "resolver should discover exactly one session file");
+
+    const result = await rolloutModule.parseKiroCliIncremental({
+      sessionFiles: files,
+      cursors,
+      queuePath,
+      env: { KIRO_HOME: tmp },
+    });
+
+    assert.equal(result.recordsProcessed, 2);
+    assert.ok(result.bucketsQueued >= 2, "two turns span two half-hour buckets");
+
+    const queueContent = await fs.readFile(queuePath, "utf8");
+    const rows = queueContent
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    assert.ok(rows.length >= 2, "queue must have at least two bucket rows");
+    for (const row of rows) {
+      assert.equal(row.source, "kiro", "CLI MUST emit source='kiro' for merge with IDE");
+    }
+    const totalInput = rows.reduce((s, r) => s + (r.input_tokens || 0), 0);
+    assert.equal(totalInput, 1500, "1200 + 300 from fixture turns");
+
+    // Cursor state isolated in kiroCli slot
+    assert.ok(cursors.kiroCli, "cursors.kiroCli must be set after parse");
+    assert.equal(
+      cursors.kiro,
+      undefined,
+      "CLI parser must NOT touch cursors.kiro (IDE cursor)",
+    );
+
+    // Idempotent re-run
+    const result2 = await rolloutModule.parseKiroCliIncremental({
+      sessionFiles: files,
+      cursors,
+      queuePath,
+      env: { KIRO_HOME: tmp },
+    });
+    assert.equal(result2.eventsAggregated, 0, "second run must not double-count");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseKiroCliIncremental produces zero buckets for empty user_turn_metadatas", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "cli");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const sessionId = "fixture-empty-0000-0000-0000-000000000002";
+    const emptyFixture = await fs.readFile(
+      path.join(__dirname, "fixtures", "kiro-cli", "empty-source.json"),
+      "utf8",
+    );
+    await fs.writeFile(path.join(sessionsDir, `${sessionId}.json`), emptyFixture);
+
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+
+    assert.ok(
+      typeof rolloutModule.parseKiroCliIncremental === "function",
+      "parseKiroCliIncremental must be exported from src/lib/rollout (TASK-003)",
+    );
+
+    const files = rolloutModule.resolveKiroCliSessionFiles({ KIRO_HOME: tmp });
+    const queueSizeBefore = await safeFileSize(queuePath);
+
+    const result = await rolloutModule.parseKiroCliIncremental({
+      sessionFiles: files,
+      cursors,
+      queuePath,
+      env: { KIRO_HOME: tmp },
+    });
+
+    assert.equal(result.recordsProcessed, 0);
+    assert.equal(result.eventsAggregated, 0);
+    assert.equal(result.bucketsQueued, 0);
+    const queueSizeAfter = await safeFileSize(queuePath);
+    assert.equal(queueSizeAfter, queueSizeBefore, "empty session must not grow the queue");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveKiroCliSessionFiles skips files with an active .lock sibling", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "cli");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    // Completed session: .json only, no .lock
+    await fs.writeFile(path.join(sessionsDir, "done-0000.json"), "{}");
+    // Live session: .json + .lock
+    await fs.writeFile(path.join(sessionsDir, "live-0000.json"), "{}");
+    await fs.writeFile(path.join(sessionsDir, "live-0000.lock"), '{"pid":1}');
+
+    assert.ok(
+      typeof rolloutModule.resolveKiroCliSessionFiles === "function",
+      "resolveKiroCliSessionFiles must be exported from src/lib/rollout (TASK-002)",
+    );
+
+    const files = rolloutModule.resolveKiroCliSessionFiles({ KIRO_HOME: tmp });
+    assert.equal(files.length, 1, "only the unlocked session must be returned");
+    assert.ok(files[0].endsWith("done-0000.json"));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+async function safeFileSize(p) {
+  try {
+    const st = await fs.stat(p);
+    return st.size;
+  } catch {
+    return 0;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kiro CLI — mutable-request delta + Bedrock-ID canonicalization.
+// Exercises the SQLite-backed path via a synthetic DB written in-process.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("parseKiroCliIncremental canonicalizes Bedrock model IDs and re-buckets on fingerprint change", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kirocli-mutable-"));
+  try {
+    const dbPath = path.join(tmp, "data.sqlite3");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const env = { KIRO_CLI_DB_PATH: dbPath };
+
+    // One conversation with one request: Bedrock ARN-style model id, small
+    // prompt/response.
+    function convValue(promptLen, responseLen) {
+      return {
+        model_info: { model_id: "auto" },
+        user_turn_metadata: {
+          continuation_id: "conv-1",
+          requests: [
+            {
+              request_id: "req-1",
+              message_id: "msg-1",
+              request_start_timestamp_ms: Date.parse("2026-04-20T10:05:00.000Z"),
+              user_prompt_length: promptLen,
+              response_size: responseLen,
+              model_id: "anthropic.claude-sonnet-4-20250514-v1:0",
+            },
+          ],
+        },
+      };
+    }
+
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT, created_at INTEGER, updated_at INTEGER, PRIMARY KEY (key, conversation_id));",
+    ]);
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO conversations_v2 VALUES ('project-a', 'conv-1', '${JSON.stringify(convValue(400, 80)).replace(/'/g, "''")}', 1771667600000, 1771667700000);`,
+    ]);
+
+    const cursors = { version: 1 };
+
+    // First run: 400 chars prompt -> 100 input tokens; 80 chars response -> 20 output tokens
+    const r1 = await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
+    assert.equal(r1.recordsProcessed, 1);
+    assert.equal(r1.eventsAggregated, 1);
+
+    const rowsA = (await fs.readFile(queuePath, "utf8"))
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    assert.equal(rowsA.length, 1);
+    assert.equal(rowsA[0].source, "kiro", "source must merge under 'kiro'");
+    assert.equal(
+      rowsA[0].model,
+      "claude-sonnet-4",
+      "Bedrock ARN 'anthropic.claude-sonnet-4-20250514-v1:0' must canonicalize to 'claude-sonnet-4'",
+    );
+    assert.equal(rowsA[0].input_tokens, 100);
+    assert.equal(rowsA[0].output_tokens, 20);
+
+    // Second run with the SAME request data: idempotent — no new queue row.
+    const r2 = await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
+    assert.equal(r2.eventsAggregated, 0, "idempotent re-run must not re-add");
+    const rowsB = (await fs.readFile(queuePath, "utf8"))
+      .split("\n")
+      .filter((l) => l.trim());
+    assert.equal(rowsB.length, 1, "queue must not grow on idempotent re-run");
+
+    // Mutate the request: Kiro rewrites the same request_id with larger
+    // prompt/response. The parser must subtract the prior contribution and
+    // add the new one — not skip forever.
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `UPDATE conversations_v2 SET value = '${JSON.stringify(convValue(800, 160)).replace(/'/g, "''")}' WHERE conversation_id = 'conv-1';`,
+    ]);
+    const r3 = await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
+    assert.equal(r3.eventsAggregated, 1, "fingerprint-changed request must be re-bucketed");
+
+    const rowsC = (await fs.readFile(queuePath, "utf8"))
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    // The queue appends cumulative snapshots; consumers (readQueueData in
+    // src/lib/local-api.js) dedupe by (source, model, hour_start) and keep
+    // the LATEST row. So the mutation is correctly reflected iff the last
+    // row for this bucket shows the new 200 / 40 approx counts.
+    const lastForBucket = rowsC
+      .filter(
+        (row) =>
+          row.source === "kiro" &&
+          row.model === "claude-sonnet-4" &&
+          row.hour_start === "2026-04-20T10:00:00.000Z",
+      )
+      .pop();
+    assert.ok(lastForBucket, "mutated bucket must have at least one queue row");
+    assert.equal(
+      lastForBucket.input_tokens,
+      200,
+      "latest row for the bucket must reflect the post-mutation prompt tokens (800 chars / 4)",
+    );
+    assert.equal(
+      lastForBucket.output_tokens,
+      40,
+      "latest row for the bucket must reflect the post-mutation response tokens (160 chars / 4)",
+    );
+
+    // Cursor state records the per-request fingerprint + contribution so a
+    // third identical run is again idempotent.
+    const r4 = await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
+    assert.equal(r4.eventsAggregated, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Reads historical conversations from ~/Library/Application Support/kiro-cli/data.sqlite3 (table conversations_v2) and emits queue entries under source='kiro' so CLI and IDE usage merge at the token, cost, and leaderboard levels without any downstream code change on the token side. Kiro CLI does not persist explicit token counts; they are approximated at 4 chars/token from user_prompt_length and response_size. Model IDs (Bedrock ARNs like anthropic.claude-sonnet-4-20250514-v1:0) are canonicalized so IDE and CLI rows collapse when they refer to the same underlying model. Per-request cursor state (cursors.kiroCli.requests) captures each request's fingerprint and contribution so mutations (same request_id, changed prompt/response size) subtract-old/add-new instead of being skipped forever. Pricing tables in src/lib/local-api.js and dashboard/edge-patches/tokentracker-leaderboard-refresh.ts get kiro-agent and kiro-cli-agent entries plus a fuzzy kiro-* rule so cost no longer silently rounds to zero.

# PR Goal (one sentence)

## Scope

-

## Codex Context (required when requesting @codex review)

- **Delta since last Codex review:** (commits or summary)
- **Intended behavior / invariants:**
- **Edge cases covered:**
- **Tests run (command + result):**
- **Known gaps / out of scope:**

## Risk Layer Trigger (if any)

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Layer Addendum (fill ONLY if any trigger checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence (tests or repro)

-

## Public Exposure Checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback
- [ ] Mark N/A if no public exposure

## Regression Test Gate

### Most likely regression surface

-

### Verification method (choose at least one)

- [ ]

### Uncovered scope

-
