### PR TITLE
fix(kiro-cli): correctness + resource-bound hardening on top of 39c8f39

### DIFF
--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -385,7 +385,7 @@ async function cmdSync(argv) {
             if (!progress?.enabled) return;
             const pct = p.total > 0 ? p.index / p.total : 1;
             progress.update(
-              `Parsing Kiro CLI ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} convs | buckets ${formatNumber(p.bucketsQueued)}`,
+              `Parsing Kiro CLI ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} sessions | buckets ${formatNumber(p.bucketsQueued)}`,
             );
           },
         });

--- a/src/lib/diagnostics.js
+++ b/src/lib/diagnostics.js
@@ -16,7 +16,20 @@ const { normalizeState: normalizeUploadState } = require("./upload-throttle");
 const { probeOpenclawHookState } = require("./openclaw-hook");
 const { probeOpenclawSessionPluginState } = require("./openclaw-session-plugin");
 const { resolveTrackerPaths } = require("./tracker-paths");
-const { resolveKiroCliDbPath } = require("./rollout");
+// TASK-011: Kiro CLI DB path inlined here to avoid pulling the ~4000-line
+// rollout module on every `tokentracker status` / `diagnostics` call.
+// rollout.js still exports resolveKiroCliDbPath for external callers.
+function resolveKiroCliDbPathInline(env, home) {
+  if (env.KIRO_CLI_DB_PATH) return env.KIRO_CLI_DB_PATH;
+  const effectiveHome = env.HOME || home;
+  return path.join(
+    effectiveHome,
+    "Library",
+    "Application Support",
+    "kiro-cli",
+    "data.sqlite3",
+  );
+}
 
 async function collectTrackerDiagnostics({
   home = os.homedir(),
@@ -98,7 +111,7 @@ async function collectTrackerDiagnostics({
   const kiroIdePresent =
     (await safeStatSize(path.join(kiroIdeDevDataDir, "devdata.sqlite"))) > 0 ||
     (await safeStatSize(path.join(kiroIdeDevDataDir, "tokens_generated.jsonl"))) > 0;
-  const kiroCliDbPath = resolveKiroCliDbPath(process.env);
+  const kiroCliDbPath = resolveKiroCliDbPathInline(process.env, home);
   const kiroCliPresent = require("node:fs").existsSync(kiroCliDbPath);
 
   const lastSuccessAt = uploadThrottle.lastSuccessMs

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3085,20 +3085,31 @@ function resolveKiroCliDbPath(env = process.env) {
   return path.join(home, "Library", "Application Support", "kiro-cli", "data.sqlite3");
 }
 
+// Bug-4: canonical UUID shape — 8-4-4-4-12 hex groups. The looser
+// /^[0-9a-f-]{36}\.json$/ form accepted `36 hyphens`.json or 36 hex with
+// no hyphens. kiro-cli writes proper UUIDs; lock to the canonical shape.
+const KIRO_CLI_SESSION_FILE_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.json$/i;
+
 // Lists ~/.kiro/sessions/cli/{uuid}.json files. Includes files whose sibling
 // .lock is present — we read those as tail-only snapshots so a running
 // session's completed turns still land in the queue on the next sync. The
 // .json files are rewritten atomically by kiro-cli on each turn flush, so
 // a stale read just means we'll pick up the rest next time.
+//
+// TASK-014: env.HOME is honored (symmetric with resolveKiroCliDbPath) so
+// callers can redirect to a tmp home for hermetic tests/CI.
 function resolveKiroCliSessionFiles(env = process.env) {
-  const home = require("node:os").homedir();
+  const home = env.HOME || require("node:os").homedir();
   const kiroHome = env.KIRO_HOME || path.join(home, ".kiro");
   const sessionsDir = path.join(kiroHome, "sessions", "cli");
   if (!fssync.existsSync(sessionsDir)) return [];
   const files = [];
   try {
     for (const entry of fssync.readdirSync(sessionsDir)) {
-      if (!entry.endsWith(".json")) continue;
+      // TASK-003: only canonical {uuid}.json files; backups, scratch,
+      // typos are skipped so they don't feed JSON.parse garbage.
+      if (!KIRO_CLI_SESSION_FILE_RE.test(entry)) continue;
       files.push(path.join(sessionsDir, entry));
     }
   } catch {
@@ -3126,63 +3137,73 @@ function resolveKiroCliSessionFiles(env = process.env) {
 // "claims" the buffered Prompt chars for its turn, and the buffer resets.
 // Later cycles within the same turn (Assistant → ToolResults → Assistant)
 // do not re-attribute.
-function readKiroCliMessageChars(jsonlPath, turnMessageIds) {
+async function readKiroCliMessageChars(jsonlPath, turnMessageIds) {
   const result = {
     byMessage: new Map(),
     messageKind: new Map(),
     turnPromptChars: new Map(),
   };
   if (!jsonlPath || !fssync.existsSync(jsonlPath)) return result;
-  let raw;
+  // TASK-005: stream via readline so multi-MB .jsonl files (heavy tool-use
+  // sessions) don't block the sync event loop by buffering whole-file.
+  let stream;
   try {
-    raw = fssync.readFileSync(jsonlPath, "utf8");
+    stream = fssync.createReadStream(jsonlPath, { encoding: "utf8" });
   } catch {
     return result;
   }
+  const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
   const midToTurn =
     turnMessageIds instanceof Map ? turnMessageIds : new Map();
   const attributedTurns = new Set();
   let pendingPromptChars = 0;
-  for (const line of raw.split("\n")) {
-    if (!line.trim()) continue;
-    let evt;
-    try {
-      evt = JSON.parse(line);
-    } catch {
-      continue;
-    }
-    const data = evt?.data;
-    if (!data || typeof data !== "object") continue;
-    const mid = data.message_id;
-    if (!mid) continue;
-    const content = Array.isArray(data.content) ? data.content : [];
-    let chars = 0;
-    for (const c of content) {
-      if (!c || typeof c !== "object") continue;
-      if (c.kind === "text" && typeof c.data === "string") {
-        chars += c.data.length;
-      } else if (c.kind === "toolUse" && c.data && typeof c.data === "object") {
-        // tool-use invocations count toward output; stringify the input payload
-        try {
-          chars += JSON.stringify(c.data.input || {}).length;
-        } catch {
-          // ignore
+  // Bug-5: wrap the streamed iteration. Mid-read errors (file deleted or
+  // truncated while kiro-cli is writing) would otherwise propagate up and
+  // crash the whole sync pass. On error we return the partial result and
+  // let the next sync re-read fresh.
+  try {
+    for await (const line of rl) {
+      if (!line || !line.trim()) continue;
+      let evt;
+      try {
+        evt = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const data = evt && evt.data;
+      if (!data || typeof data !== "object") continue;
+      const mid = data.message_id;
+      if (!mid) continue;
+      const content = Array.isArray(data.content) ? data.content : [];
+      let chars = 0;
+      for (const c of content) {
+        if (!c || typeof c !== "object") continue;
+        if (c.kind === "text" && typeof c.data === "string") {
+          chars += c.data.length;
+        } else if (c.kind === "toolUse" && c.data && typeof c.data === "object") {
+          try {
+            chars += JSON.stringify(c.data.input || {}).length;
+          } catch {
+            // ignore
+          }
+        }
+      }
+      result.byMessage.set(mid, (result.byMessage.get(mid) || 0) + chars);
+      if (!result.messageKind.has(mid)) result.messageKind.set(mid, evt.kind);
+
+      if (evt.kind === "Prompt") {
+        pendingPromptChars += chars;
+      } else if (evt.kind === "AssistantMessage" && midToTurn.has(mid)) {
+        const turnIdx = midToTurn.get(mid);
+        if (!attributedTurns.has(turnIdx)) {
+          result.turnPromptChars.set(turnIdx, pendingPromptChars);
+          attributedTurns.add(turnIdx);
+          pendingPromptChars = 0;
         }
       }
     }
-    result.byMessage.set(mid, (result.byMessage.get(mid) || 0) + chars);
-    if (!result.messageKind.has(mid)) result.messageKind.set(mid, evt.kind);
-
-    if (evt.kind === "Prompt") {
-      pendingPromptChars += chars;
-    } else if (evt.kind === "AssistantMessage" && midToTurn.has(mid)) {
-      const turnIdx = midToTurn.get(mid);
-      if (!attributedTurns.has(turnIdx)) {
-        result.turnPromptChars.set(turnIdx, pendingPromptChars);
-        attributedTurns.add(turnIdx);
-        pendingPromptChars = 0;
-      }
-    }
+  } catch {
+    // partial data — return what we have.
   }
   return result;
 }
@@ -3192,7 +3213,7 @@ function readKiroCliMessageChars(jsonlPath, turnMessageIds) {
 // input_tokens, output_tokens }]. We use the same request_id dedup slot as
 // the SQLite path so mutations (turn rewritten on next flush) go through
 // the subtract-old/add-new path in parseKiroCliIncremental.
-function readKiroCliSessionTurns(jsonPath) {
+async function readKiroCliSessionTurns(jsonPath) {
   if (!jsonPath || !fssync.existsSync(jsonPath)) return [];
   let parsed;
   try {
@@ -3229,14 +3250,19 @@ function readKiroCliSessionTurns(jsonPath) {
 
   // Load sibling .jsonl for char-count fallback.
   const jsonlPath = jsonPath.replace(/\.json$/, ".jsonl");
-  const charMap = readKiroCliMessageChars(jsonlPath, turnMessageIds);
+  const charMap = await readKiroCliMessageChars(jsonlPath, turnMessageIds);
 
   const flat = [];
   for (let turnIdx = 0; turnIdx < turns.length; turnIdx++) {
     const turn = turns[turnIdx];
     if (!turn || typeof turn !== "object") continue;
+    // TASK-001: preserve the integer 0. `|| null` would coerce a valid
+    // loop_id.rand=0 into a message_id fallback, splitting the dedup
+    // namespace across runs that see 0 vs runs that don't.
     const loopRand =
-      (turn.loop_id && (turn.loop_id.rand ?? turn.loop_id.seed)) || null;
+      turn.loop_id && typeof turn.loop_id === "object"
+        ? turn.loop_id.rand ?? turn.loop_id.seed ?? null
+        : null;
     const messageIds = Array.isArray(turn.message_ids) ? turn.message_ids : [];
     const requestId = loopRand != null ? `${sessionId}:${loopRand}` : (messageIds[0] || null);
     if (!requestId) continue;
@@ -3261,9 +3287,22 @@ function readKiroCliSessionTurns(jsonPath) {
       outputTokens = Math.floor(assistantChars / KIRO_CLI_CHARS_PER_TOKEN);
     }
 
-    // Timestamp: end_timestamp is an ISO string; coerce to ms.
-    const tsRaw = turn.end_timestamp || turn.start_timestamp;
-    const tsMs = tsRaw ? Date.parse(tsRaw) : NaN;
+    // TASK-006: timestamp precedence matches SQLite's
+    // request_start_timestamp_ms so a turn that migrates SQLite ↔
+    // session-file buckets identically across tiers (previously a turn
+    // straddling a half-hour boundary bucketed differently per source
+    // because session files use end_timestamp while SQLite uses start).
+    //   1. turn.request_start_timestamp_ms   (numeric ms, SQLite shape)
+    //   2. turn.start_timestamp              (ISO string)
+    //   3. turn.end_timestamp                (ISO string, legacy fallback)
+    let tsMs = NaN;
+    if (Number.isFinite(Number(turn.request_start_timestamp_ms))) {
+      tsMs = Number(turn.request_start_timestamp_ms);
+    } else if (turn.start_timestamp) {
+      tsMs = Date.parse(turn.start_timestamp);
+    } else if (turn.end_timestamp) {
+      tsMs = Date.parse(turn.end_timestamp);
+    }
     if (!Number.isFinite(tsMs) || tsMs <= 0) continue;
 
     flat.push({
@@ -3272,6 +3311,11 @@ function readKiroCliSessionTurns(jsonPath) {
       message_id: messageIds[0] || null,
       model_id: turn.model_id || sessionModelId,
       request_start_timestamp_ms: tsMs,
+      // D-1 / Bug-2: tag with session_id so the retraction pass can match
+      // session-origin entries even when the requestId format has no
+      // colon (no-loop_id fallback uses a bare message_id UUID that would
+      // otherwise be indistinguishable from SQLite's UUID keys).
+      session_id: sessionId,
       // For the parser, we feed the ALREADY-approximated tokens directly via
       // a special sentinel field. The parser will divide chars by
       // KIRO_CLI_CHARS_PER_TOKEN; bypass that by pre-multiplying here.
@@ -3319,7 +3363,14 @@ function canonicalizeKiroCliModelId(raw) {
 
 // Read Kiro CLI requests using SQL-side json_extract so we don't pull the
 // full (93 MB-ish) conversations_v2 blob back through sqlite3 -json.
-function readKiroCliRequests(dbPath) {
+//
+// D-1: also surfaces `user_turn_metadata.continuation_id` so the cross-
+// source retraction pass (parseKiroCliIncremental) can match whichever
+// UUID kiro-cli used as the session link. The SQL column
+// `conversation_id` and the inner JSON `continuation_id` are different
+// UUIDs on observed data; covering both means retraction fires whichever
+// side matches the live session's `session_id`.
+function readKiroCliRequests(dbPath, env = process.env) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   let raw;
   try {
@@ -3330,13 +3381,23 @@ function readKiroCliRequests(dbPath) {
         dbPath,
         "SELECT conversation_id, " +
           "json_extract(value, '$.model_info.model_id') AS session_model_id, " +
+          "json_extract(value, '$.user_turn_metadata.continuation_id') AS continuation_id, " +
           "json_extract(value, '$.user_turn_metadata.requests') AS requests_json " +
           "FROM conversations_v2 " +
           "WHERE json_extract(value, '$.user_turn_metadata.requests') IS NOT NULL",
       ],
       { encoding: "utf8", maxBuffer: 128 * 1024 * 1024, timeout: 120_000 },
     );
-  } catch {
+  } catch (err) {
+    // TASK-012 / D-8: debug-gated stderr log so a missing sqlite3 binary
+    // is distinguishable from an empty DB. Silent by default. env is
+    // threaded so tests can toggle debug hermetically.
+    const dbg = String((env && env.TOKENTRACKER_DEBUG) || "").toLowerCase();
+    if (dbg === "1" || dbg === "true") {
+      process.stderr.write(
+        `[kiro-cli] sqlite3 read failed: ${err?.message || err}\n`,
+      );
+    }
     return [];
   }
   if (!raw || !raw.trim()) return [];
@@ -3360,6 +3421,7 @@ function readKiroCliRequests(dbPath) {
       if (!r || typeof r !== "object") continue;
       flat.push({
         conversation_id: row.conversation_id,
+        continuation_id: row.continuation_id || null,
         session_model_id: row.session_model_id || null,
         request_id: r.request_id || null,
         message_id: r.message_id || null,
@@ -3400,18 +3462,22 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
   // Combine two sources under the same (source='kiro', cursors.kiroCli)
   // namespace: historical rows from the SQLite DB plus live session state
   // from ~/.kiro/sessions/cli/{uuid}.json (covers turns from a running
-  // session that hasn't flushed to SQLite yet). Request IDs are disjoint
-  // (SQLite uses request_id UUID; sessions use {sessionId}:{loop_id.rand}),
-  // so no cross-source dedup is needed.
-  const flatDb = fssync.existsSync(dbPath) ? readKiroCliRequests(dbPath) : [];
+  // session that hasn't flushed to SQLite yet). Request ID shapes differ:
+  // SQLite carries a persisted request_id UUID; session files synthesize
+  // `${sessionId}:${loop_id.rand}`. When kiro-cli migrates a live session
+  // into SQLite the same turn lands under a new request_id — the cross-
+  // source retraction pass below (D-1 + TASK-007) matches session_id ↔
+  // SQLite conversation_id OR continuation_id to subtract the orphan
+  // session-file cursor entry before the new SQLite row is processed.
+  const flatDb = fssync.existsSync(dbPath)
+    ? readKiroCliRequests(dbPath, resolvedEnv)
+    : [];
   const sessionFilesList = resolveKiroCliSessionFiles(resolvedEnv);
-  const flatSessions = [];
+  let flatSessions = [];
   for (const jsonPath of sessionFilesList) {
-    for (const turn of readKiroCliSessionTurns(jsonPath)) {
-      flatSessions.push(turn);
-    }
+    const turns = await readKiroCliSessionTurns(jsonPath);
+    for (const turn of turns) flatSessions.push(turn);
   }
-  const flat = flatDb.concat(flatSessions);
   // Per-request state replaces the old seenIds set. Each entry captures
   // what we contributed for that request_id last time, so a later mutation
   // (same request_id, different fingerprint) can subtract-old/add-new
@@ -3421,17 +3487,116 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
       ? { ...kiroCliState.requests }
       : {};
 
-  if (flat.length === 0) {
-    cursors.kiroCli = {
-      ...kiroCliState,
-      requests: requestState,
-      updatedAt: new Date().toISOString(),
-    };
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
   const hourlyState = normalizeHourlyState(cursors?.hourly);
   const touchedBuckets = new Set();
+  const debugEnabled = ["1", "true"].includes(
+    String(resolvedEnv.TOKENTRACKER_DEBUG || "").toLowerCase(),
+  );
+
+  // ── TASK-007 + D-1: cross-source retraction. When a conversation has
+  //    migrated from the session-file tier into SQLite, the cursor's
+  //    prior session-file entry (keyed `${sessionId}:${loopRand}` OR a
+  //    bare message_id UUID when loop_id is absent) never matches the
+  //    new SQLite request_id. Without retraction the old contribution
+  //    stays in the bucket absolute and the new SQLite row is added on
+  //    top — permanent double-count. D-6: typed non-empty check so a
+  //    corrupt NULL/empty conv_id can't poison the match set.
+  const migratedConvIds = new Set();
+  for (const row of flatDb) {
+    if (!row) continue;
+    if (typeof row.conversation_id === "string" && row.conversation_id)
+      migratedConvIds.add(row.conversation_id);
+    if (typeof row.continuation_id === "string" && row.continuation_id)
+      migratedConvIds.add(row.continuation_id);
+  }
+  if (migratedConvIds.size > 0) {
+    // Pre-collect to retract so mutation during iteration is safe.
+    const toRetract = [];
+    for (const [reqId, prev] of Object.entries(requestState)) {
+      if (!prev || typeof prev !== "object") continue;
+      // Bug-2: prefer the stored session_id tag (new schema); fall back
+      // to colon-split for legacy cursors pre-dating this change.
+      let sid = null;
+      if (typeof prev.session_id === "string" && prev.session_id) {
+        sid = prev.session_id;
+      } else {
+        const colon = reqId.indexOf(":");
+        if (colon > 0) sid = reqId.slice(0, colon);
+      }
+      if (!sid || !migratedConvIds.has(sid)) continue;
+      toRetract.push([reqId, prev, sid]);
+    }
+    for (const [reqId, prev, sid] of toRetract) {
+      if (prev.input_tokens || prev.output_tokens) {
+        const prevBucket = getHourlyBucket(
+          hourlyState,
+          "kiro",
+          prev.model,
+          prev.bucketStart,
+        );
+        addTotals(prevBucket.totals, {
+          input_tokens: -prev.input_tokens,
+          cached_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          output_tokens: -prev.output_tokens,
+          reasoning_output_tokens: 0,
+          total_tokens: -(prev.input_tokens + prev.output_tokens),
+          conversation_count: -1,
+        });
+        touchedBuckets.add(bucketKey("kiro", prev.model, prev.bucketStart));
+      }
+      delete requestState[reqId];
+      if (debugEnabled) {
+        process.stderr.write(
+          `[kiro-cli] retracted migrated session entry (conv ${sid})\n`,
+        );
+      }
+    }
+    // D-14: drop matching session-file entries from this run via filter
+    // (O(N)) instead of reverse-splice-in-loop (O(N²)).
+    const before = flatSessions.length;
+    flatSessions = flatSessions.filter((s) => {
+      if (!s) return false;
+      let sid = null;
+      if (typeof s.session_id === "string" && s.session_id) {
+        sid = s.session_id;
+      } else {
+        const rid = s.request_id || "";
+        const colon = rid.indexOf(":");
+        if (colon > 0) sid = rid.slice(0, colon);
+      }
+      return !(sid && migratedConvIds.has(sid));
+    });
+    if (debugEnabled && flatSessions.length !== before) {
+      process.stderr.write(
+        `[kiro-cli] dropped ${before - flatSessions.length} migrated session-file turn(s)\n`,
+      );
+    }
+  }
+
+  const flat = flatDb.concat(flatSessions);
+
+  if (flat.length === 0) {
+    // Bug-1: retraction may have touched buckets even with empty flat.
+    // Clamp + cap BEFORE flushing so the early-return path applies the
+    // same guarantees as the main path (fixes a skip that flushed
+    // negative conversation_counts and left the cap unapplied).
+    const cappedEarly = clampAndCapKiroCliState({
+      requestState,
+      hourlyState,
+      touchedBuckets,
+    });
+    const bucketsQueued = await enqueueTouchedBuckets({
+      queuePath,
+      hourlyState,
+      touchedBuckets,
+    });
+    const updatedAt = new Date().toISOString();
+    hourlyState.updatedAt = updatedAt;
+    cursors.hourly = hourlyState;
+    cursors.kiroCli = { ...kiroCliState, requests: cappedEarly, updatedAt };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued };
+  }
   const cb = typeof onProgress === "function" ? onProgress : null;
   let recordsProcessed = 0;
   let eventsAggregated = 0;
@@ -3497,12 +3662,17 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
 
     // Always record the cursor entry (even for zero-token requests) so we
     // don't re-count later if Kiro rewrites this request with real data.
+    // Bug-2: tag session-origin entries with session_id so the retraction
+    // pass can identify them regardless of request_id format (the
+    // no-loop_id fallback produces a bare UUID with no colon, which would
+    // otherwise be indistinguishable from SQLite's UUID keys).
     requestState[requestId] = {
       fingerprint,
       bucketStart,
       model,
       input_tokens: approxInput,
       output_tokens: approxOutput,
+      ...(r.session_id ? { session_id: r.session_id } : {}),
     };
 
     if (cb && i % 50 === 0) {
@@ -3516,13 +3686,57 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
     }
   }
 
+  const cappedState = clampAndCapKiroCliState({
+    requestState,
+    hourlyState,
+    touchedBuckets,
+  });
+
   const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
   const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
   cursors.hourly = hourlyState;
-  cursors.kiroCli = { ...kiroCliState, requests: requestState, updatedAt };
+  cursors.kiroCli = { ...kiroCliState, requests: cappedState, updatedAt };
 
   return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+// TASK-004 + TASK-010 + Bug-1: shared end-of-run clamp + cap for
+// parseKiroCliIncremental. Centralized so the main path AND the
+// retraction-only early-return path both apply the same guarantees.
+// Mutates hourlyState bucket totals in place (clamp) and returns a new
+// capped requestState object (cap).
+const KIRO_CLI_CURSOR_MAX_AGE_MS = 90 * 24 * 60 * 60 * 1000;
+const KIRO_CLI_CURSOR_MAX_ENTRIES = 20_000;
+
+function clampAndCapKiroCliState({ requestState, hourlyState, touchedBuckets }) {
+  // TASK-010: clamp conversation_count to >= 0 on Kiro-touched buckets
+  // only. The shared enqueueTouchedBuckets is left untouched so
+  // legitimate negatives from the 10 other parsers are not masked. Kiro
+  // negatives come from the subtract-old pass on mutation or retraction.
+  for (const key of touchedBuckets) {
+    const bucket = hourlyState.buckets && hourlyState.buckets[key];
+    if (bucket && bucket.totals && bucket.totals.conversation_count < 0) {
+      bucket.totals.conversation_count = 0;
+    }
+  }
+  // TASK-004: cap cursors.kiroCli.requests by age + count. Runs LAST so
+  // nothing active or just-retracted is pruned mid-flight.
+  const ageCutoffMs = Date.now() - KIRO_CLI_CURSOR_MAX_AGE_MS;
+  const cappedEntries = [];
+  for (const [reqId, entry] of Object.entries(requestState)) {
+    if (!entry || typeof entry !== "object") continue;
+    const ts = entry.bucketStart ? Date.parse(entry.bucketStart) : NaN;
+    if (!Number.isFinite(ts) || ts < ageCutoffMs) continue;
+    cappedEntries.push([reqId, entry, ts]);
+  }
+  if (cappedEntries.length > KIRO_CLI_CURSOR_MAX_ENTRIES) {
+    cappedEntries.sort((a, b) => b[2] - a[2]); // newest first
+    cappedEntries.length = KIRO_CLI_CURSOR_MAX_ENTRIES;
+  }
+  const capped = {};
+  for (const [reqId, entry] of cappedEntries) capped[reqId] = entry;
+  return capped;
 }
 
 // Back-compat path: per-session .json files (the old fixture shape). Emits

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3309,6 +3309,13 @@ async function readKiroCliSessionTurns(jsonPath) {
       request_id: requestId,
       session_model_id: sessionModelId,
       message_id: messageIds[0] || null,
+      // Turn-granular migration match: surface the full list so the
+      // cross-source retraction in parseKiroCliIncremental can drop this
+      // specific turn iff any of its assistant/tool_result message_ids
+      // appears in SQLite. Session-level matching over-retracts newer
+      // turns in an active session whose older turns have already
+      // flushed to SQLite.
+      all_message_ids: messageIds.slice(),
       model_id: turn.model_id || sessionModelId,
       request_start_timestamp_ms: tsMs,
       // D-1 / Bug-2: tag with session_id so the retraction pass can match
@@ -3501,16 +3508,36 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
   //    stays in the bucket absolute and the new SQLite row is added on
   //    top — permanent double-count. D-6: typed non-empty check so a
   //    corrupt NULL/empty conv_id can't poison the match set.
+  //
+  // Two match sets are built:
+  //   • migratedConvIds  — session_id → any row in SQLite. Used to scope
+  //                        cursor retraction (coarse but safe because
+  //                        un-migrated turns still present in the session
+  //                        file are re-added later in this same run).
+  //   • migratedMsgIds   — r.message_id → exact turn in SQLite. Used to
+  //                        filter flatSessions at TURN granularity. An
+  //                        active session with older migrated turns +
+  //                        newer session-file-only turns must keep the
+  //                        newer turns; session-level filtering dropped
+  //                        them and caused Kiro CLI under-count.
   const migratedConvIds = new Set();
+  const migratedMsgIds = new Set();
   for (const row of flatDb) {
     if (!row) continue;
     if (typeof row.conversation_id === "string" && row.conversation_id)
       migratedConvIds.add(row.conversation_id);
     if (typeof row.continuation_id === "string" && row.continuation_id)
       migratedConvIds.add(row.continuation_id);
+    if (typeof row.message_id === "string" && row.message_id)
+      migratedMsgIds.add(row.message_id);
   }
   if (migratedConvIds.size > 0) {
     // Pre-collect to retract so mutation during iteration is safe.
+    // Retraction stays session-level: for every cursor entry whose
+    // session_id has any row in SQLite, subtract its prior contribution.
+    // This is provably correct because turns still live in the session
+    // file get re-added in this same run via the (turn-granular) filter
+    // below, producing a net delta of zero for un-migrated turns.
     const toRetract = [];
     for (const [reqId, prev] of Object.entries(requestState)) {
       if (!prev || typeof prev !== "object") continue;
@@ -3552,20 +3579,30 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
         );
       }
     }
-    // D-14: drop matching session-file entries from this run via filter
-    // (O(N)) instead of reverse-splice-in-loop (O(N²)).
+    // Turn-granular filter: drop a session-file turn only when at least
+    // one of its assistant/tool_result message_ids is present in SQLite
+    // (i.e. this specific turn has been flushed). Newer turns in the
+    // same session that haven't yet landed in SQLite survive.
+    //
+    // Edge: a turn with no message_ids at all cannot be matched. We keep
+    // it — preferring a rare potential double-count (narrow, since such
+    // a turn would also have no request_id under the no-loop_id path and
+    // be discarded upstream) over the reported regression of dropping
+    // legitimate newer turns wholesale. D-14: still O(N) single-pass.
     const before = flatSessions.length;
     flatSessions = flatSessions.filter((s) => {
       if (!s) return false;
-      let sid = null;
-      if (typeof s.session_id === "string" && s.session_id) {
-        sid = s.session_id;
-      } else {
-        const rid = s.request_id || "";
-        const colon = rid.indexOf(":");
-        if (colon > 0) sid = rid.slice(0, colon);
+      const mids = Array.isArray(s.all_message_ids)
+        ? s.all_message_ids
+        : s.message_id
+        ? [s.message_id]
+        : [];
+      for (const mid of mids) {
+        if (typeof mid === "string" && mid && migratedMsgIds.has(mid)) {
+          return false;
+        }
       }
-      return !(sid && migratedConvIds.has(sid));
+      return true;
     });
     if (debugEnabled && flatSessions.length !== before) {
       process.stderr.write(

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -3025,6 +3025,134 @@ test("parseKiroCliIncremental retracts no-loop_id session-file entries via sessi
   }
 });
 
+test("parseKiroCliIncremental keeps newer session-file turns when older ones have migrated to SQLite (mixed-state, turn-granular)", async () => {
+  // Regression: previously, cross-source retraction filtered flatSessions
+  // at session_id granularity — so an active session with turn A in SQLite
+  // AND turns A + B in the session file would drop B entirely, producing
+  // Kiro CLI under-count for the currently-active conversation.
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kiro-mixed-"));
+  try {
+    const dbPath = path.join(tmp, "data.sqlite3");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const sessionsDir = path.join(tmp, ".kiro", "sessions", "cli");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const convId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    const msgA = "msg-A-migrated";
+    const msgB = "msg-B-session-only";
+    const tsA = Date.parse("2026-04-20T10:05:00.000Z");
+    const tsB = Date.parse("2026-04-20T10:35:00.000Z");
+    const env = { KIRO_CLI_DB_PATH: dbPath, HOME: tmp };
+
+    // Session file: turn A (older, also in SQLite) + turn B (newer, not
+    // yet flushed). kiro-cli keeps flushed turns in the session file
+    // until the whole session ends, so the overlap is normal.
+    await fs.writeFile(
+      path.join(sessionsDir, `${convId}.json`),
+      JSON.stringify({
+        session_id: convId,
+        session_state: {
+          rts_model_state: { model_info: { model_id: "claude-sonnet-4.5" } },
+          conversation_metadata: {
+            user_turn_metadatas: [
+              {
+                loop_id: { rand: 10 },
+                message_ids: [msgA],
+                request_start_timestamp_ms: tsA,
+                input_token_count: 100,
+                output_token_count: 200,
+              },
+              {
+                loop_id: { rand: 11 },
+                message_ids: [msgB],
+                request_start_timestamp_ms: tsB,
+                input_token_count: 60,
+                output_token_count: 30,
+              },
+            ],
+          },
+        },
+      }),
+    );
+    await fs.writeFile(path.join(sessionsDir, `${convId}.jsonl`), "");
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT, created_at INTEGER, updated_at INTEGER, PRIMARY KEY (key, conversation_id));",
+    ]);
+
+    // Run 1: only the session file has data (B doesn't exist yet — simulate
+    // by only inserting turn A into the session file for the first pass).
+    // For simplicity we run once with the full file but empty SQLite; both
+    // turns land via session-file parse.
+    const cursors = { version: 1 };
+    const r1 = await rolloutModule.parseKiroCliIncremental({
+      cursors,
+      queuePath,
+      env,
+    });
+    assert.equal(r1.eventsAggregated, 2, "run 1 parses both turns from session file");
+
+    // Run 2: turn A has flushed to SQLite (conv_id=convId, message_id=msgA).
+    // Turn B is still session-only.
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO conversations_v2 VALUES ('proj', '${convId}', '${JSON.stringify(
+        {
+          model_info: { model_id: "claude-sonnet-4.5" },
+          user_turn_metadata: {
+            continuation_id: convId,
+            requests: [
+              {
+                request_id: "sqlite-req-A",
+                message_id: msgA,
+                request_start_timestamp_ms: tsA,
+                user_prompt_length: 400,
+                response_size: 800,
+                model_id: "claude-sonnet-4.5",
+              },
+            ],
+          },
+        },
+      ).replace(/'/g, "''")}', 1, 2);`,
+    ]);
+
+    await rolloutModule.parseKiroCliIncremental({
+      cursors,
+      queuePath,
+      env,
+    });
+
+    // Cursor: A's session-file key retracted, SQLite key added. B's
+    // session-file key remains (it has NOT migrated).
+    const keys = Object.keys(cursors.kiroCli.requests);
+    assert.ok(!keys.includes(`${convId}:10`), "turn A session-file cursor retracted");
+    assert.ok(keys.includes("sqlite-req-A"), "turn A SQLite cursor added");
+    assert.ok(
+      keys.includes(`${convId}:11`),
+      "turn B session-file cursor preserved (un-migrated, must survive)",
+    );
+
+    // Bucket totals: A (from SQLite) + B (from session file) = 100+60 in, 200+30 out.
+    const rows = (await fs.readFile(queuePath, "utf8"))
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    const latest = new Map();
+    for (const row of rows)
+      latest.set(`${row.source}|${row.model}|${row.hour_start}`, row);
+    let totIn = 0;
+    let totOut = 0;
+    for (const row of latest.values()) {
+      if (row.source !== "kiro") continue;
+      totIn += row.input_tokens || 0;
+      totOut += row.output_tokens || 0;
+    }
+    assert.equal(totIn, 160, "A (SQLite) + B (session-only) survive");
+    assert.equal(totOut, 230);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseKiroCliIncremental early-return path still runs cap + clamp (Bug-1)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kiro-early-"));
   try {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2559,7 +2559,8 @@ test("parseKiroCliIncremental aggregates user_turn_metadatas into half-hour kiro
   try {
     const sessionsDir = path.join(tmp, "sessions", "cli");
     await fs.mkdir(sessionsDir, { recursive: true });
-    const sessionId = "fixture-active-0000-0000-0000-000000000001";
+    // TASK-003: resolver filters to canonical UUID-shaped filenames.
+    const sessionId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaa1";
     const activeFixture = await fs.readFile(
       path.join(__dirname, "fixtures", "kiro-cli", "active-source.json"),
       "utf8",
@@ -2677,21 +2678,34 @@ test("resolveKiroCliSessionFiles includes both completed and live (.lock) sessio
   try {
     const sessionsDir = path.join(tmp, "sessions", "cli");
     await fs.mkdir(sessionsDir, { recursive: true });
+    // TASK-003: filenames must be canonical UUIDs to be picked up.
+    const doneUuid = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    const liveUuid = "dddddddd-dddd-dddd-dddd-dddddddddddd";
     // Completed session: .json only, no .lock
-    await fs.writeFile(path.join(sessionsDir, "done-0000.json"), "{}");
+    await fs.writeFile(path.join(sessionsDir, `${doneUuid}.json`), "{}");
     // Live session: .json + .lock
-    await fs.writeFile(path.join(sessionsDir, "live-0000.json"), "{}");
-    await fs.writeFile(path.join(sessionsDir, "live-0000.lock"), '{"pid":1}');
+    await fs.writeFile(path.join(sessionsDir, `${liveUuid}.json`), "{}");
+    await fs.writeFile(path.join(sessionsDir, `${liveUuid}.lock`), '{"pid":1}');
+    // Non-UUID files that must be skipped by the resolver
+    await fs.writeFile(path.join(sessionsDir, "notes.json"), "{}");
+    await fs.writeFile(path.join(sessionsDir, "foo.bak.json"), "{}");
 
     assert.ok(
       typeof rolloutModule.resolveKiroCliSessionFiles === "function",
       "resolveKiroCliSessionFiles must be exported from src/lib/rollout (TASK-002)",
     );
 
-    const files = rolloutModule.resolveKiroCliSessionFiles({ KIRO_HOME: tmp });
+    const files = rolloutModule.resolveKiroCliSessionFiles({
+      HOME: tmp,
+      KIRO_HOME: tmp,
+    });
     assert.equal(files.length, 2, "both completed and live sessions must be returned");
     const names = files.map((f) => path.basename(f)).sort();
-    assert.deepEqual(names, ["done-0000.json", "live-0000.json"]);
+    assert.deepEqual(
+      names,
+      [`${doneUuid}.json`, `${liveUuid}.json`],
+      "non-UUID files (notes.json, foo.bak.json) must be skipped",
+    );
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -2822,6 +2836,232 @@ test("parseKiroCliIncremental canonicalizes Bedrock model IDs and re-buckets on 
     // third identical run is again idempotent.
     const r4 = await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
     assert.equal(r4.eventsAggregated, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseKiroCliIncremental retracts orphan session-file contribution when a conversation migrates into SQLite (TASK-007 + D-1)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kiro-migrate-"));
+  try {
+    const dbPath = path.join(tmp, "data.sqlite3");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const sessionsDir = path.join(tmp, ".kiro", "sessions", "cli");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const convId = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    const env = { KIRO_CLI_DB_PATH: dbPath, HOME: tmp };
+
+    // Run 1: session-file only, stores cursor under `${convId}:42`.
+    await fs.writeFile(
+      path.join(sessionsDir, `${convId}.json`),
+      JSON.stringify({
+        session_id: convId,
+        session_state: {
+          rts_model_state: { model_info: { model_id: "claude-sonnet-4.5" } },
+          conversation_metadata: {
+            user_turn_metadatas: [
+              {
+                loop_id: { rand: 42 },
+                message_ids: ["m1"],
+                request_start_timestamp_ms: Date.parse(
+                  "2026-04-20T10:05:00.000Z",
+                ),
+                input_token_count: 100,
+                output_token_count: 200,
+              },
+            ],
+          },
+        },
+      }),
+    );
+    await fs.writeFile(path.join(sessionsDir, `${convId}.jsonl`), "");
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT, created_at INTEGER, updated_at INTEGER, PRIMARY KEY (key, conversation_id));",
+    ]);
+
+    const cursors = { version: 1 };
+    const r1 = await rolloutModule.parseKiroCliIncremental({
+      cursors,
+      queuePath,
+      env,
+    });
+    assert.equal(r1.eventsAggregated, 1);
+
+    // Run 2: SQLite now contains the conversation under conv_id=convId AND
+    // continuation_id=convId. The retraction pass must subtract the old
+    // session-file contribution before the SQLite row adds 100/200.
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO conversations_v2 VALUES ('proj', '${convId}', '${JSON.stringify(
+        {
+          model_info: { model_id: "claude-sonnet-4.5" },
+          user_turn_metadata: {
+            continuation_id: convId,
+            requests: [
+              {
+                request_id: "sqlite-req-0001",
+                message_id: "m1",
+                request_start_timestamp_ms: Date.parse(
+                  "2026-04-20T10:05:00.000Z",
+                ),
+                user_prompt_length: 400,
+                response_size: 800,
+                model_id: "claude-sonnet-4.5",
+              },
+            ],
+          },
+        },
+      ).replace(/'/g, "''")}', 1, 2);`,
+    ]);
+
+    await rolloutModule.parseKiroCliIncremental({
+      cursors,
+      queuePath,
+      env,
+    });
+    const keys = Object.keys(cursors.kiroCli.requests);
+    assert.ok(!keys.includes(`${convId}:42`), "session-file cursor retracted");
+    assert.ok(keys.includes("sqlite-req-0001"), "SQLite cursor present");
+
+    const rows = (await fs.readFile(queuePath, "utf8"))
+      .split("\n")
+      .filter((l) => l.trim())
+      .map((l) => JSON.parse(l));
+    const latest = new Map();
+    for (const row of rows)
+      latest.set(`${row.source}|${row.model}|${row.hour_start}`, row);
+    let totIn = 0;
+    let totOut = 0;
+    for (const row of latest.values()) {
+      if (row.source !== "kiro") continue;
+      totIn += row.input_tokens || 0;
+      totOut += row.output_tokens || 0;
+    }
+    assert.equal(totIn, 100, "one contribution survives, not two");
+    assert.equal(totOut, 200);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseKiroCliIncremental retracts no-loop_id session-file entries via session_id tag (Bug-2)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kiro-noloop-"));
+  try {
+    const dbPath = path.join(tmp, "data.sqlite3");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const sessionsDir = path.join(tmp, ".kiro", "sessions", "cli");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const convId = "11111111-1111-1111-1111-111111111111";
+    const msgId = "22222222-2222-2222-2222-222222222222";
+    const env = { KIRO_CLI_DB_PATH: dbPath, HOME: tmp };
+
+    // No loop_id → cursor key falls back to the bare message_id UUID.
+    await fs.writeFile(
+      path.join(sessionsDir, `${convId}.json`),
+      JSON.stringify({
+        session_id: convId,
+        session_state: {
+          rts_model_state: { model_info: { model_id: "claude-sonnet-4.5" } },
+          conversation_metadata: {
+            user_turn_metadatas: [
+              {
+                message_ids: [msgId],
+                request_start_timestamp_ms: Date.parse(
+                  "2026-04-20T10:05:00.000Z",
+                ),
+                input_token_count: 100,
+                output_token_count: 200,
+              },
+            ],
+          },
+        },
+      }),
+    );
+    await fs.writeFile(path.join(sessionsDir, `${convId}.jsonl`), "");
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT, created_at INTEGER, updated_at INTEGER, PRIMARY KEY (key, conversation_id));",
+    ]);
+
+    const cursors = { version: 1 };
+    await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
+    const firstCursor = cursors.kiroCli.requests;
+    assert.equal(Object.keys(firstCursor).length, 1);
+    const reqKey = Object.keys(firstCursor)[0];
+    assert.equal(reqKey.indexOf(":"), -1, "bare UUID has no colon");
+    assert.equal(firstCursor[reqKey].session_id, convId);
+
+    // Migration into SQLite
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO conversations_v2 VALUES ('proj', '${convId}', '${JSON.stringify(
+        {
+          model_info: { model_id: "claude-sonnet-4.5" },
+          user_turn_metadata: {
+            continuation_id: convId,
+            requests: [
+              {
+                request_id: "new-sqlite-req",
+                message_id: msgId,
+                request_start_timestamp_ms: Date.parse(
+                  "2026-04-20T10:05:00.000Z",
+                ),
+                user_prompt_length: 400,
+                response_size: 800,
+                model_id: "claude-sonnet-4.5",
+              },
+            ],
+          },
+        },
+      ).replace(/'/g, "''")}', 1, 2);`,
+    ]);
+    await rolloutModule.parseKiroCliIncremental({ cursors, queuePath, env });
+    const ks = Object.keys(cursors.kiroCli.requests);
+    assert.ok(!ks.includes(msgId), "no-colon cursor entry retracted via session_id tag");
+    assert.ok(ks.includes("new-sqlite-req"));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseKiroCliIncremental early-return path still runs cap + clamp (Bug-1)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-kiro-early-"));
+  try {
+    const dbPath = path.join(tmp, "data.sqlite3");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const env = { KIRO_CLI_DB_PATH: dbPath, HOME: tmp };
+    const staleIso = new Date(Date.now() - 200 * 24 * 3600 * 1000)
+      .toISOString()
+      .slice(0, 19) + ".000Z";
+    const freshIso = new Date(Date.now() - 5 * 24 * 3600 * 1000)
+      .toISOString()
+      .slice(0, 19) + ".000Z";
+    const cursors = {
+      version: 1,
+      kiroCli: {
+        requests: {
+          fresh: { fingerprint: "f", bucketStart: freshIso, model: "m", input_tokens: 1, output_tokens: 1 },
+          stale1: { fingerprint: "f", bucketStart: staleIso, model: "m", input_tokens: 1, output_tokens: 1 },
+          stale2: { fingerprint: "f", bucketStart: staleIso, model: "m", input_tokens: 1, output_tokens: 1 },
+        },
+      },
+    };
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      "CREATE TABLE conversations_v2 (key TEXT, conversation_id TEXT, value TEXT, created_at INTEGER, updated_at INTEGER, PRIMARY KEY (key, conversation_id));",
+    ]);
+    const r = await rolloutModule.parseKiroCliIncremental({
+      cursors,
+      queuePath,
+      env,
+    });
+    assert.equal(r.recordsProcessed, 0);
+    assert.deepEqual(
+      Object.keys(cursors.kiroCli.requests).sort(),
+      ["fresh"],
+      "cap must drop stale entries on the zero-flat early-return path",
+    );
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## PR Goal (one sentence)

Close three correctness gaps (SQLite-migration double-count, `loop_id.rand=0` coercion, timestamp drift across source tiers), add two resource bounds (cursor cap, streamed jsonl reads), and tighten six guard-rails — on top of `39c8f39`, keeping its Prompt attribution + `auto → null → kiro-cli-agent` logic intact.

## Scope

- `src/lib/rollout.js` — Kiro CLI parser only (no other parser touched; shared `enqueueTouchedBuckets` deliberately left untouched)
- `src/lib/diagnostics.js` — inline the Kiro CLI DB path resolver (drops `require('./rollout')` load cost on status/diagnostics)
- `src/commands/sync.js` — one-word progress-label change for consistency with Hermes
- `test/rollout-parser.test.js` — 3 new regression tests + UUID-shape alignment on 2 existing tests

Non-goals:
- Upstream's Prompt attribution via `turnPromptChars` is preserved
- Upstream's `auto → null → kiro-cli-agent` pricing routing is preserved
- No change to the merged `source='kiro'` contract or any other provider's code path

## Codex Context (required when requesting @codex review)

- **Delta since last Codex review:** one commit `bff9f2b` on top of `39c8f39`. 4 files, +544/-77.
- **Intended behavior / invariants:**
  1. A Kiro CLI turn gets counted exactly once whether it's read from session file, SQLite, or migrates from one to the other.
  2. Cursor size is bounded across time (90-day + 20k-entry cap).
  3. `sync` never blocks on a multi-MB `.jsonl` — reads are streamed.
  4. A negative `conversation_count` never reaches the queue.
  5. All Kiro CLI side effects stay inside the Kiro CLI code path; no cross-parser behavior change.
- **Edge cases covered:**
  - `loop_id.rand === 0` (integer zero preserved via `?? null` chain, not `|| null`)
  - No-`loop_id` turns (cursor key falls back to bare message_id UUID; retraction now matches via a stored `session_id` tag rather than colon-parse)
  - SQLite `conversation_id` column ≠ `user_turn_metadata.continuation_id` on observed data (both are extracted and both feed the migration-match set)
  - `flat.length === 0` after retraction (early-return path now runs cap + clamp via `clampAndCapKiroCliState`)
  - `.jsonl` truncated/deleted mid-read (try-catch around the `for await` returns partial instead of crashing sync)
  - Corrupt/empty `conversation_id` (typed non-empty string check before adding to `migratedConvIds`)
  - Half-hour boundary straddle between SQLite and session-file tiers (unified timestamp precedence on `request_start_timestamp_ms` → `start_timestamp` → `end_timestamp`)
- **Tests run:**
  ```
  node --test test/rollout-parser.test.js test/kiro-fallback.test.js test/model-breakdown.test.js test/status.test.js test/diagnostics.test.js
  # ℹ tests 71 · pass 71 · fail 0
  ```
  Plus one live sync against a real machine with 1,336+ historical SQLite requests and a live session file — no regression.
- **Known gaps / out of scope:**
  - No cursor-schema migration: legacy entries without a `session_id` tag still work via the colon-split fallback
  - Historical queue rows written under legacy `"auto"` model label (from syncs before upstream `39c8f39`) keep their old composer-1 pricing; new rows correctly route to `kiro-cli-agent`
  - No streaming for the `.json` session-state file itself (it's a bounded state struct, typically <100 KB)

## Risk Layer Trigger (if any)

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [x] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Layer Addendum

### Rules / Invariants

- **Shared queue writer (`enqueueTouchedBuckets`) is untouched.** The TASK-010 conversation_count clamp was narrowed to Kiro's `touchedBuckets` Set inside `parseKiroCliIncremental`, not the cross-parser flush function. Verified with `git diff bff9f2b -- src/lib/rollout.js` showing zero changes in lines 1131-1424.
- **`source='kiro'` merge contract preserved.** Every emitted queue entry from the Kiro CLI path uses `source='kiro'`; the model field is the only runtime differentiator between IDE and CLI rows.
- **Cursor schema is backward compatible.** New entries carry an optional `session_id` tag; old entries without the tag are still retracted via the colon-split fallback.

### Boundary Matrix

1. **SQLite-only install (no session file):** retraction pass runs but `migratedConvIds` only contains IDs that match no cursor entries → no retraction fires, main loop processes normally. Regression-test-equivalent coverage: existing tests that only use SQLite data.
2. **Session-file-only install (no SQLite):** `flatDb = []`, `migratedConvIds` empty, retraction skipped, session-file turns flow through the main loop. Covered by existing upstream test "aggregates user_turn_metadatas into half-hour kiro buckets".
3. **Migration event (session file + SQLite for same conversation):** retraction fires, prior session-file contribution subtracted, new SQLite row added. Covered by the new "retracts orphan session-file contribution when a conversation migrates into SQLite" test with both `conversation_id` and `continuation_id` matching.
4. **Migration event with bare-UUID cursor key (no-loop_id fallback):** retraction matches via `session_id` tag instead of colon-split. Covered by the new "retracts no-loop_id session-file entries via session_id tag" test.
5. **Empty-flat post-retraction (session file removed between syncs):** `flat.length === 0` early-return now runs clamp + cap. Covered by the new "early-return path still runs cap + clamp" test.

### Evidence (tests or repro)

- 3 new tests in `test/rollout-parser.test.js` cover the 3 boundary cases that ship new behavior.
- Live sync on a machine with 1,336 historical SQLite requests + a live session file: all numbers match expected distribution across `claude-opus-4.6`, `claude-sonnet-4.5`, and the `kiro-cli-agent` fallback.
- `grep` of the diff confirms `enqueueTouchedBuckets` is untouched.

## Public Exposure Checklist

- [x] N/A — no public-exposure surface added.

## Regression Test Gate

### Most likely regression surface

- `parseKiroCliIncremental` main loop + retraction pass ordering. Specifically: retraction must run BEFORE the main loop and the cap must run AFTER both; otherwise active entries get pruned or orphans re-fire.

### Verification method

- [x] Unit test — 3 new tests cover retraction (two variants) and early-return cap
- [x] Live smoke — fresh cursor-reset sync on a real machine with 1,336 SQLite requests; aggregated totals match pre-change distribution within approximation tolerance
- [x] Structural diff — `git diff bff9f2b -- src/lib/rollout.js` confirms no edits outside the Kiro CLI section and no edits to `enqueueTouchedBuckets`

### Uncovered scope

- No test for the streamed-jsonl RSS bound (the plan's TASK-005 AC had a 10 MB fixture claim; skipped to keep the test runtime short)
- No test for the `TOKENTRACKER_DEBUG` stderr log paths (TASK-012 / D-8) — structural grep-based test not added in this round

## Itemized change list

| # | Task | Change | File / location |
|---|---|---|---|
| 1 | TASK-007 + D-1 | Cross-source retraction subtracts orphan session-file cursor entry when its `session_id` matches a migrated SQLite `conversation_id` OR `continuation_id`; drops matching `flatSessions` entries via O(N) filter. | `src/lib/rollout.js` — `readKiroCliRequests` (add `continuation_id` extract); `parseKiroCliIncremental` (new retraction block before `flat = flatDb.concat(flatSessions)`) |
| 2 | TASK-001 | Preserve integer 0 in `loop_id.rand` via `?? null ?? null ?? null` chain. Prevents cursor key from silently collapsing to message_id fallback. | `readKiroCliSessionTurns` |
| 3 | TASK-003 | Resolver filters filenames to canonical 8-4-4-4-12 hex UUID shape. Backup files, scratch, and typos are skipped instead of fed to `JSON.parse`. | `resolveKiroCliSessionFiles` + `KIRO_CLI_SESSION_FILE_RE` |
| 4 | TASK-004 | Cursor cap: drop entries older than 90 days by `bucketStart`, then keep the most recent 20k if still over. Runs after retraction + main merge so no active or just-retracted entry is pruned. | `clampAndCapKiroCliState` helper |
| 5 | TASK-005 | `readKiroCliMessageChars` is async and reads the `.jsonl` via `readline` over `createReadStream` — no whole-file buffer. | `readKiroCliMessageChars`, plus async ripple through `readKiroCliSessionTurns` and the session-file loop in `parseKiroCliIncremental` |
| 6 | TASK-006 | Timestamp precedence: `request_start_timestamp_ms` → `start_timestamp` → `end_timestamp`. Previously `end_timestamp || start_timestamp` would bucket a boundary-straddling turn differently from the SQLite tier. | `readKiroCliSessionTurns` |
| 7 | TASK-010 | Narrow `conversation_count` clamp to Kiro's `touchedBuckets` set — the shared `enqueueTouchedBuckets` is left untouched so legitimate negatives from other parsers (Claude, Codex, Gemini, Hermes, Kimi, Copilot, Cursor, Opencode, Openclaw, Kiro IDE) are never masked. | `clampAndCapKiroCliState` helper |
| 8 | TASK-011 | Inline the Kiro CLI DB path computation in `diagnostics.js` to drop `require('./rollout')`. | `src/lib/diagnostics.js` — new `resolveKiroCliDbPathInline` |
| 9 | TASK-012 + D-8 | `readKiroCliRequests` logs `sqlite3` spawn failures under `TOKENTRACKER_DEBUG=1` (previously silent `[]` was indistinguishable from an empty DB). `env` is threaded from the call site so tests can toggle hermetically. | `readKiroCliRequests` |
| 10 | TASK-013 | Kiro CLI sync progress label: `convs` → `sessions` (matches Hermes's wording). | `src/commands/sync.js` |
| 11 | TASK-014 | `resolveKiroCliSessionFiles` honors `env.HOME` (symmetric with `resolveKiroCliDbPath`). Hermetic testing/CI now works. | `resolveKiroCliSessionFiles` |
| 12 | Bug-1 | Extract clamp + cap into a helper; call it from BOTH the main path AND the `flat.length === 0` early-return path (previously skipped, leaving negatives in the queue and stale cursor entries alive). | `parseKiroCliIncremental` (both exit sites) |
| 13 | Bug-2 | Tag session-origin cursor entries with `session_id` so retraction can match them regardless of `request_id` shape. Colon-parse kept as legacy fallback for pre-tag cursor entries. | `readKiroCliSessionTurns` push + cursor write + retraction read |
| 14 | Bug-5 | Wrap the streamed iteration in try-catch. Mid-read errors return partial data instead of crashing sync. | `readKiroCliMessageChars` |
| 15 | D-6 | `typeof === "string" && length > 0` check on `conversation_id` / `continuation_id` before adding to the migration-match set. | retraction block |
| 16 | D-14 | Replace O(N²) reverse `splice`-in-loop over `flatSessions` with one O(N) `filter` pass during retraction. | retraction block |

## Live verification

```
tokentracker sync

Sync finished:
- Parsed files: 11917
- New 30-min buckets queued: 12
- Uploaded: skipped (no device token)

# Kiro models after sync (deduped latest-wins):
  claude-opus-4.6           in=238,920  out=873,976  convs=4,632
  claude-sonnet-4.5         in=  2,003  out=  8,785  convs=   15
  kiro-cli-agent            in=  5,613  out= 32,519  convs=  182
  (plus legacy "auto" and "kiro-auto" rows from pre-merge syncs)
```