### PR TITLE
[codex] Use neutral inactive heatmap cells

### DIFF
--- a/dashboard/src/ui/matrix-a/components/ActivityHeatmap.jsx
+++ b/dashboard/src/ui/matrix-a/components/ActivityHeatmap.jsx
@@ -8,7 +8,7 @@ const CELL_GAP = 3;
 const LABEL_WIDTH = 26;
 
 const HEATMAP_COLORS_LIGHT = [
-  "#ecfdf5", // level 0
+  "#ebedf0", // level 0 - inactive, GitHub-style neutral
   "#a7f3d0", // level 1
   "#6ee7b7", // level 2
   "#34d399", // level 3
@@ -16,7 +16,7 @@ const HEATMAP_COLORS_LIGHT = [
 ];
 
 const HEATMAP_COLORS_DARK = [
-  "#064e3b", // level 0 - darkest emerald
+  "#30363d", // level 0 - inactive, GitHub-style neutral
   "#065f46", // level 1
   "#059669", // level 2
   "#10b981", // level 3


### PR DESCRIPTION
# PR Goal (one sentence)

Make inactive Activity Heatmap cells neutral gray so token activity is the only green signal.

## Scope

- Change the Dashboard Activity Heatmap level-0 palette from green to neutral gray in light and dark themes.
- Keep active levels 1-4 on the existing green scale.
- No data, API, copy, or layout behavior changes.

## Codex Context (required when requesting @codex review)

- **Delta since last Codex review:** One small dashboard color-palette change in `ActivityHeatmap.jsx`.
- **Intended behavior / invariants:** Empty/no-token days render as neutral inactive cells; days with token activity still render as green intensity levels.
- **Edge cases covered:** Dark theme keeps inactive cells neutral instead of emerald, while active cells remain visually distinct.
- **Tests run (command + result):** `node --test test/dashboard-layout-adjustments.test.js test/visual-baselines.test.js` -> 13 passed.
- **Known gaps / out of scope:** No visual baseline image update; this only adjusts component palette constants.

## Risk Layer Trigger (if any)

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Public Exposure Checklist (if applicable)

- [x] Mark N/A if no public exposure

## Regression Test Gate

### Most likely regression surface

Activity Heatmap visual contrast in light and dark themes.

### Verification method (choose at least one)

- [x] Focused node test coverage for dashboard layout and visual-baseline config presence.
- [x] Local dashboard preview at `http://127.0.0.1:5173/`.

### Uncovered scope

No screenshot baseline was regenerated for this palette-only change.
