### PR TITLE
feat: add local session outcome markers and filters

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -215,6 +215,13 @@ dashboard.projects.limit_top_3,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_
 dashboard.projects.limit_top_6,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_6,"TOP 6",,active
 dashboard.projects.limit_top_10,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_10,"TOP 10",,active
 dashboard.projects.empty,ui,ProjectUsagePanel,ProjectUsagePanel,empty,"No public repositories",,active
+dashboard.sessions.title,ui,DataDetails,DataDetails,sessions_title,"Sessions",,active
+dashboard.sessions.filter.all,ui,DataDetails,DataDetails,filter_all,"All",,active
+dashboard.sessions.filter.productive,ui,DataDetails,DataDetails,filter_productive,"Productive",,active
+dashboard.sessions.filter.exploratory,ui,DataDetails,DataDetails,filter_exploratory,"Exploratory",,active
+dashboard.sessions.filter.blocked,ui,DataDetails,DataDetails,filter_blocked,"Blocked",,active
+dashboard.sessions.filter.wasted,ui,DataDetails,DataDetails,filter_wasted,"Wasted",,active
+dashboard.sessions.filter.unset,ui,DataDetails,DataDetails,filter_unset,"Set outcome…",,active
 dashboard.upgrade_alert.title,ui,UpgradeAlertModal,UpgradeAlertModal,title,"Update available",,active
 dashboard.upgrade_alert.subtitle,ui,UpgradeAlertModal,UpgradeAlertModal,subtitle,"TokenTracker v{{required}} is now available.",,active
 dashboard.upgrade_alert.subtitle_generic,ui,UpgradeAlertModal,UpgradeAlertModal,subtitle_generic,"A new version of TokenTracker is available.",,active

--- a/dashboard/src/hooks/use-session-buckets.js
+++ b/dashboard/src/hooks/use-session-buckets.js
@@ -1,0 +1,21 @@
+import { useCallback, useEffect, useState } from "react";
+import { getSessionBuckets } from "../lib/api";
+
+export function useSessionBuckets({ limit = 20 } = {}) {
+  const [entries, setEntries] = useState([]);
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await getSessionBuckets({ limit });
+      setEntries(Array.isArray(res?.entries) ? res.entries : []);
+    } catch {
+      setEntries([]);
+    }
+  }, [limit]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { entries, refresh };
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -22,6 +22,7 @@ const PATHS = {
   usageMonthly: "tokentracker-usage-monthly",
   usageHeatmap: "tokentracker-usage-heatmap",
   usageModelBreakdown: "tokentracker-usage-model-breakdown",
+  sessionBuckets: "tokentracker-session-buckets",
   projectUsageSummary: "tokentracker-project-usage-summary",
   userStatus: "tokentracker-user-status",
   localSync: "tokentracker-local-sync",
@@ -111,6 +112,10 @@ export async function getProjectUsageSummary({
   if (to) params.to = to;
   if (limit != null) params.limit = String(limit);
   return fetchLocalJson(PATHS.projectUsageSummary, params);
+}
+
+export async function getSessionBuckets({ limit = 20 }: AnyRecord = {}) {
+  return fetchLocalJson(PATHS.sessionBuckets, { limit });
 }
 
 async function fetchInsforgeFunction(slug: string, options: {
@@ -370,4 +375,3 @@ export async function getUsageHeatmap({
     ...tzParams,
   });
 }
-

--- a/dashboard/src/lib/session-outcomes.js
+++ b/dashboard/src/lib/session-outcomes.js
@@ -1,0 +1,35 @@
+const STORAGE_KEY = "tokentracker_session_outcomes_v1";
+
+export const SESSION_OUTCOME_OPTIONS = [
+  "productive",
+  "exploratory",
+  "blocked",
+  "wasted",
+];
+
+export function getSessionOutcomes() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+export function setSessionOutcome(id, outcome) {
+  const next = { ...getSessionOutcomes() };
+  if (!outcome) delete next[id];
+  else next[id] = outcome;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  return next;
+}
+
+export function buildOutcomeCounts(entries, outcomes) {
+  const counts = { all: Array.isArray(entries) ? entries.length : 0 };
+  for (const option of SESSION_OUTCOME_OPTIONS) counts[option] = 0;
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    const outcome = outcomes?.[entry.id];
+    if (outcome && counts[outcome] != null) counts[outcome] += 1;
+  }
+  return counts;
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -5,6 +5,7 @@ import { useTrendData } from "../hooks/use-trend-data.js";
 import { useUsageData } from "../hooks/use-usage-data.js";
 import { useUsageLimits } from "../hooks/use-usage-limits.js";
 import { useUsageModelBreakdown } from "../hooks/use-usage-model-breakdown.js";
+import { useSessionBuckets } from "../hooks/use-session-buckets.js";
 import {
   isAccessTokenReady,
   normalizeAccessToken,
@@ -445,6 +446,7 @@ export function DashboardPage({
     timeZone,
     tzOffsetMinutes,
   });
+  const { entries: sessionEntries } = useSessionBuckets();
 
   const shareDailyToTrend = period === "week" || period === "month";
   const useDailyTrend = period === "week" || period === "month";
@@ -1203,6 +1205,7 @@ export function DashboardPage({
       projectUsageEntries={projectUsageEntries}
       projectUsageLimit={projectUsageLimit}
       setProjectUsageLimit={setProjectUsageLimit}
+      sessionEntries={sessionEntries}
       topModels={topModels}
       signedIn={signedIn}
       publicMode={publicMode}

--- a/dashboard/src/ui/matrix-a/components/DataDetails.jsx
+++ b/dashboard/src/ui/matrix-a/components/DataDetails.jsx
@@ -1,11 +1,18 @@
 import React, { useState } from "react";
 import { Card } from "../../openai/components";
+import {
+  buildOutcomeCounts,
+  getSessionOutcomes,
+  SESSION_OUTCOME_OPTIONS,
+  setSessionOutcome,
+} from "../../../lib/session-outcomes.js";
 
 export function DataDetails({
   // Project props
   projectEntries = [],
   projectLimit = 3,
   onProjectLimitChange,
+  sessionEntries = [],
   // Daily breakdown props
   copy,
   hasDetailsActual,
@@ -33,6 +40,13 @@ export function DataDetails({
   setDetailsPage,
 }) {
   const [activeTab, setActiveTab] = useState("daily");
+  const [outcomes, setOutcomes] = useState(() => getSessionOutcomes());
+  const [sessionFilter, setSessionFilter] = useState("all");
+  const outcomeCounts = buildOutcomeCounts(sessionEntries, outcomes);
+  const visibleSessions = sessionEntries.filter((entry) => {
+    if (sessionFilter === "all") return true;
+    return outcomes[entry.id] === sessionFilter;
+  });
 
   return (
     <Card className="flex-1 flex flex-col min-h-0 overflow-hidden" bodyClassName="flex-1 flex flex-col min-h-0">
@@ -64,6 +78,19 @@ export function DataDetails({
             }`}
           >
             {copy("dashboard.projects.title")}
+          </button>
+          <button
+            role="tab"
+            aria-selected={activeTab === "sessions"}
+            type="button"
+            onClick={() => setActiveTab("sessions")}
+            className={`text-xs font-medium px-3 py-1.5 rounded transition-colors ${
+              activeTab === "sessions"
+                ? "text-oai-black dark:text-oai-white bg-oai-gray-100 dark:bg-oai-gray-800"
+                : "text-oai-gray-500 dark:text-oai-gray-300 hover:text-oai-black dark:hover:text-oai-white hover:bg-oai-gray-50 dark:hover:bg-oai-gray-800/50"
+            }`}
+          >
+            {copy("dashboard.sessions.title")}
           </button>
         </div>
         {activeTab === "projects" && (
@@ -211,6 +238,77 @@ export function DataDetails({
           ) : null}
         </div>
       )}
+
+      {activeTab === "sessions" && (
+        <div className="flex-1 flex flex-col min-h-0">
+          <div className="mb-3 flex flex-wrap gap-2">
+            <OutcomeChip
+              label={copy("dashboard.sessions.filter.all")}
+              count={outcomeCounts.all}
+              active={sessionFilter === "all"}
+              onClick={() => setSessionFilter("all")}
+            />
+            {SESSION_OUTCOME_OPTIONS.map((option) => (
+              <OutcomeChip
+                key={option}
+                label={copy(`dashboard.sessions.filter.${option}`)}
+                count={outcomeCounts[option]}
+                active={sessionFilter === option}
+                onClick={() => setSessionFilter(option)}
+              />
+            ))}
+          </div>
+          <div className="space-y-2 overflow-auto">
+            {visibleSessions.map((entry) => (
+              <div key={entry.id} className="rounded-lg border border-oai-gray-100 dark:border-oai-gray-800 px-3 py-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium text-oai-black dark:text-oai-white truncate">
+                      {entry.source} · {entry.model}
+                    </div>
+                    <div className="text-xs text-oai-gray-500 dark:text-oai-gray-400">
+                      {String(entry.hour_start).replace("T", " ").slice(0, 16)}
+                    </div>
+                  </div>
+                  <div className="text-sm font-medium text-oai-black dark:text-oai-white tabular-nums">
+                    {entry.billable_total_tokens}
+                  </div>
+                </div>
+                <div className="mt-3">
+                  <select
+                    value={outcomes[entry.id] || ""}
+                    onChange={(event) => setOutcomes(setSessionOutcome(entry.id, event.target.value))}
+                    className="text-xs text-oai-gray-600 dark:text-oai-gray-300 bg-white dark:bg-oai-gray-900 border border-oai-gray-200 dark:border-oai-gray-700 rounded px-2 py-1"
+                  >
+                    <option value="">{copy("dashboard.sessions.filter.unset")}</option>
+                    {SESSION_OUTCOME_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {copy(`dashboard.sessions.filter.${option}`)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
     </Card>
+  );
+}
+
+function OutcomeChip({ label, count, active, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-full px-3 py-1 text-xs transition-colors ${
+        active
+          ? "bg-oai-gray-900 text-white dark:bg-white dark:text-oai-gray-900"
+          : "bg-oai-gray-100 dark:bg-oai-gray-800 text-oai-gray-600 dark:text-oai-gray-300"
+      }`}
+    >
+      {label} {count}
+    </button>
   );
 }

--- a/dashboard/src/ui/matrix-a/views/DashboardView.jsx
+++ b/dashboard/src/ui/matrix-a/views/DashboardView.jsx
@@ -27,6 +27,7 @@ export function DashboardView(props) {
     projectUsageEntries,
     projectUsageLimit,
     setProjectUsageLimit,
+    sessionEntries,
     topModels,
     signedIn,
     publicMode,
@@ -250,6 +251,7 @@ export function DashboardView(props) {
                     projectEntries={projectUsageEntries}
                     projectLimit={projectUsageLimit}
                     onProjectLimitChange={setProjectUsageLimit}
+                    sessionEntries={sessionEntries}
                     copy={copy}
                     hasDetailsActual={hasDetailsActual}
                     dailyEmptyPrefix={dailyEmptyPrefix}

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -333,6 +333,23 @@ function aggregateHourlyByDay(rows, dayKey, timeZoneContext) {
   return Array.from(byHour.values()).sort((a, b) => a.hour.localeCompare(b.hour));
 }
 
+function listRecentSessionBuckets(rows, limit = 20) {
+  return rows
+    .filter((row) => row?.hour_start)
+    .slice()
+    .sort((a, b) => String(b.hour_start).localeCompare(String(a.hour_start)))
+    .slice(0, Math.max(1, limit))
+    .map((row) => ({
+      id: `${row.source || "unknown"}|${row.model || "unknown"}|${row.hour_start}`,
+      source: row.source || "unknown",
+      model: row.model || "unknown",
+      hour_start: row.hour_start,
+      total_tokens: String(row.total_tokens || 0),
+      billable_total_tokens: String(row.billable_total_tokens || row.total_tokens || 0),
+      conversation_count: Number(row.conversation_count || 0),
+    }));
+}
+
 // ---------------------------------------------------------------------------
 // Sync helper
 // ---------------------------------------------------------------------------
@@ -912,6 +929,16 @@ function createLocalApiHandler({ queuePath }) {
       json(res, {
         from, to, days: 0, sources,
         pricing: { model: "per-model", pricing_mode: "per_token_type", source: "litellm", effective_from: new Date().toISOString().slice(0, 10) },
+      });
+      return true;
+    }
+
+    if (p === "/functions/tokentracker-session-buckets") {
+      const limit = Number(url.searchParams.get("limit") || 20);
+      const rows = readQueueData(qp);
+      json(res, {
+        generated_at: new Date().toISOString(),
+        entries: listRecentSessionBuckets(rows, limit),
       });
       return true;
     }

--- a/test/session-outcomes.test.js
+++ b/test/session-outcomes.test.js
@@ -1,0 +1,73 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { createLocalApiHandler } = require("../src/lib/local-api");
+
+function createRequest({ method = "GET" } = {}) {
+  return {
+    method,
+    headers: {},
+    async *[Symbol.asyncIterator]() {},
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    headers: null,
+    body: Buffer.alloc(0),
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      this.headers = headers;
+    },
+    end(chunk) {
+      this.body = chunk ? Buffer.from(chunk) : Buffer.alloc(0);
+    },
+  };
+}
+
+test("session buckets endpoint returns recent queue buckets", async () => {
+  const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "tokentracker-sessions-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    await fsp.writeFile(
+      queuePath,
+      [
+        JSON.stringify({ source: "codex", model: "gpt-5.4", hour_start: "2026-04-10T02:00:00.000Z", total_tokens: 100 }),
+        JSON.stringify({ source: "gemini", model: "gemini-2.5-pro", hour_start: "2026-04-11T02:00:00.000Z", total_tokens: 200 }),
+      ].join("\n"),
+      "utf8",
+    );
+    const handler = createLocalApiHandler({ queuePath });
+    const req = createRequest();
+    const res = createResponse();
+    const handled = await handler(req, res, new URL("http://127.0.0.1/functions/tokentracker-session-buckets"));
+    assert.equal(handled, true);
+    const payload = JSON.parse(res.body.toString("utf8"));
+    assert.equal(payload.entries.length, 2);
+    assert.equal(payload.entries[0].source, "gemini");
+  } finally {
+    await fsp.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("session outcomes helper counts labeled outcomes", async () => {
+  globalThis.localStorage = {
+    store: new Map(),
+    getItem(key) { return this.store.get(key) || null; },
+    setItem(key, value) { this.store.set(key, String(value)); },
+    removeItem(key) { this.store.delete(key); },
+  };
+  const { buildOutcomeCounts } = await import("../dashboard/src/lib/session-outcomes.js");
+  const counts = buildOutcomeCounts(
+    [{ id: "a" }, { id: "b" }],
+    { a: "productive", b: "wasted" },
+  );
+  assert.equal(counts.all, 2);
+  assert.equal(counts.productive, 1);
+  assert.equal(counts.wasted, 1);
+});


### PR DESCRIPTION
## Why
Issue #24 asks for a way to distinguish productive usage from exploratory or wasted usage.

## What changed
- added a local session-buckets endpoint derived from recent queue entries
- added local outcome tagging storage and counts
- added a Sessions tab with outcome filters and per-session labeling

## Verification
- `node --test test/session-outcomes.test.js`
- `npm run validate:copy`

Closes #24