### PR TITLE
feat: add weekly review summaries to the dashboard

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -199,6 +199,19 @@ dashboard.rolling.title,ui,RollingUsagePanel,RollingUsagePanel,title,"Recent Act
 dashboard.rolling.last_7d,ui,RollingUsagePanel,RollingUsagePanel,label_last_7d,"Last 7 days",,active
 dashboard.rolling.last_30d,ui,RollingUsagePanel,RollingUsagePanel,label_last_30d,"Last 30 days",,active
 dashboard.rolling.avg_active_day,ui,RollingUsagePanel,RollingUsagePanel,label_avg_active_day,"Daily average",,active
+dashboard.weekly_review.title,ui,WeeklyReviewCard,WeeklyReviewCard,title,"Weekly Review",,active
+dashboard.weekly_review.subtitle,ui,WeeklyReviewCard,WeeklyReviewCard,subtitle,"A quick read on the last 7 days",,active
+dashboard.weekly_review.total,ui,WeeklyReviewCard,WeeklyReviewCard,label_total,"This week",,active
+dashboard.weekly_review.previous,ui,WeeklyReviewCard,WeeklyReviewCard,label_previous,"Previous week",,active
+dashboard.weekly_review.top_project,ui,WeeklyReviewCard,WeeklyReviewCard,label_top_project,"Top project",,active
+dashboard.weekly_review.top_model,ui,WeeklyReviewCard,WeeklyReviewCard,label_top_model,"Top model",,active
+dashboard.weekly_review.spike_label,ui,WeeklyReviewCard,WeeklyReviewCard,label_spike,"Biggest spike",,active
+dashboard.weekly_review.spike_value,ui,WeeklyReviewCard,WeeklyReviewCard,spike_value,"{{day}} drove {{tokens}}",,active
+dashboard.weekly_review.spike_empty,ui,WeeklyReviewCard,WeeklyReviewCard,spike_empty,"No spike data yet",,active
+dashboard.weekly_review.recommendation.default,ui,WeeklyReviewCard,WeeklyReviewCard,recommendation_default,"Usage looks steady. Keep an eye on your heaviest project before next week ramps up.",,active
+dashboard.weekly_review.recommendation.project,ui,WeeklyReviewCard,WeeklyReviewCard,recommendation_project,"Most of this week came from {{project}}. If it was exploratory work, consider a cheaper model for first-pass runs.",,active
+dashboard.weekly_review.recommendation.model,ui,WeeklyReviewCard,WeeklyReviewCard,recommendation_model,"{{model}} dominated the week. If this was repetitive work, try a lower-cost model for the next pass.",,active
+dashboard.weekly_review.recommendation.spike,ui,WeeklyReviewCard,WeeklyReviewCard,recommendation_spike,"Review the sessions around {{day}}. That spike is the clearest place to reduce wasted spend.",,active
 
 dashboard.model_breakdown.title,ui,NeuralDivergenceMap,NeuralDivergenceMap,title,"Model Breakdown",,active
 dashboard.model_breakdown.footer,ui,NeuralDivergenceMap,NeuralDivergenceMap,footer,"Multi-Engine Load Balancing // Active Session",,active

--- a/dashboard/src/lib/weekly-review.js
+++ b/dashboard/src/lib/weekly-review.js
@@ -1,0 +1,96 @@
+function toFiniteNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function toBillableTokens(row) {
+  if (!row || typeof row !== "object") return 0;
+  return (
+    toFiniteNumber(row.billable_total_tokens) ??
+    toFiniteNumber(row.total_tokens) ??
+    0
+  );
+}
+
+function sortRowsByDay(rows) {
+  return rows
+    .filter((row) => row?.day)
+    .slice()
+    .sort((a, b) => String(a.day).localeCompare(String(b.day)));
+}
+
+function sumTokens(rows) {
+  return rows.reduce((acc, row) => acc + toBillableTokens(row), 0);
+}
+
+function pickTopDay(rows) {
+  let best = null;
+  for (const row of rows) {
+    const tokens = toBillableTokens(row);
+    if (!best || tokens > best.tokens) {
+      best = { day: row.day, tokens };
+    }
+  }
+  return best;
+}
+
+function pickTopProject(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  if (list.length === 0) return null;
+  return list
+    .map((entry) => ({
+      name: entry?.project_key || entry?.project_ref || "Unknown",
+      tokens: toBillableTokens(entry),
+    }))
+    .sort((a, b) => b.tokens - a.tokens)[0] || null;
+}
+
+function pickTopModel(topModels) {
+  const list = Array.isArray(topModels) ? topModels : [];
+  if (list.length === 0) return null;
+  const row = list[0];
+  return {
+    name: row?.name || row?.id || "Unknown",
+    percent: toFiniteNumber(row?.percent) ?? 0,
+  };
+}
+
+export function buildWeeklyReview({ dailyRows, projectEntries, topModels } = {}) {
+  const sortedRows = sortRowsByDay(Array.isArray(dailyRows) ? dailyRows : []);
+  const currentWeek = sortedRows.slice(-7);
+  const previousWeek = sortedRows.slice(-14, -7);
+  const total = sumTokens(currentWeek);
+  const previousTotal = sumTokens(previousWeek);
+  const change = previousTotal > 0 ? total - previousTotal : null;
+  const spike = pickTopDay(currentWeek);
+  const topProject = pickTopProject(projectEntries);
+  const topModel = pickTopModel(topModels);
+
+  const projectShare =
+    total > 0 && topProject?.tokens ? topProject.tokens / total : 0;
+
+  let recommendationKey = "dashboard.weekly_review.recommendation.default";
+  let recommendationValues = {};
+
+  if (projectShare >= 0.4 && topProject?.name) {
+    recommendationKey = "dashboard.weekly_review.recommendation.project";
+    recommendationValues = { project: topProject.name };
+  } else if (topModel?.name && topModel.percent >= 50) {
+    recommendationKey = "dashboard.weekly_review.recommendation.model";
+    recommendationValues = { model: topModel.name };
+  } else if (spike?.day) {
+    recommendationKey = "dashboard.weekly_review.recommendation.spike";
+    recommendationValues = { day: spike.day };
+  }
+
+  return {
+    total,
+    previousTotal,
+    change,
+    topDay: spike,
+    topProject,
+    topModel,
+    recommendationKey,
+    recommendationValues,
+  };
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -1241,6 +1241,7 @@ export function DashboardPage({
       summaryCostValue={summaryCostValue}
       summaryConversationsValue={summaryConversationsValue}
       rollingUsage={rolling}
+      weeklyReviewRows={dailyBreakdownRows}
       costInfoEnabled={costInfoEnabled}
       openCostModal={openCostModal}
       allowBreakdownToggle={allowBreakdownToggle}

--- a/dashboard/src/ui/matrix-a/components/WeeklyReviewCard.jsx
+++ b/dashboard/src/ui/matrix-a/components/WeeklyReviewCard.jsx
@@ -1,0 +1,95 @@
+import React, { useMemo } from "react";
+import { copy } from "../../../lib/copy";
+import { formatCompactNumber } from "../../../lib/format";
+import { buildWeeklyReview } from "../../../lib/weekly-review.js";
+
+function formatValue(value) {
+  if (!Number.isFinite(Number(value)) || Number(value) <= 0) {
+    return copy("shared.placeholder.short");
+  }
+  return formatCompactNumber(value, {
+    thousandSuffix: copy("shared.unit.thousand_abbrev"),
+    millionSuffix: copy("shared.unit.million_abbrev"),
+    billionSuffix: copy("shared.unit.billion_abbrev"),
+  });
+}
+
+export function WeeklyReviewCard({
+  dailyRows = [],
+  projectEntries = [],
+  topModels = [],
+  className = "",
+}) {
+  const review = useMemo(
+    () => buildWeeklyReview({ dailyRows, projectEntries, topModels }),
+    [dailyRows, projectEntries, topModels],
+  );
+
+  return (
+    <div className={`rounded-xl border border-oai-gray-200 dark:border-oai-gray-800 bg-white dark:bg-oai-gray-900 p-5 ${className}`}>
+      <div className="mb-4">
+        <h3 className="text-sm font-medium text-oai-gray-500 dark:text-oai-gray-300 uppercase tracking-wide">
+          {copy("dashboard.weekly_review.title")}
+        </h3>
+        <p className="mt-1 text-xs text-oai-gray-500 dark:text-oai-gray-400">
+          {copy("dashboard.weekly_review.subtitle")}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Metric
+          label={copy("dashboard.weekly_review.total")}
+          value={formatValue(review.total)}
+        />
+        <Metric
+          label={copy("dashboard.weekly_review.previous")}
+          value={formatValue(review.previousTotal)}
+        />
+        <Metric
+          label={copy("dashboard.weekly_review.top_project")}
+          value={review.topProject?.name || copy("shared.placeholder.short")}
+          compact
+        />
+        <Metric
+          label={copy("dashboard.weekly_review.top_model")}
+          value={review.topModel?.name || copy("shared.placeholder.short")}
+          compact
+        />
+      </div>
+
+      <div className="mt-4 rounded-lg bg-oai-gray-50 dark:bg-oai-gray-800/70 px-3 py-3">
+        <div className="text-[11px] uppercase tracking-wide text-oai-gray-500 dark:text-oai-gray-400">
+          {copy("dashboard.weekly_review.spike_label")}
+        </div>
+        <div className="mt-1 text-sm text-oai-black dark:text-oai-white">
+          {review.topDay?.day
+            ? copy("dashboard.weekly_review.spike_value", {
+                day: review.topDay.day,
+                tokens: formatValue(review.topDay.tokens),
+              })
+            : copy("dashboard.weekly_review.spike_empty")}
+        </div>
+      </div>
+
+      <div className="mt-4 text-sm text-oai-gray-700 dark:text-oai-gray-300 leading-6">
+        {copy(review.recommendationKey, review.recommendationValues)}
+      </div>
+    </div>
+  );
+}
+
+function Metric({ label, value, compact = false }) {
+  return (
+    <div className="rounded-lg border border-oai-gray-100 dark:border-oai-gray-800 px-3 py-3">
+      <div className="text-[11px] uppercase tracking-wide text-oai-gray-500 dark:text-oai-gray-400">
+        {label}
+      </div>
+      <div
+        className={`mt-1 font-semibold text-oai-black dark:text-oai-white ${compact ? "text-sm truncate" : "text-lg"}`}
+        title={compact ? value : undefined}
+      >
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/ui/matrix-a/views/DashboardView.jsx
+++ b/dashboard/src/ui/matrix-a/views/DashboardView.jsx
@@ -6,6 +6,7 @@ import { DataDetails } from "../components/DataDetails.jsx";
 import { StatsPanel } from "../components/StatsPanel.jsx";
 import { UsageOverview } from "../components/UsageOverview.jsx";
 import { TrendMonitor } from "../components/TrendMonitor.jsx";
+import { WeeklyReviewCard } from "../components/WeeklyReviewCard.jsx";
 import { FadeIn } from "../../foundation/FadeIn.jsx";
 import { MacAppBanner } from "../components/MacAppBanner.jsx";
 import { WidgetOnboardingCard } from "../components/WidgetOnboardingCard.jsx";
@@ -59,6 +60,7 @@ export function DashboardView(props) {
     summaryCostValue,
     summaryConversationsValue,
     rollingUsage,
+    weeklyReviewRows,
     costInfoEnabled,
     openCostModal,
     costModalOpen,
@@ -158,6 +160,14 @@ export function DashboardView(props) {
                 />
 
                 {isLocalMode ? <WidgetOnboardingCard /> : null}
+
+                {!screenshotMode ? (
+                  <WeeklyReviewCard
+                    dailyRows={weeklyReviewRows}
+                    projectEntries={projectUsageEntries}
+                    topModels={topModels}
+                  />
+                ) : null}
 
                 {shouldShowInstall ? (
                   <FadeIn delay={0.25}>

--- a/test/weekly-review.test.js
+++ b/test/weekly-review.test.js
@@ -1,0 +1,51 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+test("weekly review helper summarizes the last two weeks", async () => {
+  const { buildWeeklyReview } = await import("../dashboard/src/lib/weekly-review.js");
+
+  const review = buildWeeklyReview({
+    dailyRows: [
+      { day: "2026-04-01", billable_total_tokens: 100 },
+      { day: "2026-04-02", billable_total_tokens: 150 },
+      { day: "2026-04-03", billable_total_tokens: 200 },
+      { day: "2026-04-04", billable_total_tokens: 250 },
+      { day: "2026-04-05", billable_total_tokens: 300 },
+      { day: "2026-04-06", billable_total_tokens: 350 },
+      { day: "2026-04-07", billable_total_tokens: 400 },
+      { day: "2026-04-08", billable_total_tokens: 500 },
+      { day: "2026-04-09", billable_total_tokens: 600 },
+      { day: "2026-04-10", billable_total_tokens: 700 },
+      { day: "2026-04-11", billable_total_tokens: 800 },
+      { day: "2026-04-12", billable_total_tokens: 900 },
+      { day: "2026-04-13", billable_total_tokens: 1000 },
+      { day: "2026-04-14", billable_total_tokens: 1100 },
+    ],
+    projectEntries: [
+      { project_key: "octo/api", billable_total_tokens: 2400 },
+      { project_key: "octo/web", billable_total_tokens: 1200 },
+    ],
+    topModels: [{ name: "gpt-5.4", percent: "61.2" }],
+  });
+
+  assert.equal(review.total, 5600);
+  assert.equal(review.previousTotal, 1750);
+  assert.equal(review.topDay.day, "2026-04-14");
+  assert.equal(review.topProject.name, "octo/api");
+  assert.equal(review.topModel.name, "gpt-5.4");
+  assert.equal(
+    review.recommendationKey,
+    "dashboard.weekly_review.recommendation.project",
+  );
+});
+
+test("dashboard wires the weekly review card into the left column", () => {
+  const src = fs.readFileSync(
+    path.join(process.cwd(), "dashboard/src/ui/matrix-a/views/DashboardView.jsx"),
+    "utf8",
+  );
+  assert.match(src, /WeeklyReviewCard/);
+  assert.match(src, /weeklyReviewRows/);
+});


### PR DESCRIPTION
## Why
Issue #20 asks for a weekly review summary that makes the dashboard easier to scan without manually cross-referencing multiple panels.

## What changed
- added a weekly review card to the dashboard
- summarized the current week, previous week, top project, top model, and biggest spike day
- generated a simple recommendation from the existing weekly data

## Verification
- `node --test test/weekly-review.test.js`
- `npm run validate:copy`

Closes #20