### PR TITLE
feat: add project drilldowns with period-over-period comparisons

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -218,6 +218,14 @@ dashboard.projects.limit_top_3,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_
 dashboard.projects.limit_top_6,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_6,"TOP 6",,active
 dashboard.projects.limit_top_10,ui,ProjectUsagePanel,ProjectUsagePanel,limit_top_10,"TOP 10",,active
 dashboard.projects.empty,ui,ProjectUsagePanel,ProjectUsagePanel,empty,"No public repositories",,active
+dashboard.projects.drilldown.title,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,title,"Project Detail",,active
+dashboard.projects.drilldown.current,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,current,"Current period",,active
+dashboard.projects.drilldown.previous,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,previous,"Previous period",,active
+dashboard.projects.drilldown.breakdown,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,breakdown,"Source breakdown",,active
+dashboard.projects.drilldown.breakdown_empty,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,breakdown_empty,"No source activity in this period.",,active
+dashboard.projects.drilldown.loading,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,loading,"Loading…",,active
+dashboard.projects.drilldown.error,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,error,"Could not load project details.",,active
+dashboard.projects.drilldown.close,ui,ProjectUsageDrilldownModal,ProjectUsageDrilldownModal,close,"Close",,active
 dashboard.upgrade_alert.title,ui,UpgradeAlertModal,UpgradeAlertModal,title,"Update available",,active
 dashboard.upgrade_alert.subtitle,ui,UpgradeAlertModal,UpgradeAlertModal,subtitle,"TokenTracker v{{required}} is now available.",,active
 dashboard.upgrade_alert.subtitle_generic,ui,UpgradeAlertModal,UpgradeAlertModal,subtitle_generic,"A new version of TokenTracker is available.",,active

--- a/dashboard/src/hooks/use-project-usage-detail.js
+++ b/dashboard/src/hooks/use-project-usage-detail.js
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getProjectUsageDetail } from "../lib/api";
+
+export function useProjectUsageDetail({
+  projectKey,
+  from,
+  to,
+  compareFrom,
+  compareTo,
+  timeZone,
+  tzOffsetMinutes,
+  open,
+}) {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const requestIdRef = useRef(0);
+
+  const refresh = useCallback(async () => {
+    if (!open || !projectKey) {
+      requestIdRef.current += 1;
+      setData(null);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+    const requestId = ++requestIdRef.current;
+    setData(null);
+    setError(null);
+    setLoading(true);
+    try {
+      const res = await getProjectUsageDetail({
+        projectKey,
+        from,
+        to,
+        compareFrom,
+        compareTo,
+        timeZone,
+        tzOffsetMinutes,
+      });
+      if (requestId !== requestIdRef.current) return;
+      setData(res);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      setData(null);
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      if (requestId === requestIdRef.current) setLoading(false);
+    }
+  }, [compareFrom, compareTo, from, open, projectKey, timeZone, to, tzOffsetMinutes]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { data, loading, error };
+}

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -24,6 +24,7 @@ const PATHS = {
   usageHeatmap: "tokentracker-usage-heatmap",
   usageModelBreakdown: "tokentracker-usage-model-breakdown",
   projectUsageSummary: "tokentracker-project-usage-summary",
+  projectUsageDetail: "tokentracker-project-usage-detail",
   userStatus: "tokentracker-user-status",
   localSync: "tokentracker-local-sync",
   usageLimits: "tokentracker-usage-limits",
@@ -112,6 +113,26 @@ export async function getProjectUsageSummary({
   if (to) params.to = to;
   if (limit != null) params.limit = String(limit);
   return fetchLocalJson(PATHS.projectUsageSummary, params);
+}
+
+export async function getProjectUsageDetail({
+  projectKey,
+  from,
+  to,
+  compareFrom,
+  compareTo,
+  timeZone,
+  tzOffsetMinutes,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  return fetchLocalJson(PATHS.projectUsageDetail, {
+    project_key: projectKey,
+    from,
+    to,
+    compare_from: compareFrom,
+    compare_to: compareTo,
+    ...tzParams,
+  });
 }
 
 async function fetchInsforgeFunction(slug: string, options: {

--- a/dashboard/src/lib/project-drilldown.js
+++ b/dashboard/src/lib/project-drilldown.js
@@ -1,0 +1,13 @@
+export function getPreviousRange({ from, to }) {
+  const start = new Date(`${from}T00:00:00Z`);
+  const end = new Date(`${to}T00:00:00Z`);
+  const dayCount = Math.max(1, Math.round((end - start) / 86400000) + 1);
+  const previousEnd = new Date(start);
+  previousEnd.setUTCDate(previousEnd.getUTCDate() - 1);
+  const previousStart = new Date(previousEnd);
+  previousStart.setUTCDate(previousStart.getUTCDate() - dayCount + 1);
+  return {
+    from: previousStart.toISOString().slice(0, 10),
+    to: previousEnd.toISOString().slice(0, 10),
+  };
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useActivityHeatmap } from "../hooks/use-activity-heatmap.js";
 import { useProjectUsageSummary } from "../hooks/use-project-usage-summary";
+import { useProjectUsageDetail } from "../hooks/use-project-usage-detail.js";
 import { useTrendData } from "../hooks/use-trend-data.js";
 import { useUsageData } from "../hooks/use-usage-data.js";
 import { useUsageLimits } from "../hooks/use-usage-limits.js";
@@ -44,6 +45,7 @@ import { ProjectUsagePanel } from "../ui/matrix-a/components/ProjectUsagePanel.j
 import { DashboardView } from "../ui/matrix-a/views/DashboardView.jsx";
 import { ShareModal } from "../ui/share/ShareModal";
 import { useShareCardData } from "../ui/share/use-share-card-data";
+import { getPreviousRange } from "../lib/project-drilldown.js";
 
 const PERIODS = ["day", "week", "month", "total", "custom"];
 const DETAILS_DATE_KEYS = new Set(["day", "hour", "month"]);
@@ -434,6 +436,7 @@ export function DashboardPage({
   });
 
   const [projectUsageLimit, setProjectUsageLimit] = useState(3);
+  const [selectedProjectEntry, setSelectedProjectEntry] = useState(null);
   const {
     entries: projectUsageEntries,
     loading: projectUsageLoading,
@@ -446,6 +449,21 @@ export function DashboardPage({
     to,
     timeZone,
     tzOffsetMinutes,
+  });
+  const previousRange = useMemo(() => getPreviousRange({ from, to }), [from, to]);
+  const {
+    data: projectDrilldown,
+    loading: projectDrilldownLoading,
+    error: projectDrilldownError,
+  } = useProjectUsageDetail({
+    projectKey: selectedProjectEntry?.project_key,
+    from,
+    to,
+    compareFrom: previousRange.from,
+    compareTo: previousRange.to,
+    timeZone,
+    tzOffsetMinutes,
+    open: Boolean(selectedProjectEntry),
   });
 
   const shareDailyToTrend = period === "week" || period === "month";
@@ -1208,6 +1226,12 @@ export function DashboardPage({
       projectUsageEntries={projectUsageEntries}
       projectUsageLimit={projectUsageLimit}
       setProjectUsageLimit={setProjectUsageLimit}
+      onSelectProjectEntry={setSelectedProjectEntry}
+      projectDrilldown={projectDrilldown}
+      projectDrilldownLoading={projectDrilldownLoading}
+      projectDrilldownError={projectDrilldownError}
+      projectDrilldownOpen={Boolean(selectedProjectEntry)}
+      closeProjectDrilldown={() => setSelectedProjectEntry(null)}
       topModels={topModels}
       signedIn={signedIn}
       publicMode={publicMode}

--- a/dashboard/src/ui/matrix-a/components/DataDetails.jsx
+++ b/dashboard/src/ui/matrix-a/components/DataDetails.jsx
@@ -6,6 +6,7 @@ export function DataDetails({
   projectEntries = [],
   projectLimit = 3,
   onProjectLimitChange,
+  onSelectProjectEntry,
   // Daily breakdown props
   copy,
   hasDetailsActual,
@@ -84,11 +85,10 @@ export function DataDetails({
       {activeTab === "projects" && (
         <div className="space-y-1">
           {projectEntries.slice(0, projectLimit).map((entry) => (
-            <a
+            <button
+              type="button"
               key={entry?.project_key || entry?.project_ref}
-              href={entry?.project_ref || "#"}
-              target="_blank"
-              rel="noopener noreferrer"
+              onClick={() => onSelectProjectEntry?.(entry)}
               className="flex items-center gap-3 p-2 rounded-lg hover:oai-bg-elevated transition-colors"
             >
               <div className="w-8 h-8 rounded-md oai-bg-elevated flex items-center justify-center oai-text-caption font-medium text-oai-gray-500 dark:text-oai-gray-300">
@@ -104,7 +104,7 @@ export function DataDetails({
                   entry?.total_tokens?.toLocaleString?.() ||
                   "—"}
               </div>
-            </a>
+            </button>
           ))}
         </div>
       )}

--- a/dashboard/src/ui/matrix-a/components/ProjectUsageDrilldownModal.jsx
+++ b/dashboard/src/ui/matrix-a/components/ProjectUsageDrilldownModal.jsx
@@ -1,0 +1,106 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { X } from "lucide-react";
+import React from "react";
+import { copy } from "../../../lib/copy";
+import { formatCompactNumber } from "../../../lib/format";
+
+function formatTokens(value) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return copy("shared.placeholder.short");
+  return formatCompactNumber(n, { decimals: 1 });
+}
+
+export function ProjectUsageDrilldownModal({ open, onClose, data, loading, error }) {
+  const sources = data?.current?.sources || [];
+  return (
+    <Dialog.Root open={open} onOpenChange={(next) => { if (!next) onClose?.(); }}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 z-[100] bg-black/40" />
+        <Dialog.Viewport className="fixed inset-0 z-[101] flex items-center justify-center p-4">
+          <Dialog.Popup className="relative w-full max-w-2xl rounded-2xl border border-oai-gray-200 dark:border-oai-gray-800 bg-white dark:bg-oai-gray-950 p-6 shadow-xl">
+            <Dialog.Title render={<h2 className="text-lg font-semibold text-oai-black dark:text-white pr-10" />}>
+              {data?.project_key || copy("dashboard.projects.drilldown.title")}
+            </Dialog.Title>
+
+            <Dialog.Close
+              type="button"
+              className="absolute top-3 right-3 flex h-9 w-9 items-center justify-center rounded-md text-oai-gray-500 dark:text-oai-gray-400 hover:text-oai-gray-800 dark:hover:text-oai-gray-100 hover:bg-oai-gray-100 dark:hover:bg-oai-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oai-brand/50 transition-colors z-10"
+              aria-label={copy("dashboard.projects.drilldown.close")}
+            >
+              <X size={16} strokeWidth={2} aria-hidden />
+            </Dialog.Close>
+
+            <div className="mt-4 grid grid-cols-2 gap-4">
+              <SummaryBlock
+                label={copy("dashboard.projects.drilldown.current")}
+                total={loading || error ? copy("shared.placeholder.short") : formatTokens(data?.current?.totals?.billable_total_tokens)}
+                range={loading || error ? "—" : `${data?.current?.from || "—"} → ${data?.current?.to || "—"}`}
+              />
+              <SummaryBlock
+                label={copy("dashboard.projects.drilldown.previous")}
+                total={loading || error ? copy("shared.placeholder.short") : formatTokens(data?.previous?.totals?.billable_total_tokens)}
+                range={loading || error ? "—" : `${data?.previous?.from || "—"} → ${data?.previous?.to || "—"}`}
+              />
+            </div>
+
+            <div className="mt-6">
+              <div className="mb-2 text-xs uppercase tracking-wide text-oai-gray-500 dark:text-oai-gray-400">
+                {copy("dashboard.projects.drilldown.breakdown")}
+              </div>
+              <BreakdownContent loading={loading} error={error} sources={sources} />
+            </div>
+          </Dialog.Popup>
+        </Dialog.Viewport>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function BreakdownContent({ loading, error, sources }) {
+  if (loading) {
+    return (
+      <div className="text-sm text-oai-gray-500 dark:text-oai-gray-400">
+        {copy("dashboard.projects.drilldown.loading")}
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="text-sm text-red-500 dark:text-red-400" role="alert">
+        {copy("dashboard.projects.drilldown.error")}
+      </div>
+    );
+  }
+  if (!sources.length) {
+    return (
+      <div className="text-sm text-oai-gray-500 dark:text-oai-gray-400">
+        {copy("dashboard.projects.drilldown.breakdown_empty")}
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {sources.map((entry) => (
+        <div
+          key={entry.source}
+          className="flex items-center justify-between rounded-lg border border-oai-gray-100 dark:border-oai-gray-800 px-3 py-2"
+        >
+          <span className="text-sm text-oai-black dark:text-white">{entry.source}</span>
+          <span className="text-sm font-medium text-oai-black dark:text-white">
+            {formatTokens(entry.billable_total_tokens)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SummaryBlock({ label, total, range }) {
+  return (
+    <div className="rounded-xl border border-oai-gray-200 dark:border-oai-gray-800 px-4 py-4">
+      <div className="text-xs uppercase tracking-wide text-oai-gray-500 dark:text-oai-gray-400">{label}</div>
+      <div className="mt-1 text-lg font-semibold text-oai-black dark:text-white">{total}</div>
+      <div className="mt-1 text-xs text-oai-gray-500 dark:text-oai-gray-400">{range}</div>
+    </div>
+  );
+}

--- a/dashboard/src/ui/matrix-a/components/ProjectUsagePanel.jsx
+++ b/dashboard/src/ui/matrix-a/components/ProjectUsagePanel.jsx
@@ -95,6 +95,7 @@ export function ProjectUsagePanel({
   entries = [],
   limit = 3,
   onLimitChange,
+  onSelectEntry,
   loading = false,
   error = null,
   className = "",
@@ -188,6 +189,7 @@ export function ProjectUsagePanel({
             <ProjectUsageCard
               key={`${entry?.project_key || "repo"}-${entry?.project_ref || ""}`}
               entry={entry}
+              onSelectEntry={onSelectEntry}
               placeholder={placeholder}
               tokensLabel={tokensLabel}
               starsLabel={starsLabel}
@@ -202,6 +204,7 @@ export function ProjectUsagePanel({
 
 function ProjectUsageCard({
   entry,
+  onSelectEntry,
   placeholder,
   tokensLabel,
   starsLabel,
@@ -232,11 +235,11 @@ function ProjectUsageCard({
       : formatCompactNumber(tokensRaw, tokenFormatOptions);
 
   return (
-    <a
-      href={projectRef || (repoId ? `https://github.com/${repoId}` : "#")}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="flex items-center gap-3 p-3 rounded-lg border border-oai-gray-200 dark:border-oai-gray-700 hover:border-oai-gray-300 dark:hover:border-oai-gray-600 transition-colors"
+    <button
+      type="button"
+      data-project-card="true"
+      onClick={() => onSelectEntry?.(entry)}
+      className="w-full text-left flex items-center gap-3 p-3 rounded-lg border border-oai-gray-200 dark:border-oai-gray-700 hover:border-oai-gray-300 dark:hover:border-oai-gray-600 transition-colors"
     >
       {avatarUrl ? (
         <img src={avatarUrl} alt="" className="w-10 h-10 rounded bg-oai-gray-100 dark:bg-oai-gray-800 object-cover" />
@@ -252,6 +255,6 @@ function ProjectUsageCard({
           <span>{tokensCompact}</span>
         </div>
       </div>
-    </a>
+    </button>
   );
 }

--- a/dashboard/src/ui/matrix-a/views/DashboardView.jsx
+++ b/dashboard/src/ui/matrix-a/views/DashboardView.jsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import { Shell, Card, Button } from "../../openai/components";
 import { CostAnalysisModal } from "../components/CostAnalysisModal.jsx";
 import { DataDetails } from "../components/DataDetails.jsx";
+import { ProjectUsageDrilldownModal } from "../components/ProjectUsageDrilldownModal.jsx";
 import { StatsPanel } from "../components/StatsPanel.jsx";
 import { UsageOverview } from "../components/UsageOverview.jsx";
 import { TrendMonitor } from "../components/TrendMonitor.jsx";
@@ -27,6 +28,12 @@ export function DashboardView(props) {
     projectUsageEntries,
     projectUsageLimit,
     setProjectUsageLimit,
+    onSelectProjectEntry,
+    projectDrilldown,
+    projectDrilldownLoading,
+    projectDrilldownError,
+    projectDrilldownOpen,
+    closeProjectDrilldown,
     topModels,
     signedIn,
     publicMode,
@@ -250,6 +257,7 @@ export function DashboardView(props) {
                     projectEntries={projectUsageEntries}
                     projectLimit={projectUsageLimit}
                     onProjectLimitChange={setProjectUsageLimit}
+                    onSelectProjectEntry={onSelectProjectEntry}
                     copy={copy}
                     hasDetailsActual={hasDetailsActual}
                     dailyEmptyPrefix={dailyEmptyPrefix}
@@ -283,6 +291,13 @@ export function DashboardView(props) {
         )}
       </Shell>
       <CostAnalysisModal isOpen={costModalOpen} onClose={closeCostModal} fleetData={fleetData} />
+      <ProjectUsageDrilldownModal
+        open={projectDrilldownOpen}
+        onClose={closeProjectDrilldown}
+        data={projectDrilldown}
+        loading={projectDrilldownLoading}
+        error={projectDrilldownError}
+      />
     </>
   );
 }

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -377,6 +377,81 @@ function aggregateHourlyByDay(rows, dayKey, timeZoneContext) {
   return Array.from(byHour.values()).sort((a, b) => a.hour.localeCompare(b.hour));
 }
 
+function filterRowsByRange(rows, { from, to, timeZoneContext } = {}) {
+  return rows.filter((row) => {
+    if (!row?.hour_start) return false;
+    const day = rowDayKey(row, timeZoneContext);
+    if (from && day < from) return false;
+    if (to && day > to) return false;
+    return true;
+  });
+}
+
+function aggregateProjectEntries(projectRows) {
+  const byProject = new Map();
+  for (const row of projectRows) {
+    const key = row.project_key || "unknown";
+    if (!byProject.has(key)) {
+      byProject.set(key, {
+        project_key: key,
+        project_ref: row.project_ref || key,
+        total_tokens: 0,
+        billable_total_tokens: 0,
+      });
+    }
+    const agg = byProject.get(key);
+    agg.total_tokens += Number(row.total_tokens || 0);
+    agg.billable_total_tokens += Number(row.total_tokens || row.billable_total_tokens || 0);
+    if (!agg.project_ref && row.project_ref) agg.project_ref = row.project_ref;
+  }
+  return Array.from(byProject.values())
+    .sort((a, b) => b.billable_total_tokens - a.billable_total_tokens)
+    .map((entry) => ({
+      ...entry,
+      total_tokens: String(entry.total_tokens),
+      billable_total_tokens: String(entry.billable_total_tokens),
+    }));
+}
+
+function aggregateProjectSources(projectRows) {
+  const bySource = new Map();
+  for (const row of projectRows) {
+    const source = row.source || "unknown";
+    if (!bySource.has(source)) {
+      bySource.set(source, {
+        source,
+        total_tokens: 0,
+        billable_total_tokens: 0,
+      });
+    }
+    const agg = bySource.get(source);
+    agg.total_tokens += Number(row.total_tokens || 0);
+    agg.billable_total_tokens += Number(row.total_tokens || row.billable_total_tokens || 0);
+  }
+  return Array.from(bySource.values())
+    .sort((a, b) => b.billable_total_tokens - a.billable_total_tokens)
+    .map((entry) => ({
+      ...entry,
+      total_tokens: String(entry.total_tokens),
+      billable_total_tokens: String(entry.billable_total_tokens),
+    }));
+}
+
+function sumProjectTotals(projectRows) {
+  const totals = projectRows.reduce(
+    (acc, row) => {
+      acc.total_tokens += Number(row.total_tokens || 0);
+      acc.billable_total_tokens += Number(row.total_tokens || row.billable_total_tokens || 0);
+      return acc;
+    },
+    { total_tokens: 0, billable_total_tokens: 0 },
+  );
+  return {
+    total_tokens: String(totals.total_tokens),
+    billable_total_tokens: String(totals.billable_total_tokens),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Sync helper
 // ---------------------------------------------------------------------------
@@ -1091,33 +1166,24 @@ function createLocalApiHandler({ queuePath }) {
         path.dirname(qp),
         "project.queue.jsonl",
       );
-      const projectRows = readProjectQueueData(projectQueuePath);
-
-      const byProject = new Map();
-      for (const row of projectRows) {
-        const key = row.project_key || "unknown";
-        if (!byProject.has(key)) {
-          byProject.set(key, {
-            project_key: key,
-            project_ref: row.project_ref || key,
-            total_tokens: 0,
-            billable_total_tokens: 0,
-          });
-        }
-        const agg = byProject.get(key);
-        agg.total_tokens += Number(row.total_tokens || 0);
-        agg.billable_total_tokens += Number(row.total_tokens || 0);
-        if (!agg.project_ref && row.project_ref) agg.project_ref = row.project_ref;
-      }
+      const timeZoneContext = getTimeZoneContext(url);
+      const from = url.searchParams.get("from") || "";
+      const to = url.searchParams.get("to") || "";
+      const projectRows = filterRowsByRange(readProjectQueueData(projectQueuePath), {
+        from,
+        to,
+        timeZoneContext,
+      });
+      const entries = aggregateProjectEntries(projectRows);
 
       // If no project-attributed rows exist yet (user hasn't synced project
       // attribution, or never used a project-capable CLI), fall back to
       // per-source aggregation over the main queue so the panel isn't
       // totally empty. This path used to also exist for the non-empty case
       // and produce wrong numbers; keep it only as the empty fallback.
-      let entries;
-      if (byProject.size === 0) {
-        const rows = readQueueData(qp);
+      let finalEntries = entries;
+      if (entries.length === 0) {
+        const rows = filterRowsByRange(readQueueData(qp), { from, to, timeZoneContext });
         const bySrc = new Map();
         for (const row of rows) {
           const src = row.source || "unknown";
@@ -1132,15 +1198,7 @@ function createLocalApiHandler({ queuePath }) {
           bySrc.get(src).total_tokens += row.total_tokens || 0;
           bySrc.get(src).billable_total_tokens += row.total_tokens || 0;
         }
-        entries = Array.from(bySrc.values())
-          .sort((a, b) => b.billable_total_tokens - a.billable_total_tokens)
-          .map((e) => ({
-            ...e,
-            total_tokens: String(e.total_tokens),
-            billable_total_tokens: String(e.billable_total_tokens),
-          }));
-      } else {
-        entries = Array.from(byProject.values())
+        finalEntries = Array.from(bySrc.values())
           .sort((a, b) => b.billable_total_tokens - a.billable_total_tokens)
           .map((e) => ({
             ...e,
@@ -1149,7 +1207,44 @@ function createLocalApiHandler({ queuePath }) {
           }));
       }
 
-      json(res, { generated_at: new Date().toISOString(), entries });
+      json(res, { generated_at: new Date().toISOString(), entries: finalEntries });
+      return true;
+    }
+
+    if (p === "/functions/tokentracker-project-usage-detail") {
+      const projectQueuePath = path.join(path.dirname(qp), "project.queue.jsonl");
+      const timeZoneContext = getTimeZoneContext(url);
+      const projectKey = url.searchParams.get("project_key") || "";
+      const from = url.searchParams.get("from") || "";
+      const to = url.searchParams.get("to") || "";
+      const compareFrom = url.searchParams.get("compare_from") || "";
+      const compareTo = url.searchParams.get("compare_to") || "";
+      const allRows = readProjectQueueData(projectQueuePath).filter(
+        (row) => String(row.project_key || "") === projectKey,
+      );
+      const currentRows = filterRowsByRange(allRows, { from, to, timeZoneContext });
+      const previousRows = filterRowsByRange(allRows, {
+        from: compareFrom,
+        to: compareTo,
+        timeZoneContext,
+      });
+      json(res, {
+        generated_at: new Date().toISOString(),
+        project_key: projectKey,
+        project_ref: currentRows[0]?.project_ref || previousRows[0]?.project_ref || null,
+        current: {
+          from,
+          to,
+          totals: sumProjectTotals(currentRows),
+          sources: aggregateProjectSources(currentRows),
+        },
+        previous: {
+          from: compareFrom,
+          to: compareTo,
+          totals: sumProjectTotals(previousRows),
+          sources: aggregateProjectSources(previousRows),
+        },
+      });
       return true;
     }
 

--- a/test/project-drilldown.test.js
+++ b/test/project-drilldown.test.js
@@ -1,0 +1,81 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const fsp = require("node:fs/promises");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const { createLocalApiHandler } = require("../src/lib/local-api");
+
+function createRequest({ method = "GET" } = {}) {
+  return {
+    method,
+    headers: {},
+    async *[Symbol.asyncIterator]() {},
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    headers: null,
+    body: Buffer.alloc(0),
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      this.headers = headers;
+    },
+    end(chunk) {
+      this.body = chunk ? Buffer.from(chunk) : Buffer.alloc(0);
+    },
+  };
+}
+
+test("project usage detail returns current and previous period breakdowns", async () => {
+  const tmp = await fsp.mkdtemp(path.join(os.tmpdir(), "tokentracker-project-detail-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const projectQueuePath = path.join(tmp, "project.queue.jsonl");
+    await fsp.writeFile(queuePath, "", "utf8");
+    await fsp.writeFile(
+      projectQueuePath,
+      [
+        JSON.stringify({ project_key: "octo/api", project_ref: "https://github.com/octo/api", source: "codex", hour_start: "2026-04-10T00:00:00.000Z", total_tokens: 100 }),
+        JSON.stringify({ project_key: "octo/api", project_ref: "https://github.com/octo/api", source: "gemini", hour_start: "2026-04-11T00:00:00.000Z", total_tokens: 200 }),
+        JSON.stringify({ project_key: "octo/api", project_ref: "https://github.com/octo/api", source: "codex", hour_start: "2026-04-08T00:00:00.000Z", total_tokens: 50 }),
+      ].join("\n"),
+      "utf8",
+    );
+
+    const handler = createLocalApiHandler({ queuePath });
+    const req = createRequest();
+    const res = createResponse();
+    const url = new URL("http://127.0.0.1/functions/tokentracker-project-usage-detail");
+    url.searchParams.set("project_key", "octo/api");
+    url.searchParams.set("from", "2026-04-10");
+    url.searchParams.set("to", "2026-04-11");
+    url.searchParams.set("compare_from", "2026-04-08");
+    url.searchParams.set("compare_to", "2026-04-09");
+
+    const handled = await handler(req, res, url);
+    assert.equal(handled, true);
+    const payload = JSON.parse(res.body.toString("utf8"));
+    assert.equal(payload.current.totals.billable_total_tokens, "300");
+    assert.equal(payload.previous.totals.billable_total_tokens, "50");
+    assert.equal(payload.current.sources.length, 2);
+  } finally {
+    await fsp.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("dashboard wires project drilldown modal flow", () => {
+  const dashboardSrc = fs.readFileSync(
+    path.join(process.cwd(), "dashboard/src/pages/DashboardPage.jsx"),
+    "utf8",
+  );
+  assert.match(dashboardSrc, /selectedProjectEntry/);
+  const viewSrc = fs.readFileSync(
+    path.join(process.cwd(), "dashboard/src/ui/matrix-a/views/DashboardView.jsx"),
+    "utf8",
+  );
+  assert.match(viewSrc, /ProjectUsageDrilldownModal/);
+});


### PR DESCRIPTION
## Why
Issue #23 asks for project drilldowns that make it easy to compare one period against another.

## What changed
- fixed local project summaries to respect date filters
- added a project detail endpoint with current vs previous period totals and source breakdowns
- added a project drilldown modal in the dashboard

## Verification
- `node --test test/project-drilldown.test.js`
- `npm run validate:copy`

Closes #23