### PR TITLE
feat: add local budget alerts with projected overruns

### DIFF
--- a/dashboard/src/components/settings/BudgetAlertsSection.jsx
+++ b/dashboard/src/components/settings/BudgetAlertsSection.jsx
@@ -1,0 +1,81 @@
+import React, { useCallback, useId, useState } from "react";
+
+import { copy } from "../../lib/copy";
+import {
+  getBudgetAlertPrefs,
+  setBudgetAlertPrefs,
+} from "../../lib/budget-alerts.js";
+import { SectionCard, SettingsRow } from "./Controls.jsx";
+
+export function BudgetAlertsSection() {
+  const [prefs, setPrefs] = useState(() => getBudgetAlertPrefs());
+
+  const updateField = useCallback(
+    (key, value) => {
+      const next = setBudgetAlertPrefs({ ...prefs, [key]: value });
+      setPrefs(next);
+    },
+    [prefs],
+  );
+
+  return (
+    <SectionCard
+      title={copy("settings.section.budgets")}
+      subtitle={copy("settings.section.budgetsSubtitle")}
+    >
+      <BudgetSettingsRow
+        label={copy("settings.budget.daily")}
+        hint={copy("settings.budget.dailyHint")}
+        value={prefs.daily}
+        onChange={(value) => updateField("daily", value)}
+      />
+      <BudgetSettingsRow
+        label={copy("settings.budget.weekly")}
+        hint={copy("settings.budget.weeklyHint")}
+        value={prefs.weekly}
+        onChange={(value) => updateField("weekly", value)}
+      />
+      <BudgetSettingsRow
+        label={copy("settings.budget.monthly")}
+        hint={copy("settings.budget.monthlyHint")}
+        value={prefs.monthly}
+        onChange={(value) => updateField("monthly", value)}
+      />
+    </SectionCard>
+  );
+}
+
+function BudgetSettingsRow({ label, hint, value, onChange }) {
+  const labelId = useId();
+  const hintId = useId();
+  return (
+    <SettingsRow
+      label={<span id={labelId}>{label}</span>}
+      hint={hint ? <span id={hintId}>{hint}</span> : null}
+      control={
+        <BudgetInput
+          value={value}
+          onChange={onChange}
+          ariaLabelledBy={labelId}
+          ariaDescribedBy={hint ? hintId : undefined}
+        />
+      }
+    />
+  );
+}
+
+function BudgetInput({ value, onChange, ariaLabelledBy, ariaDescribedBy }) {
+  return (
+    <input
+      type="number"
+      min="0"
+      step="1"
+      value={value ?? ""}
+      onChange={(event) => onChange(event.target.value)}
+      placeholder="0"
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      className="w-24 rounded-md border border-oai-gray-300 dark:border-oai-gray-700 bg-transparent px-2.5 py-1.5 text-right text-sm text-oai-black dark:text-white outline-none focus:border-oai-brand-500 focus:ring-1 focus:ring-inset focus:ring-oai-brand-500"
+    />
+  );
+}

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -218,6 +218,11 @@ dashboard.projects.limit_top_3,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_
 dashboard.projects.limit_top_6,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_6,"TOP 6",,active
 dashboard.projects.limit_top_10,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_10,"TOP 10",,active
 dashboard.projects.empty,ui,ProjectUsagePanel,ProjectUsagePanel,empty,"No public repositories",,active
+dashboard.budget.title,ui,BudgetAlertCard,BudgetAlertCard,title,"Budget Alert",,active
+dashboard.budget.alert.over,ui,BudgetAlertCard,BudgetAlertCard,message_over,"Current spend is {{total}} against a budget of {{budget}} ({{percent}}% over).",,active
+dashboard.budget.alert.forecast,ui,BudgetAlertCard,BudgetAlertCard,message_forecast,"You are on pace for {{projected}} against a budget of {{budget}} ({{percent}}% over).",,active
+dashboard.budget.top_project,ui,BudgetAlertCard,BudgetAlertCard,top_project,"Top project: {{project}}",,active
+dashboard.budget.cta,ui,BudgetAlertCard,BudgetAlertCard,cta,"Open project usage",,active
 dashboard.upgrade_alert.title,ui,UpgradeAlertModal,UpgradeAlertModal,title,"Update available",,active
 dashboard.upgrade_alert.subtitle,ui,UpgradeAlertModal,UpgradeAlertModal,subtitle,"TokenTracker v{{required}} is now available.",,active
 dashboard.upgrade_alert.subtitle_generic,ui,UpgradeAlertModal,UpgradeAlertModal,subtitle_generic,"A new version of TokenTracker is available.",,active
@@ -508,6 +513,8 @@ settings.page.title,ui,SettingsPage,SettingsPage,title,"Settings",,active
 settings.page.subtitle,ui,SettingsPage,SettingsPage,subtitle,"Manage your account, appearance, and display preferences.",,active
 settings.section.appearance,ui,SettingsPage,SettingsPage,sec_appearance,"Appearance",,active
 settings.section.account,ui,SettingsPage,SettingsPage,sec_account,"Account",,active
+settings.section.budgets,ui,SettingsPage,SettingsPage,sec_budgets,"Budget Alerts",,active
+settings.section.budgetsSubtitle,ui,SettingsPage,SettingsPage,sec_budgets_sub,"Set local daily, weekly, and monthly spend thresholds for dashboard alerts.",,active
 settings.section.limits,ui,SettingsPage,SettingsPage,sec_limits,"Limits Display",,active
 settings.section.limitsSubtitle,ui,SettingsPage,SettingsPage,sec_limits_sub,"Reorder providers and choose which ones appear on the Limits page.",,active
 settings.appearance.theme.label,ui,SettingsPage,SettingsPage,theme_label,"Theme",,active
@@ -557,6 +564,12 @@ leaderboard.github.tooltipSuffix,ui,LeaderboardPage,LeaderboardPage,github_toolt
 settings.account.signOut,ui,SettingsPage,SettingsPage,sign_out,"Sign out",,active
 settings.account.signIn,ui,SettingsPage,SettingsPage,sign_in,"Sign in",,active
 settings.account.signedOutHint,ui,SettingsPage,SettingsPage,signed_out_hint,"Sign in to manage cloud sync and leaderboard preferences.",,active
+settings.budget.daily,ui,SettingsPage,SettingsPage,budget_daily,"Daily budget (USD)",,active
+settings.budget.dailyHint,ui,SettingsPage,SettingsPage,budget_daily_hint,"Alert when a day exceeds or is on pace to exceed this amount.",,active
+settings.budget.weekly,ui,SettingsPage,SettingsPage,budget_weekly,"Weekly budget (USD)",,active
+settings.budget.weeklyHint,ui,SettingsPage,SettingsPage,budget_weekly_hint,"Compare the current week against a local weekly budget.",,active
+settings.budget.monthly,ui,SettingsPage,SettingsPage,budget_monthly,"Monthly budget (USD)",,active
+settings.budget.monthlyHint,ui,SettingsPage,SettingsPage,budget_monthly_hint,"Forecast month-end spend from the current pace.",,active
 settings.section.menubar,ui,SettingsPage,SettingsPage,sec_menubar,"Menu Bar App",,active
 settings.section.menubarSubtitle,ui,SettingsPage,SettingsPage,sec_menubar_sub,"Preferences for the macOS menu bar app, mirroring the right-click menu.",,active
 settings.menubar.showStats,ui,SettingsPage,SettingsPage,mb_show_stats,"Show stats in menu bar",,active

--- a/dashboard/src/lib/budget-alerts.js
+++ b/dashboard/src/lib/budget-alerts.js
@@ -1,0 +1,92 @@
+const STORAGE_KEY = "tokentracker_budget_alerts_v1";
+
+function toPositiveNumber(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function toDate(value) {
+  if (typeof value !== "string" || !value) return null;
+  const date = new Date(`${value}T00:00:00`);
+  return Number.isFinite(date.getTime()) ? date : null;
+}
+
+export function getBudgetAlertPrefs() {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { daily: null, weekly: null, monthly: null };
+    const parsed = JSON.parse(raw);
+    return {
+      daily: toPositiveNumber(parsed?.daily),
+      weekly: toPositiveNumber(parsed?.weekly),
+      monthly: toPositiveNumber(parsed?.monthly),
+    };
+  } catch {
+    return { daily: null, weekly: null, monthly: null };
+  }
+}
+
+export function setBudgetAlertPrefs(prefs) {
+  const normalized = {
+    daily: toPositiveNumber(prefs?.daily),
+    weekly: toPositiveNumber(prefs?.weekly),
+    monthly: toPositiveNumber(prefs?.monthly),
+  };
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized));
+  return normalized;
+}
+
+function resolveBudget(period, budgets) {
+  if (period === "day") return toPositiveNumber(budgets?.daily);
+  if (period === "week") return toPositiveNumber(budgets?.weekly);
+  if (period === "month") return toPositiveNumber(budgets?.monthly);
+  return null;
+}
+
+function elapsedFraction(from, to, now = new Date()) {
+  const start = toDate(from);
+  const end = toDate(to);
+  if (!start || !end || end < start) return 1;
+  const totalDays = Math.max(1, Math.round((end - start) / 86400000) + 1);
+  const nowDate = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const elapsedDays = Math.min(
+    totalDays,
+    Math.max(1, Math.round((nowDate - start) / 86400000) + 1),
+  );
+  return elapsedDays / totalDays;
+}
+
+export function buildBudgetAlert({
+  period,
+  from,
+  to,
+  totalCostUsd,
+  budgets,
+  topProject,
+  now = new Date(),
+}) {
+  const budget = resolveBudget(period, budgets);
+  const total = Number(totalCostUsd);
+  if (!budget || !Number.isFinite(total) || total <= 0) return null;
+
+  const fraction = period === "week" || period === "month"
+    ? elapsedFraction(from, to, now)
+    : 1;
+  const projected = fraction > 0 ? total / fraction : total;
+
+  if (total < budget && projected <= budget) return null;
+
+  const overrunPct = Math.max(
+    total >= budget ? ((total - budget) / budget) * 100 : ((projected - budget) / budget) * 100,
+    0,
+  );
+
+  return {
+    budget,
+    total,
+    projected,
+    topProject: topProject?.project_key || topProject?.project_ref || null,
+    overrunPct: Math.round(overrunPct),
+    status: total >= budget ? "over" : "forecast",
+  };
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -21,6 +21,7 @@ import {
   toDisplayNumber,
   toFiniteNumber,
 } from "../lib/format";
+import { buildBudgetAlert, getBudgetAlertPrefs } from "../lib/budget-alerts.js";
 import { shouldShowInstallCard } from "../lib/install-status";
 import { getMockNow, isMockEnabled } from "../lib/mock-data";
 import { buildFleetData, buildTopModels } from "../lib/model-breakdown";
@@ -144,6 +145,7 @@ export function DashboardPage({
   const [installCopied, setInstallCopied] = useState(false);
   const [sessionExpiredCopied, setSessionExpiredCopied] = useState(false);
   const [manualSyncLoading, setManualSyncLoading] = useState(false);
+  const [detailsActiveTab, setDetailsActiveTab] = useState("daily");
   const mockEnabled = isMockEnabled();
   const authTokenAllowed = signedIn && !sessionSoftExpired;
   const authAccessToken = useMemo(() => {
@@ -598,6 +600,21 @@ export function DashboardPage({
     }
     return trendRows;
   }, [daily, period, trendRows, useDailyTrend]);
+  const topProjectEntry = useMemo(() => {
+    return Array.isArray(projectUsageEntries) && projectUsageEntries.length > 0
+      ? projectUsageEntries[0]
+      : null;
+  }, [projectUsageEntries]);
+  const budgetAlert = useMemo(() => {
+    return buildBudgetAlert({
+      period,
+      from,
+      to,
+      totalCostUsd: summary?.total_cost_usd,
+      budgets: typeof window === "undefined" ? {} : getBudgetAlertPrefs(),
+      topProject: topProjectEntry,
+    });
+  }, [from, period, summary?.total_cost_usd, to, topProjectEntry]);
   const trendFromForDisplay = useDailyTrend ? from : trendFrom;
   const trendToForDisplay = useDailyTrend ? to : trendTo;
 
@@ -609,6 +626,13 @@ export function DashboardPage({
     }
     return toDisplayNumber(row?.[key]);
   }
+
+  const handleViewBudgetProject = useCallback(() => {
+    setDetailsActiveTab("projects");
+    if (typeof document !== "undefined") {
+      document.getElementById("details-section")?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, []);
 
   function renderDetailDate(row) {
     const raw = row?.[detailsDateKey];
@@ -1246,6 +1270,10 @@ export function DashboardPage({
       summaryCostValue={summaryCostValue}
       summaryConversationsValue={summaryConversationsValue}
       rollingUsage={rolling}
+      budgetAlert={budgetAlert}
+      onViewBudgetProject={handleViewBudgetProject}
+      detailsActiveTab={detailsActiveTab}
+      setDetailsActiveTab={setDetailsActiveTab}
       costInfoEnabled={costInfoEnabled}
       openCostModal={openCostModal}
       allowBreakdownToggle={allowBreakdownToggle}

--- a/dashboard/src/pages/SettingsPage.jsx
+++ b/dashboard/src/pages/SettingsPage.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { LimitsSettingsPanel } from "../components/LimitsSettingsPanel.jsx";
 import { AccountSection } from "../components/settings/AccountSection.jsx";
 import { AppearanceSection } from "../components/settings/AppearanceSection.jsx";
+import { BudgetAlertsSection } from "../components/settings/BudgetAlertsSection.jsx";
 import { SectionCard } from "../components/settings/Controls.jsx";
 import { MenuBarSection, NativeAppFooter } from "../components/settings/MenuBarSection.jsx";
 import { useLimitsDisplayPrefs } from "../hooks/use-limits-display-prefs.js";
@@ -27,6 +28,7 @@ export function SettingsPage() {
             <AppearanceSection />
             <MenuBarSection />
             <AccountSection />
+            <BudgetAlertsSection />
             <SectionCard title={copy("settings.section.limits")}>
               <LimitsSettingsPanel prefs={limitsPrefs} />
             </SectionCard>

--- a/dashboard/src/ui/matrix-a/components/BudgetAlertCard.jsx
+++ b/dashboard/src/ui/matrix-a/components/BudgetAlertCard.jsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { copy } from "../../../lib/copy";
+import { formatUsdCurrency } from "../../../lib/format";
+
+export function BudgetAlertCard({ alert, onViewProject, className = "" }) {
+  if (!alert) return null;
+
+  const message = alert.status === "over"
+    ? copy("dashboard.budget.alert.over", {
+        total: formatUsdCurrency(alert.total) || "$0",
+        budget: formatUsdCurrency(alert.budget) || "$0",
+        percent: alert.overrunPct,
+      })
+    : copy("dashboard.budget.alert.forecast", {
+        projected: formatUsdCurrency(alert.projected) || "$0",
+        budget: formatUsdCurrency(alert.budget) || "$0",
+        percent: alert.overrunPct,
+      });
+
+  return (
+    <div className={`rounded-xl border border-amber-300/70 dark:border-amber-500/30 bg-amber-50 dark:bg-amber-950/30 p-4 ${className}`}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="text-xs uppercase tracking-wide text-amber-700 dark:text-amber-300">
+            {copy("dashboard.budget.title")}
+          </div>
+          <div className="mt-1 text-sm text-amber-900 dark:text-amber-100 leading-6">
+            {message}
+          </div>
+          {alert.topProject ? (
+            <div className="mt-2 text-xs text-amber-800/80 dark:text-amber-200/80">
+              {copy("dashboard.budget.top_project", { project: alert.topProject })}
+            </div>
+          ) : null}
+        </div>
+        {onViewProject ? (
+          <button
+            type="button"
+            onClick={onViewProject}
+            className="shrink-0 rounded-md border border-amber-400/60 dark:border-amber-500/40 px-3 py-1.5 text-xs font-medium text-amber-900 dark:text-amber-100 hover:bg-amber-100 dark:hover:bg-amber-900/40 transition-colors"
+          >
+            {copy("dashboard.budget.cta")}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/ui/matrix-a/components/DataDetails.jsx
+++ b/dashboard/src/ui/matrix-a/components/DataDetails.jsx
@@ -31,8 +31,12 @@ export function DataDetails({
   detailsPageCount,
   detailsPage,
   setDetailsPage,
+  activeTab,
+  onActiveTabChange,
 }) {
-  const [activeTab, setActiveTab] = useState("daily");
+  const [internalActiveTab, setInternalActiveTab] = useState("daily");
+  const resolvedActiveTab = activeTab || internalActiveTab;
+  const setResolvedActiveTab = onActiveTabChange || setInternalActiveTab;
 
   return (
     <Card className="flex-1 flex flex-col min-h-0 overflow-hidden" bodyClassName="flex-1 flex flex-col min-h-0">
@@ -41,11 +45,11 @@ export function DataDetails({
         <div role="tablist" aria-label="Data view" className="flex gap-1">
           <button
             role="tab"
-            aria-selected={activeTab === "daily"}
+            aria-selected={resolvedActiveTab === "daily"}
             type="button"
-            onClick={() => setActiveTab("daily")}
+            onClick={() => setResolvedActiveTab("daily")}
             className={`text-xs font-medium px-3 py-1.5 rounded transition-colors ${
-              activeTab === "daily"
+              resolvedActiveTab === "daily"
                 ? "text-oai-black dark:text-oai-white bg-oai-gray-100 dark:bg-oai-gray-800"
                 : "text-oai-gray-500 dark:text-oai-gray-300 hover:text-oai-black dark:hover:text-oai-white hover:bg-oai-gray-50 dark:hover:bg-oai-gray-800/50"
             }`}
@@ -54,11 +58,11 @@ export function DataDetails({
           </button>
           <button
             role="tab"
-            aria-selected={activeTab === "projects"}
+            aria-selected={resolvedActiveTab === "projects"}
             type="button"
-            onClick={() => setActiveTab("projects")}
+            onClick={() => setResolvedActiveTab("projects")}
             className={`text-xs font-medium px-3 py-1.5 rounded transition-colors ${
-              activeTab === "projects"
+              resolvedActiveTab === "projects"
                 ? "text-oai-black dark:text-oai-white bg-oai-gray-100 dark:bg-oai-gray-800"
                 : "text-oai-gray-500 dark:text-oai-gray-300 hover:text-oai-black dark:hover:text-oai-white hover:bg-oai-gray-50 dark:hover:bg-oai-gray-800/50"
             }`}
@@ -66,7 +70,7 @@ export function DataDetails({
             {copy("dashboard.projects.title")}
           </button>
         </div>
-        {activeTab === "projects" && (
+        {resolvedActiveTab === "projects" && (
           <select
             aria-label="Number of projects to display"
             value={projectLimit}
@@ -110,7 +114,7 @@ export function DataDetails({
       )}
 
       {/* Daily Tab */}
-      {activeTab === "daily" && (
+      {resolvedActiveTab === "daily" && (
         <div className="flex-1 flex flex-col min-h-0">
           {dailyBreakdownRows?.length === 0 ? (
             <div className="oai-text-body-sm text-oai-gray-500 dark:text-oai-gray-300 mb-4">
@@ -186,7 +190,7 @@ export function DataDetails({
           )}
 
           {/* Pagination - 使用 design system typography，Daily Breakdown 不需要分页 */}
-          {activeTab !== "daily" && DETAILS_PAGED_PERIODS.has(period) && detailsPageCount > 1 ? (
+          {resolvedActiveTab !== "daily" && DETAILS_PAGED_PERIODS.has(period) && detailsPageCount > 1 ? (
             <div className="mt-3 flex items-center justify-between oai-text-caption">
               <button
                 type="button"

--- a/dashboard/src/ui/matrix-a/views/DashboardView.jsx
+++ b/dashboard/src/ui/matrix-a/views/DashboardView.jsx
@@ -6,6 +6,7 @@ import { DataDetails } from "../components/DataDetails.jsx";
 import { StatsPanel } from "../components/StatsPanel.jsx";
 import { UsageOverview } from "../components/UsageOverview.jsx";
 import { TrendMonitor } from "../components/TrendMonitor.jsx";
+import { BudgetAlertCard } from "../components/BudgetAlertCard.jsx";
 import { FadeIn } from "../../foundation/FadeIn.jsx";
 import { MacAppBanner } from "../components/MacAppBanner.jsx";
 import { WidgetOnboardingCard } from "../components/WidgetOnboardingCard.jsx";
@@ -59,6 +60,10 @@ export function DashboardView(props) {
     summaryCostValue,
     summaryConversationsValue,
     rollingUsage,
+    budgetAlert,
+    onViewBudgetProject,
+    detailsActiveTab,
+    setDetailsActiveTab,
     costInfoEnabled,
     openCostModal,
     costModalOpen,
@@ -245,37 +250,48 @@ export function DashboardView(props) {
                 />
 
                 {!screenshotMode ? (
-                  <FadeIn delay={0.5} className="flex-1 flex flex-col min-h-0">
-                    <DataDetails
-                    projectEntries={projectUsageEntries}
-                    projectLimit={projectUsageLimit}
-                    onProjectLimitChange={setProjectUsageLimit}
-                    copy={copy}
-                    hasDetailsActual={hasDetailsActual}
-                    dailyEmptyPrefix={dailyEmptyPrefix}
-                    installSyncCmd={installSyncCmd}
-                    dailyEmptySuffix={dailyEmptySuffix}
-                    detailsColumns={detailsColumns}
-                    ariaSortFor={ariaSortFor}
-                    toggleSort={toggleSort}
-                    sortIconFor={sortIconFor}
-                    pagedDetails={pagedDetails}
-                    dailyBreakdownRows={dailyBreakdownRows}
-                    dailyBreakdownColumns={dailyBreakdownColumns}
-                    dailyBreakdownAriaSortFor={dailyBreakdownAriaSortFor}
-                    dailyBreakdownSortIconFor={dailyBreakdownSortIconFor}
-                    dailyBreakdownDateKey={dailyBreakdownDateKey}
-                    detailsDateKey={detailsDateKey}
-                    renderDetailDate={renderDetailDate}
-                    renderDailyBreakdownDate={renderDailyBreakdownDate}
-                    renderDetailCell={renderDetailCell}
-                    DETAILS_PAGED_PERIODS={DETAILS_PAGED_PERIODS}
-                    period={period}
-                    detailsPageCount={detailsPageCount}
-                    detailsPage={detailsPage}
-                    setDetailsPage={setDetailsPage}
+                  <BudgetAlertCard
+                    alert={budgetAlert}
+                    onViewProject={onViewBudgetProject}
                   />
-                  </FadeIn>
+                ) : null}
+
+                {!screenshotMode ? (
+                  <div id="details-section" className="flex-1 flex flex-col min-h-0">
+                    <FadeIn delay={0.5} className="flex-1 flex flex-col min-h-0">
+                      <DataDetails
+                        projectEntries={projectUsageEntries}
+                        projectLimit={projectUsageLimit}
+                        onProjectLimitChange={setProjectUsageLimit}
+                        copy={copy}
+                        hasDetailsActual={hasDetailsActual}
+                        dailyEmptyPrefix={dailyEmptyPrefix}
+                        installSyncCmd={installSyncCmd}
+                        dailyEmptySuffix={dailyEmptySuffix}
+                        detailsColumns={detailsColumns}
+                        ariaSortFor={ariaSortFor}
+                        toggleSort={toggleSort}
+                        sortIconFor={sortIconFor}
+                        pagedDetails={pagedDetails}
+                        dailyBreakdownRows={dailyBreakdownRows}
+                        dailyBreakdownColumns={dailyBreakdownColumns}
+                        dailyBreakdownAriaSortFor={dailyBreakdownAriaSortFor}
+                        dailyBreakdownSortIconFor={dailyBreakdownSortIconFor}
+                        dailyBreakdownDateKey={dailyBreakdownDateKey}
+                        detailsDateKey={detailsDateKey}
+                        renderDetailDate={renderDetailDate}
+                        renderDailyBreakdownDate={renderDailyBreakdownDate}
+                        renderDetailCell={renderDetailCell}
+                        DETAILS_PAGED_PERIODS={DETAILS_PAGED_PERIODS}
+                        period={period}
+                        detailsPageCount={detailsPageCount}
+                        detailsPage={detailsPage}
+                        setDetailsPage={setDetailsPage}
+                        activeTab={detailsActiveTab}
+                        onActiveTabChange={setDetailsActiveTab}
+                      />
+                    </FadeIn>
+                  </div>
                 ) : null}
               </div>
             </div>

--- a/test/budget-alerts.test.js
+++ b/test/budget-alerts.test.js
@@ -1,0 +1,51 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+test("budget alert helper detects forecasted monthly overruns", async () => {
+  const { buildBudgetAlert } = await import("../dashboard/src/lib/budget-alerts.js");
+
+  const alert = buildBudgetAlert({
+    period: "month",
+    from: "2026-04-01",
+    to: "2026-04-30",
+    totalCostUsd: "60",
+    budgets: { monthly: 100 },
+    topProject: { project_key: "octo/api" },
+    now: new Date("2026-04-10T12:00:00Z"),
+  });
+
+  assert.equal(alert.status, "forecast");
+  assert.equal(alert.topProject, "octo/api");
+  assert.ok(alert.projected > alert.budget);
+});
+
+test("budget alert helper returns null when budget is not exceeded", async () => {
+  const { buildBudgetAlert } = await import("../dashboard/src/lib/budget-alerts.js");
+  const alert = buildBudgetAlert({
+    period: "week",
+    from: "2026-04-14",
+    to: "2026-04-20",
+    totalCostUsd: "20",
+    budgets: { weekly: 100 },
+    now: new Date("2026-04-20T12:00:00Z"),
+  });
+  assert.equal(alert, null);
+});
+
+test("dashboard wires budget alerts and controllable project tab", () => {
+  const dashboardSrc = fs.readFileSync(
+    path.join(process.cwd(), "dashboard/src/pages/DashboardPage.jsx"),
+    "utf8",
+  );
+  const detailsSrc = fs.readFileSync(
+    path.join(process.cwd(), "dashboard/src/ui/matrix-a/components/DataDetails.jsx"),
+    "utf8",
+  );
+
+  assert.match(dashboardSrc, /buildBudgetAlert/);
+  assert.match(dashboardSrc, /detailsActiveTab/);
+  assert.match(detailsSrc, /activeTab/);
+  assert.match(detailsSrc, /onActiveTabChange/);
+});


### PR DESCRIPTION
## Why
Issue #21 asks for actionable budget alerts that warn before spend gets out of hand.

## What changed
- added local daily, weekly, and monthly budget preferences in Settings
- added a dashboard alert when current spend is over budget or on pace to exceed it
- added a jump from the alert into the project usage view

## Verification
- `node --test test/budget-alerts.test.js`
- `npm run validate:copy`

Closes #21