### PR TITLE
fix: tighten local dashboard and cloud sync security boundaries

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -2,6 +2,9 @@ import Foundation
 
 actor APIClient {
     static let shared = APIClient()
+    private struct LocalAuthResponse: Decodable {
+        let token: String
+    }
 
     private let baseURL = Constants.serverBaseURL
     private let session: URLSession
@@ -119,10 +122,26 @@ actor APIClient {
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if path == "/functions/tokentracker-local-sync" {
+            request.setValue(try await fetchLocalAuthToken(), forHTTPHeaderField: "x-tokentracker-local-auth")
+        }
         request.httpBody = Data("{}".utf8)
         let (data, response) = try await session.data(for: request)
         try validateResponse(response)
         return try decoder.decode(T.self, from: data)
+    }
+
+    private func fetchLocalAuthToken() async throws -> String {
+        guard let url = URL(string: baseURL + "/api/local-auth") else {
+            throw APIError.invalidURL
+        }
+        let (data, response) = try await session.data(from: url)
+        try validateResponse(response)
+        let payload = try decoder.decode(LocalAuthResponse.self, from: data)
+        guard !payload.token.isEmpty else {
+            throw APIError.invalidResponse
+        }
+        return payload.token
     }
 
     private func validateResponse(_ response: URLResponse) throws {

--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -198,6 +198,16 @@ export default async function (req: Request): Promise<Response> {
   const tokenHash = await sha256Hex(token);
   const createdAt = new Date().toISOString();
 
+  const { error: revokeErr } = await dbClient.database
+    .from("tokentracker_device_tokens")
+    .update({ revoked_at: createdAt })
+    .eq("device_id", deviceId)
+    .is("revoked_at", null);
+
+  if (revokeErr) {
+    return json({ error: "Failed to rotate device token", detail: revokeErr.message }, 500);
+  }
+
   const { error: tokenErr } = await dbClient.database.from("tokentracker_device_tokens").insert([
     {
       id: tokenId,

--- a/dashboard/src/contexts/InsforgeAuthContext.jsx
+++ b/dashboard/src/contexts/InsforgeAuthContext.jsx
@@ -3,6 +3,7 @@ import { getOrCreateInsforgeClient, isCloudInsforgeConfigured } from "../lib/ins
 import { clearCloudDeviceSession } from "../lib/cloud-sync-prefs";
 import { isLikelyExpiredAccessToken } from "../lib/auth-token";
 import { getPublicVisibility } from "../lib/api";
+import { clearLocalApiAuthToken, getLocalApiAuthHeaders } from "../lib/local-api-auth";
 
 const InsforgeAuthContext = createContext(null);
 
@@ -146,9 +147,10 @@ export function InsforgeAuthProvider({ children }) {
           // Tell the local server that the next /auth/callback is a native app flow.
           // The callback page (in system browser) checks this flag to relay code back to app.
           try {
+            const authHeaders = await getLocalApiAuthHeaders();
             await fetch("/api/auth-bridge/verifier", {
               method: "PUT",
-              headers: { "Content-Type": "application/json" },
+              headers: { "Content-Type": "application/json", ...authHeaders },
               body: JSON.stringify({ native: true }),
             });
           } catch {}
@@ -200,6 +202,7 @@ export function InsforgeAuthProvider({ children }) {
     if (!client) return;
     await client.auth.signOut();
     clearCloudDeviceSession();
+    clearLocalApiAuthToken();
     setUser(null);
   }, [client]);
 

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -12,6 +12,7 @@ import {
 } from "./mock-data";
 import { getInsforgeRemoteUrl, getInsforgeAnonKey } from "./insforge-config";
 import { isValidJwtShape } from "./auth-token";
+import { getLocalApiAuthHeaders } from "./local-api-auth";
 
 type AnyRecord = Record<string, any>;
 
@@ -261,9 +262,10 @@ export async function getUserStatus(_opts: AnyRecord = {}) {
 }
 
 export async function triggerLocalSync({ signal }: AnyRecord = {}) {
+  const authHeaders = await getLocalApiAuthHeaders();
   const response = await fetch(`/functions/${PATHS.localSync}`, {
     method: "POST",
-    headers: { Accept: "application/json" },
+    headers: { Accept: "application/json", ...authHeaders },
     cache: "no-store",
     signal,
   });
@@ -380,4 +382,3 @@ export async function getUsageHeatmap({
     ...tzParams,
   });
 }
-

--- a/dashboard/src/lib/cloud-sync-prefs.ts
+++ b/dashboard/src/lib/cloud-sync-prefs.ts
@@ -1,12 +1,21 @@
 const KEY_ENABLED = "tokentracker_cloud_sync_enabled";
 const KEY_DEVICE = "tokentracker_cloud_device_session_v1";
 const KEY_LAST_SYNC = "tokentracker_cloud_last_sync_ts";
+let memoryDeviceSession: CloudDeviceSession | null = null;
 
 export type CloudDeviceSession = {
   token: string;
   deviceId: string;
   issuedAt: string;
 };
+
+function clearLegacyStoredDeviceSession(): void {
+  try {
+    localStorage.removeItem(KEY_DEVICE);
+  } catch {
+    /* ignore */
+  }
+}
 
 export function isLocalDashboardHost(): boolean {
   if (typeof window === "undefined") return false;
@@ -34,32 +43,23 @@ export function setCloudSyncEnabled(enabled: boolean): void {
 }
 
 export function getStoredDeviceSession(): CloudDeviceSession | null {
-  try {
-    const raw = localStorage.getItem(KEY_DEVICE);
-    if (!raw) return null;
-    const o = JSON.parse(raw) as CloudDeviceSession;
-    if (typeof o?.token === "string" && o.token && typeof o.deviceId === "string") return o;
-  } catch {
-    /* ignore */
-  }
-  return null;
+  clearLegacyStoredDeviceSession();
+  return memoryDeviceSession;
 }
 
 export function setStoredDeviceSession(session: CloudDeviceSession): void {
-  try {
-    localStorage.setItem(KEY_DEVICE, JSON.stringify(session));
-  } catch {
-    /* ignore */
-  }
+  memoryDeviceSession = session;
+  clearLegacyStoredDeviceSession();
 }
 
 export function clearCloudDeviceSession(): void {
+  memoryDeviceSession = null;
   try {
-    localStorage.removeItem(KEY_DEVICE);
     localStorage.removeItem(KEY_LAST_SYNC);
   } catch {
     /* ignore */
   }
+  clearLegacyStoredDeviceSession();
 }
 
 export function getLastCloudSyncTs(): number {

--- a/dashboard/src/lib/cloud-sync.ts
+++ b/dashboard/src/lib/cloud-sync.ts
@@ -1,16 +1,29 @@
 import { getInsforgeAnonKey, getInsforgeRemoteUrl } from "./insforge-config";
 import {
+  clearCloudDeviceSession,
   getLastCloudSyncTs,
   getStoredDeviceSession,
   setLastCloudSyncTs,
   setStoredDeviceSession,
   type CloudDeviceSession,
 } from "./cloud-sync-prefs";
+import { getLocalApiAuthHeaders } from "./local-api-auth";
 
 const MIN_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+export const DEVICE_TOKEN_ROTATE_AFTER_MS = 12 * 60 * 60 * 1000;
 
 function isRemoteHttpBase(baseUrl: string): boolean {
   return typeof baseUrl === "string" && /^https?:\/\//i.test(baseUrl.trim());
+}
+
+export function shouldRotateStoredDeviceSession(
+  session: CloudDeviceSession | null,
+  nowMs = Date.now(),
+): boolean {
+  if (!session?.token || !session?.deviceId || !session?.issuedAt) return true;
+  const issuedAtMs = Date.parse(session.issuedAt);
+  if (!Number.isFinite(issuedAtMs)) return true;
+  return issuedAtMs + DEVICE_TOKEN_ROTATE_AFTER_MS <= nowMs;
 }
 
 async function triggerLeaderboardRefresh(accessToken: string): Promise<void> {
@@ -92,10 +105,11 @@ export async function postLocalUsageSync(options: {
   const body: Record<string, string> = { deviceToken };
   const bu = insforgeBaseUrl || getInsforgeRemoteUrl();
   if (isRemoteHttpBase(bu)) body.insforgeBaseUrl = bu.trim();
+  const authHeaders = await getLocalApiAuthHeaders();
 
   const res = await fetch("/functions/tokentracker-local-sync", {
     method: "POST",
-    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders },
     body: JSON.stringify(body),
   });
   const data = (await res.json().catch(() => ({}))) as Record<string, unknown>;
@@ -106,6 +120,49 @@ export async function postLocalUsageSync(options: {
   return data as { ok?: boolean; code?: number; stdout?: string; stderr?: string };
 }
 
+async function resolveCloudDeviceSession(getAccessToken: () => Promise<string | null>): Promise<CloudDeviceSession | null> {
+  const accessToken = await getAccessToken();
+  if (!accessToken) return null;
+
+  const current = getStoredDeviceSession();
+  if (current && !shouldRotateStoredDeviceSession(current)) {
+    return current;
+  }
+
+  const issued = await issueDeviceTokenForCloud(accessToken);
+  if (!issued) return null;
+  setStoredDeviceSession(issued);
+  return issued;
+}
+
+async function syncCloudUsageWithRecovery(getAccessToken: () => Promise<string | null>): Promise<string | null> {
+  let accessToken = await getAccessToken();
+  if (!accessToken) return null;
+
+  let session = await resolveCloudDeviceSession(async () => accessToken);
+  if (!session) return accessToken;
+
+  try {
+    await postLocalUsageSync({
+      deviceToken: session.token,
+      insforgeBaseUrl: getInsforgeRemoteUrl(),
+    });
+    return accessToken;
+  } catch (error) {
+    if (!getStoredDeviceSession()) throw error;
+    clearCloudDeviceSession();
+    accessToken = await getAccessToken();
+    if (!accessToken) throw error;
+    session = await resolveCloudDeviceSession(async () => accessToken);
+    if (!session) throw error;
+    await postLocalUsageSync({
+      deviceToken: session.token,
+      insforgeBaseUrl: getInsforgeRemoteUrl(),
+    });
+    return accessToken;
+  }
+}
+
 /**
  * 若开启同步且具备条件：签发（或复用）device token 并运行本地 sync，将 queue 上传到云端。
  */
@@ -113,42 +170,16 @@ export async function runCloudUsageSyncIfDue(getAccessToken: () => Promise<strin
   const last = getLastCloudSyncTs();
   if (Date.now() - last < MIN_SYNC_INTERVAL_MS) return;
 
-  const accessToken = await getAccessToken();
+  const accessToken = await syncCloudUsageWithRecovery(getAccessToken);
   if (!accessToken) return;
-
-  let session = getStoredDeviceSession();
-  if (!session) {
-    const issued = await issueDeviceTokenForCloud(accessToken);
-    if (!issued) return;
-    setStoredDeviceSession(issued);
-    session = issued;
-  }
-
-  await postLocalUsageSync({
-    deviceToken: session.token,
-    insforgeBaseUrl: getInsforgeRemoteUrl(),
-  });
   setLastCloudSyncTs(Date.now());
   await triggerLeaderboardRefresh(accessToken);
 }
 
 /** 用户打开「同步到云端」后立即尝试一次（忽略节流） */
 export async function runCloudUsageSyncNow(getAccessToken: () => Promise<string | null>): Promise<void> {
-  const accessToken = await getAccessToken();
+  const accessToken = await syncCloudUsageWithRecovery(getAccessToken);
   if (!accessToken) return;
-
-  let session = getStoredDeviceSession();
-  if (!session) {
-    const issued = await issueDeviceTokenForCloud(accessToken);
-    if (!issued) return;
-    setStoredDeviceSession(issued);
-    session = issued;
-  }
-
-  await postLocalUsageSync({
-    deviceToken: session.token,
-    insforgeBaseUrl: getInsforgeRemoteUrl(),
-  });
   setLastCloudSyncTs(Date.now());
   await triggerLeaderboardRefresh(accessToken);
 }

--- a/dashboard/src/lib/local-api-auth.ts
+++ b/dashboard/src/lib/local-api-auth.ts
@@ -1,0 +1,30 @@
+let localApiAuthToken: string | null = null;
+
+export function clearLocalApiAuthToken(): void {
+  localApiAuthToken = null;
+}
+
+export async function getLocalApiAuthToken(fetchImpl: typeof fetch = fetch): Promise<string> {
+  if (localApiAuthToken) return localApiAuthToken;
+
+  const res = await fetchImpl("/api/local-auth", {
+    method: "GET",
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    throw new Error(`Local auth request failed with HTTP ${res.status}`);
+  }
+  const data = (await res.json().catch(() => null)) as { token?: string } | null;
+  const token = typeof data?.token === "string" ? data.token.trim() : "";
+  if (!token) {
+    throw new Error("Local auth token missing from response");
+  }
+  localApiAuthToken = token;
+  return token;
+}
+
+export async function getLocalApiAuthHeaders(fetchImpl: typeof fetch = fetch): Promise<Record<string, string>> {
+  const token = await getLocalApiAuthToken(fetchImpl);
+  return { "x-tokentracker-local-auth": token };
+}

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -11,9 +11,14 @@ const { openInBrowser } = require("../lib/browser-auth");
 
 const DEFAULT_PORT = 7680;
 const NPM_PACKAGE_NAME = "tokentracker-cli";
+const LOCAL_BIND_HOST = "127.0.0.1";
 
 function buildPortInUseHint(port) {
   return `Port ${port} is still in use after cleanup. Try: npx ${NPM_PACKAGE_NAME} serve --port ${port + 1}\n`;
+}
+
+function getLocalServerUrl(port) {
+  return `http://${LOCAL_BIND_HOST}:${port}`;
 }
 
 async function cmdServe(argv) {
@@ -85,7 +90,6 @@ async function cmdServe(argv) {
       // CORS preflight
       if (req.method === "OPTIONS") {
         res.writeHead(204, {
-          "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
           "Access-Control-Allow-Headers": "Content-Type, Authorization",
         });
@@ -116,8 +120,8 @@ async function cmdServe(argv) {
   // 4. Listen (kill stale process on same port if needed)
   const port = opts.port;
   await ensurePortFree(port);
-  server.listen(port, () => {
-    const url = `http://localhost:${port}`;
+  server.listen(port, LOCAL_BIND_HOST, () => {
+    const url = getLocalServerUrl(port);
     process.stdout.write(
       [
         "",
@@ -226,4 +230,10 @@ function parseArgs(argv) {
   return opts;
 }
 
-module.exports = { cmdServe, buildPortInUseHint, NPM_PACKAGE_NAME };
+module.exports = {
+  cmdServe,
+  buildPortInUseHint,
+  NPM_PACKAGE_NAME,
+  LOCAL_BIND_HOST,
+  getLocalServerUrl,
+};

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
+const crypto = require("node:crypto");
 const { DEFAULT_BASE_URL, resolveRuntimeConfig } = require("./runtime-config");
 
 const SYNC_TIMEOUT_MS = 120_000;
@@ -392,6 +393,37 @@ function resolveAllowedInsforgeBaseUrl(value) {
   return allowed.has(requested) ? requested : null;
 }
 
+function parseCookieHeader(value) {
+  const out = new Map();
+  if (typeof value !== "string" || !value.trim()) return out;
+  for (const part of value.split(";")) {
+    const idx = part.indexOf("=");
+    if (idx < 1) continue;
+    const key = part.slice(0, idx).trim();
+    const rawValue = part.slice(idx + 1).trim();
+    if (key) out.set(key, rawValue);
+  }
+  return out;
+}
+
+function isLoopbackHostname(hostname) {
+  return hostname === "127.0.0.1" || hostname === "localhost" || hostname === "::1" || hostname === "[::1]";
+}
+
+function hasAllowedLoopbackOrigin(headers = {}) {
+  const candidates = [headers.origin, headers.referer];
+  for (const raw of candidates) {
+    if (raw == null || raw === "") continue;
+    try {
+      const url = new URL(String(raw));
+      if (url.protocol !== "http:" || !isLoopbackHostname(url.hostname)) return false;
+    } catch (_e) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function readJsonBody(req) {
   return new Promise((resolve, reject) => {
     const chunks = [];
@@ -572,6 +604,7 @@ function createLocalApiHandler({ queuePath }) {
   // so that both browser and WKWebView share the same login session via the proxy.
   // Persisted to disk so cookies survive server restarts.
   let relayCookies = new Map();
+  const localAuthToken = crypto.randomBytes(24).toString("hex");
   const trackerDataDir = path.join(os.homedir(), ".tokentracker", "tracker");
   const cookiePath = path.join(trackerDataDir, "relay-cookies.json");
 
@@ -684,13 +717,40 @@ function createLocalApiHandler({ queuePath }) {
   let _nativeAuthPending = false;
   let _nativeAuthExpiry = 0;
 
+  function isAuthorizedLocalMutation(req) {
+    const headerToken = req?.headers?.["x-tokentracker-local-auth"];
+    const cookieToken = parseCookieHeader(req?.headers?.cookie).get("tokentracker_local_auth");
+    const token = typeof headerToken === "string" && headerToken.trim()
+      ? headerToken.trim()
+      : cookieToken || "";
+    if (!token || token !== localAuthToken) return false;
+    return hasAllowedLoopbackOrigin(req?.headers || {});
+  }
+
   return async function handleLocalApi(req, res, url) {
     const p = url.pathname;
+
+    if (p === "/api/local-auth") {
+      if (String(req.method || "GET").toUpperCase() !== "GET") {
+        json(res, { error: "Method Not Allowed" }, 405);
+        return true;
+      }
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+      });
+      res.end(JSON.stringify({ token: localAuthToken }));
+      return true;
+    }
 
     // --- Auth bridge: native OAuth flag (WebView ↔ system browser) ---
     if (p === "/api/auth-bridge/verifier") {
       const method = String(req.method || "GET").toUpperCase();
       if (method === "PUT" || method === "POST") {
+        if (!isAuthorizedLocalMutation(req)) {
+          json(res, { error: "Unauthorized" }, 401);
+          return true;
+        }
         const body = await readJsonBody(req);
         _nativeAuthPending = Boolean(body?.native);
         _nativeAuthExpiry = Date.now() + 5 * 60 * 1000; // 5 min TTL
@@ -775,6 +835,10 @@ function createLocalApiHandler({ queuePath }) {
     if (p === "/functions/tokentracker-local-sync") {
       if (String(req.method || "GET").toUpperCase() !== "POST") {
         json(res, { ok: false, error: "Method Not Allowed" }, 405);
+        return true;
+      }
+      if (!isAuthorizedLocalMutation(req)) {
+        json(res, { ok: false, error: "Unauthorized" }, 401);
         return true;
       }
       try {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { spawn } = require("node:child_process");
+const { DEFAULT_BASE_URL, resolveRuntimeConfig } = require("./runtime-config");
 
 const SYNC_TIMEOUT_MS = 120_000;
 const TRACKER_BIN = path.resolve(__dirname, "../../bin/tracker.js");
@@ -361,6 +362,36 @@ function trimOutput(value, max = 4000) {
   return t.length <= max ? t : t.slice(t.length - max);
 }
 
+function normalizeRemoteHttpBaseUrl(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    url.username = "";
+    url.password = "";
+    url.hash = "";
+    return url.toString().replace(/\/$/, "");
+  } catch (_e) {
+    return null;
+  }
+}
+
+function resolveAllowedInsforgeBaseUrl(value) {
+  const requested = normalizeRemoteHttpBaseUrl(value);
+  if (!requested) return null;
+
+  const runtime = resolveRuntimeConfig();
+  const allowed = new Set(
+    [runtime.baseUrl, DEFAULT_BASE_URL]
+      .map((entry) => normalizeRemoteHttpBaseUrl(entry))
+      .filter(Boolean),
+  );
+
+  return allowed.has(requested) ? requested : null;
+}
+
 function readJsonBody(req) {
   return new Promise((resolve, reject) => {
     const chunks = [];
@@ -526,7 +557,7 @@ function scanClaudeProjects(projectMap) {
 // ---------------------------------------------------------------------------
 
 function json(res, data, status) {
-  res.writeHead(status || 200, { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" });
+  res.writeHead(status || 200, { "Content-Type": "application/json" });
   res.end(JSON.stringify(data));
 }
 
@@ -679,20 +710,8 @@ function createLocalApiHandler({ queuePath }) {
 
     // --- auth proxy: forward /api/auth/* to InsForge cloud ---
     if (p.startsWith("/api/auth/")) {
-      const { DEFAULT_BASE_URL } = require("./runtime-config.js");
-      let insforgeBase = process.env.TOKENTRACKER_INSFORGE_BASE_URL
-        || process.env.INSFORGE_BASE_URL
-        || "";
-      if (!insforgeBase) {
-        try {
-          const cfgPath = path.join(os.homedir(), ".tokentracker", "tracker", "config.json");
-          const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"));
-          insforgeBase = cfg?.baseUrl || "";
-        } catch { /* ignore */ }
-      }
-      if (!insforgeBase) {
-        insforgeBase = DEFAULT_BASE_URL;
-      }
+      const runtime = resolveRuntimeConfig();
+      const insforgeBase = runtime.baseUrl || DEFAULT_BASE_URL;
       try {
         const targetUrl = `${insforgeBase.replace(/\/$/, "")}${p}${url.search || ""}`;
         const proxyHeaders = {};
@@ -769,8 +788,13 @@ function createLocalApiHandler({ queuePath }) {
         if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
           extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
         }
-        if (typeof body.insforgeBaseUrl === "string" && /^https?:\/\//i.test(body.insforgeBaseUrl.trim())) {
-          extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = body.insforgeBaseUrl.trim();
+        if (body.insforgeBaseUrl != null) {
+          const allowedBaseUrl = resolveAllowedInsforgeBaseUrl(body.insforgeBaseUrl);
+          if (!allowedBaseUrl) {
+            json(res, { ok: false, error: "Unsupported insforgeBaseUrl override" }, 400);
+            return true;
+          }
+          extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = allowedBaseUrl;
         }
         const result = await runSyncCommand(extraEnv);
         try {
@@ -1119,6 +1143,7 @@ function createLocalApiHandler({ queuePath }) {
 
 module.exports = {
   createLocalApiHandler,
+  resolveAllowedInsforgeBaseUrl,
   resolveQueuePath,
   // Exported for cross-consumer tests (pricing + native contract lock).
   MODEL_PRICING,

--- a/src/lib/static-server.js
+++ b/src/lib/static-server.js
@@ -46,7 +46,6 @@ async function serveStaticFile(baseDir, pathname, res) {
       "Content-Type": contentType,
       "Content-Length": stat.size,
       "Cache-Control": isHtml ? "no-cache" : "public, max-age=31536000, immutable",
-      "Access-Control-Allow-Origin": "*",
     });
 
     const stream = fs.createReadStream(filePath);

--- a/test/cloud-sync-prefs.test.js
+++ b/test/cloud-sync-prefs.test.js
@@ -1,0 +1,56 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+function createStorage(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(key, String(value));
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+  };
+}
+
+async function loadModuleWithStorage(storage) {
+  globalThis.localStorage = storage;
+  return import("../dashboard/src/lib/cloud-sync-prefs.ts");
+}
+
+test("cloud device session stays in memory and clears legacy localStorage", async () => {
+  const legacyKey = "tokentracker_cloud_device_session_v1";
+  const storage = createStorage({
+    [legacyKey]: JSON.stringify({
+      token: "persisted-token",
+      deviceId: "persisted-device",
+      issuedAt: "2026-04-20T00:00:00.000Z",
+    }),
+  });
+  const previous = globalThis.localStorage;
+
+  try {
+    const mod = await loadModuleWithStorage(storage);
+
+    assert.equal(mod.getStoredDeviceSession(), null);
+    assert.equal(storage.getItem(legacyKey), null);
+
+    const session = {
+      token: "memory-token",
+      deviceId: "memory-device",
+      issuedAt: "2026-04-20T01:00:00.000Z",
+    };
+
+    mod.setStoredDeviceSession(session);
+    assert.deepEqual(mod.getStoredDeviceSession(), session);
+    assert.equal(storage.getItem(legacyKey), null);
+
+    mod.clearCloudDeviceSession();
+    assert.equal(mod.getStoredDeviceSession(), null);
+  } finally {
+    globalThis.localStorage = previous;
+  }
+});

--- a/test/cloud-sync-rotation.test.js
+++ b/test/cloud-sync-rotation.test.js
@@ -1,0 +1,45 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+test("cloud sync source includes device-session rotation and recovery", () => {
+  const src = fs.readFileSync(
+    path.join(process.cwd(), "dashboard/src/lib/cloud-sync.ts"),
+    "utf8",
+  );
+
+  assert.match(src, /DEVICE_TOKEN_ROTATE_AFTER_MS\s*=\s*12 \* 60 \* 60 \* 1000/);
+  assert.match(src, /export function shouldRotateStoredDeviceSession/);
+  assert.match(src, /issuedAtMs \+ DEVICE_TOKEN_ROTATE_AFTER_MS <= nowMs/);
+  assert.match(src, /clearCloudDeviceSession\(\)/);
+  assert.match(src, /await postLocalUsageSync/);
+});
+
+test("local auth helper caches the per-process token in memory", async () => {
+  const calls = [];
+  const previousFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, _init) => {
+    calls.push(1);
+    return new Response(JSON.stringify({ token: "local-token" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    const mod = await import("../dashboard/src/lib/local-api-auth.ts");
+    mod.clearLocalApiAuthToken();
+
+    const first = await mod.getLocalApiAuthHeaders(globalThis.fetch);
+    const second = await mod.getLocalApiAuthHeaders(globalThis.fetch);
+
+    assert.deepEqual(first, { "x-tokentracker-local-auth": "local-token" });
+    assert.deepEqual(second, { "x-tokentracker-local-auth": "local-token" });
+    assert.equal(calls.length, 1);
+
+    mod.clearLocalApiAuthToken();
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -1,0 +1,137 @@
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const path = require("node:path");
+const { test } = require("node:test");
+
+function createRequest({ method = "GET", headers = {}, body } = {}) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.headers = headers;
+
+  process.nextTick(() => {
+    if (body != null) req.emit("data", Buffer.from(body));
+    req.emit("end");
+  });
+
+  return req;
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    headers: null,
+    body: Buffer.alloc(0),
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      this.headers = headers;
+    },
+    end(chunk) {
+      this.body = chunk ? Buffer.from(chunk) : Buffer.alloc(0);
+    },
+  };
+}
+
+function loadLocalApiWithSpawn(fakeSpawn) {
+  const childProcess = require("node:child_process");
+  const originalSpawn = childProcess.spawn;
+  childProcess.spawn = fakeSpawn;
+  delete require.cache[require.resolve("../src/lib/local-api")];
+  const mod = require("../src/lib/local-api");
+  return {
+    mod,
+    restore() {
+      childProcess.spawn = originalSpawn;
+      delete require.cache[require.resolve("../src/lib/local-api")];
+    },
+  };
+}
+
+function createSuccessfulSpawn(calls) {
+  return (cmd, args, options) => {
+    calls.push({ cmd, args, options });
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stderr = new EventEmitter();
+    child.kill = () => {};
+    process.nextTick(() => {
+      child.stdout.emit("data", "sync ok");
+      child.emit("close", 0);
+    });
+    return child;
+  };
+}
+
+test("local sync rejects arbitrary insforgeBaseUrl overrides", async () => {
+  const calls = [];
+  const prevBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+  process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://allowed.example";
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const req = createRequest({
+      method: "POST",
+      body: JSON.stringify({
+        deviceToken: "device-token",
+        insforgeBaseUrl: "https://evil.example",
+      }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 400);
+    assert.deepEqual(JSON.parse(res.body.toString("utf8")), {
+      ok: false,
+      error: "Unsupported insforgeBaseUrl override",
+    });
+    assert.equal(calls.length, 0);
+  } finally {
+    restore();
+    if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+  }
+});
+
+test("local sync accepts the configured insforgeBaseUrl override", async () => {
+  const calls = [];
+  const prevBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+  process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://allowed.example";
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const req = createRequest({
+      method: "POST",
+      body: JSON.stringify({
+        deviceToken: "device-token",
+        insforgeBaseUrl: "https://allowed.example/",
+      }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0].options.env.TOKENTRACKER_INSFORGE_BASE_URL,
+      "https://allowed.example",
+    );
+  } finally {
+    restore();
+    if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+  }
+});

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -31,6 +31,19 @@ function createResponse() {
   };
 }
 
+async function getLocalAuthToken(handler) {
+  const req = createRequest({ method: "GET" });
+  const res = createResponse();
+  const handled = await handler(req, res, new URL("http://127.0.0.1/api/local-auth"));
+  assert.equal(handled, true);
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.headers["Cache-Control"], "no-store");
+  const body = JSON.parse(res.body.toString("utf8"));
+  assert.equal(typeof body.token, "string");
+  assert.ok(body.token.length > 0);
+  return body.token;
+}
+
 function loadLocalApiWithSpawn(fakeSpawn) {
   const childProcess = require("node:child_process");
   const originalSpawn = childProcess.spawn;
@@ -69,8 +82,10 @@ test("local sync rejects arbitrary insforgeBaseUrl overrides", async () => {
 
   try {
     const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const localAuthToken = await getLocalAuthToken(handler);
     const req = createRequest({
       method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
       body: JSON.stringify({
         deviceToken: "device-token",
         insforgeBaseUrl: "https://evil.example",
@@ -107,8 +122,10 @@ test("local sync accepts the configured insforgeBaseUrl override", async () => {
 
   try {
     const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const localAuthToken = await getLocalAuthToken(handler);
     const req = createRequest({
       method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
       body: JSON.stringify({
         deviceToken: "device-token",
         insforgeBaseUrl: "https://allowed.example/",
@@ -133,5 +150,60 @@ test("local sync accepts the configured insforgeBaseUrl override", async () => {
     restore();
     if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
     else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+  }
+});
+
+test("local sync rejects requests without the local auth token", async () => {
+  const calls = [];
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const req = createRequest({
+      method: "POST",
+      body: JSON.stringify({ deviceToken: "device-token" }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(JSON.parse(res.body.toString("utf8")), {
+      ok: false,
+      error: "Unauthorized",
+    });
+    assert.equal(calls.length, 0);
+  } finally {
+    restore();
+  }
+});
+
+test("auth bridge mutation requires the local auth token", async () => {
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn([]));
+
+  try {
+    const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const req = createRequest({
+      method: "PUT",
+      body: JSON.stringify({ native: true }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/api/auth-bridge/verifier"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 401);
+    assert.deepEqual(JSON.parse(res.body.toString("utf8")), { error: "Unauthorized" });
+  } finally {
+    restore();
   }
 });

--- a/test/serve-bind-host.test.js
+++ b/test/serve-bind-host.test.js
@@ -1,0 +1,9 @@
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const { LOCAL_BIND_HOST, getLocalServerUrl } = require("../src/commands/serve");
+
+test("serve binds to loopback and advertises the loopback URL", () => {
+  assert.equal(LOCAL_BIND_HOST, "127.0.0.1");
+  assert.equal(getLocalServerUrl(7680), "http://127.0.0.1:7680");
+});


### PR DESCRIPTION
## Why
The local dashboard server and cloud-sync token lifecycle were broader than they needed to be for a localhost-oriented app. This patch narrows those trust boundaries and addresses the two security review findings tracked in #17 and #18.

## What changed
- bind `tokentracker serve` to loopback and advertise the loopback URL
- remove wildcard CORS from the local server surface
- restrict `/functions/tokentracker-local-sync` overrides to the configured InsForge base URL
- keep dashboard cloud device tokens in memory and purge any legacy persisted token
- add regression coverage for the local sync guard, loopback host selection, and in-memory device-token handling

## Verification
- `node --test test/local-api-security.test.js test/serve-bind-host.test.js test/cloud-sync-prefs.test.js test/cookie-relay-persistence.test.js`

## Follow-up / workspace notes
- `npm test` is currently blocked in this workspace by missing root dev modules such as `esbuild` and `@sourcegraph/scip-typescript`
- `npm run validate:guardrails` reports existing failures unrelated to this patch
- `dashboard/node_modules` is not installed in this workspace, so dashboard typecheck/build could not be run here

Closes #17
Closes #18