### PR TITLE
fix(hermes): track real-time token updates for active sessions

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -2952,10 +2952,13 @@ function resolveHermesDbPath() {
   return path.join(home, ".hermes", "state.db");
 }
 
-function readHermesSessions(dbPath, sinceEpoch) {
+function readHermesSessions(dbPath, lastCompletedEpoch) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
-  const since = Number.isFinite(sinceEpoch) && sinceEpoch > 0 ? sinceEpoch : 0;
-  const sql = `SELECT id, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count FROM sessions WHERE started_at > ${since} AND (input_tokens > 0 OR output_tokens > 0 OR cache_read_tokens > 0 OR reasoning_tokens > 0) ORDER BY started_at ASC`;
+  const since = Number.isFinite(lastCompletedEpoch) && lastCompletedEpoch > 0 ? lastCompletedEpoch : 0;
+  // Fetch sessions that started after the cursor, OR sessions that are still
+  // in-progress (ended_at IS NULL).  Hermes updates token counts in real-time,
+  // so an active session keeps growing and must be re-read on every sync.
+  const sql = `SELECT id, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count FROM sessions WHERE (started_at > ${since} OR ended_at IS NULL) AND (input_tokens > 0 OR output_tokens > 0 OR cache_read_tokens > 0 OR reasoning_tokens > 0) ORDER BY started_at ASC`;
   let raw;
   try {
     raw = cp.execFileSync("sqlite3", ["-json", dbPath, sql], {
@@ -2979,17 +2982,25 @@ function readHermesSessions(dbPath, sinceEpoch) {
 async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }) {
   await ensureDir(path.dirname(queuePath));
   const hermesState = cursors.hermes && typeof cursors.hermes === "object" ? cursors.hermes : {};
-  const lastStartedAt =
-    typeof hermesState.lastStartedAt === "number" ? hermesState.lastStartedAt : 0;
+
+  // Only advance past sessions that have fully ended.  Active sessions
+  // (ended_at IS NULL) must be re-read every sync because Hermes updates
+  // their token counts in real-time after each turn.
+  const lastCompletedStartedAt =
+    typeof hermesState.lastCompletedStartedAt === "number" ? hermesState.lastCompletedStartedAt : 0;
+
+  // Per-session snapshot from the previous sync: { [sessionId]: { in, out, cacheRead, cacheWrite, reasoning } }
+  const prevSnapshots = (hermesState.snapshots && typeof hermesState.snapshots === "object")
+    ? hermesState.snapshots : {};
 
   const resolvedDbPath = dbPath || resolveHermesDbPath();
   if (!fssync.existsSync(resolvedDbPath)) {
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
 
-  const rows = readHermesSessions(resolvedDbPath, lastStartedAt);
+  const rows = readHermesSessions(resolvedDbPath, lastCompletedStartedAt);
   if (rows.length === 0) {
-    cursors.hermes = { ...hermesState, lastStartedAt, updatedAt: new Date().toISOString() };
+    cursors.hermes = { ...hermesState, lastCompletedStartedAt, updatedAt: new Date().toISOString() };
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
 
@@ -2997,7 +3008,8 @@ async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }
   const touchedBuckets = new Set();
   const cb = typeof onProgress === "function" ? onProgress : null;
   let eventsAggregated = 0;
-  let maxStartedAt = lastStartedAt;
+  let maxCompletedStartedAt = lastCompletedStartedAt;
+  const nextSnapshots = {};
 
   for (let i = 0; i < rows.length; i++) {
     const row = rows[i];
@@ -3007,6 +3019,28 @@ async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }
     const cacheWrite = toNonNegativeInt(row.cache_write_tokens);
     const reasoning = toNonNegativeInt(row.reasoning_tokens);
     if (inputTokens === 0 && outputTokens === 0 && cacheRead === 0 && reasoning === 0) continue;
+
+    // Save current snapshot for next sync
+    nextSnapshots[row.id] = { in: inputTokens, out: outputTokens, cacheRead, cacheWrite, reasoning };
+
+    // Compute delta from previous snapshot (if any) so that we only count
+    // new tokens since the last sync.  First time we see a session the
+    // previous snapshot is absent, so the full amount is the delta.
+    const prev = prevSnapshots[row.id];
+    let dInput = inputTokens;
+    let dOutput = outputTokens;
+    let dCacheRead = cacheRead;
+    let dCacheWrite = cacheWrite;
+    let dReasoning = reasoning;
+    if (prev) {
+      dInput = Math.max(0, inputTokens - (prev.in || 0));
+      dOutput = Math.max(0, outputTokens - (prev.out || 0));
+      dCacheRead = Math.max(0, cacheRead - (prev.cacheRead || 0));
+      dCacheWrite = Math.max(0, cacheWrite - (prev.cacheWrite || 0));
+      dReasoning = Math.max(0, reasoning - (prev.reasoning || 0));
+    }
+    // Skip if delta is zero (session unchanged since last sync)
+    if (dInput === 0 && dOutput === 0 && dCacheRead === 0 && dCacheWrite === 0 && dReasoning === 0) continue;
 
     // Prefer ended_at for bucket placement; fall back to started_at
     const epochSec = row.ended_at || row.started_at;
@@ -3018,12 +3052,12 @@ async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }
     const model = normalizeModelInput(row.model) || "hermes-agent";
 
     const delta = {
-      input_tokens: inputTokens,
-      cached_input_tokens: cacheRead,
-      cache_creation_input_tokens: cacheWrite,
-      output_tokens: outputTokens,
-      reasoning_output_tokens: reasoning,
-      total_tokens: inputTokens + outputTokens + cacheRead + cacheWrite + reasoning,
+      input_tokens: dInput,
+      cached_input_tokens: dCacheRead,
+      cache_creation_input_tokens: dCacheWrite,
+      output_tokens: dOutput,
+      reasoning_output_tokens: dReasoning,
+      total_tokens: dInput + dOutput + dCacheRead + dCacheWrite + dReasoning,
       conversation_count: toNonNegativeInt(row.message_count) || 1,
     };
 
@@ -3032,7 +3066,10 @@ async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }
     touchedBuckets.add(bucketKey("hermes", model, bucketStart));
     eventsAggregated++;
 
-    if (row.started_at > maxStartedAt) maxStartedAt = row.started_at;
+    // Only advance cursor past sessions that have ended
+    if (row.ended_at && row.started_at > maxCompletedStartedAt) {
+      maxCompletedStartedAt = row.started_at;
+    }
 
     if (cb) {
       cb({
@@ -3049,7 +3086,13 @@ async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }
   const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
   cursors.hourly = hourlyState;
-  cursors.hermes = { ...hermesState, lastStartedAt: maxStartedAt, updatedAt };
+  cursors.hermes = {
+    ...hermesState,
+    lastStartedAt: maxCompletedStartedAt, // keep for backward compat
+    lastCompletedStartedAt: maxCompletedStartedAt,
+    snapshots: nextSnapshots,
+    updatedAt,
+  };
 
   return { recordsProcessed: rows.length, eventsAggregated, bucketsQueued };
 }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2590,6 +2590,130 @@ test("parseHermesIncremental skips sessions with zero tokens", async () => {
   }
 });
 
+test("parseHermesIncremental tracks real-time token growth for active sessions (ended_at IS NULL)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-"));
+  try {
+    const dbPath = path.join(tmp, "state.db");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+
+    const epoch1 = 1775993779.0; // 2026-04-12T11:36:19Z
+
+    // Start with one completed session and one active (no ended_at)
+    createHermesDb(dbPath, [
+      { id: "sess_done", model: "gpt-5.4-mini", started_at: epoch1, ended_at: epoch1 + 120, input_tokens: 1000, output_tokens: 500, cache_read_tokens: 200, message_count: 4 },
+      { id: "sess_active", model: "claude-sonnet-4-6", started_at: epoch1 + 200, ended_at: null, input_tokens: 5000, output_tokens: 200, cache_read_tokens: 1000, message_count: 5 },
+    ]);
+
+    // First parse — both sessions processed
+    const first = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(first.recordsProcessed, 2);
+    assert.equal(first.eventsAggregated, 2);
+
+    // Cursor should have snapshots for both sessions
+    assert.ok(cursors.hermes.snapshots);
+    assert.equal(cursors.hermes.snapshots["sess_active"].in, 5000);
+    assert.equal(cursors.hermes.snapshots["sess_done"].in, 1000);
+
+    // Cursor only advances past completed sessions
+    assert.equal(cursors.hermes.lastCompletedStartedAt, epoch1);
+
+    // Simulate Hermes updating the active session in real-time
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `UPDATE sessions SET input_tokens = 8000, output_tokens = 400, cache_read_tokens = 2000, message_count = 10 WHERE id = 'sess_active';`,
+    ]);
+
+    // Second parse — should pick up the delta for the active session
+    const second = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.recordsProcessed, 1); // only the active session re-read
+    assert.equal(second.eventsAggregated, 1);
+
+    // Verify the delta was computed correctly
+    // queue.jsonl accumulates lines per sync; the last line for this model
+    // holds the running total (first full + subsequent deltas).
+    const queued2 = await readJsonLines(queuePath);
+    const activeBuckets = queued2.filter((b) => b.source === "hermes" && b.model === "claude-sonnet-4-6");
+    const activeBucket = activeBuckets[activeBuckets.length - 1];
+    assert.ok(activeBucket);
+    assert.equal(activeBucket.input_tokens, 8000);
+    assert.equal(activeBucket.output_tokens, 400);
+    assert.equal(activeBucket.cached_input_tokens, 2000);
+
+    // Snapshot should be updated
+    assert.equal(cursors.hermes.snapshots["sess_active"].in, 8000);
+    assert.equal(cursors.hermes.snapshots["sess_active"].out, 400);
+
+    // Cursor still hasn't advanced past the active session
+    assert.equal(cursors.hermes.lastCompletedStartedAt, epoch1);
+
+    // Now end the active session
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `UPDATE sessions SET ended_at = ${epoch1 + 600}, input_tokens = 10000, output_tokens = 600, cache_read_tokens = 3000 WHERE id = 'sess_active';`,
+    ]);
+
+    const third = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(third.recordsProcessed, 1);
+    assert.equal(third.eventsAggregated, 1);
+
+    // Now cursor should advance past the ended session
+    assert.equal(cursors.hermes.lastCompletedStartedAt, epoch1 + 200);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseHermesIncremental skips active session when delta is zero (unchanged)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-"));
+  try {
+    const dbPath = path.join(tmp, "state.db");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+
+    const epoch1 = 1775993779.0;
+    createHermesDb(dbPath, [
+      { id: "sess_active", model: "gpt-5.4-mini", started_at: epoch1, ended_at: null, input_tokens: 5000, output_tokens: 200, message_count: 5 },
+    ]);
+
+    // First parse
+    const first = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(first.eventsAggregated, 1);
+
+    // Second parse without any changes — should be no-op
+    const second = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseHermesIncremental backward compat: old cursor without snapshots", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-"));
+  try {
+    const dbPath = path.join(tmp, "state.db");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    // Old-style cursor with lastStartedAt but no snapshots
+    const cursors = { version: 1, hermes: { lastStartedAt: 0, updatedAt: "2026-04-12T00:00:00Z" } };
+
+    const epoch1 = 1775993779.0;
+    createHermesDb(dbPath, [
+      { id: "sess_001", model: "gpt-5.4-mini", started_at: epoch1, ended_at: epoch1 + 120, input_tokens: 1000, output_tokens: 500, message_count: 4 },
+    ]);
+
+    const result = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(result.eventsAggregated, 1);
+    // Should have created snapshots
+    assert.ok(cursors.hermes.snapshots);
+    assert.equal(cursors.hermes.snapshots["sess_001"].in, 1000);
+    // New cursor field
+    assert.equal(cursors.hermes.lastCompletedStartedAt, epoch1);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 // ── GitHub Copilot OTEL parser tests ──
 
 function writeCopilotOtelFile(filePath, spans) {


### PR DESCRIPTION
## Problem

TokenTracker significantly under-reports Hermes Agent token usage for active (in-progress) sessions.

Hermes writes real-time token counts to `~/.hermes/state.db` after every turn — the `input_tokens`, `output_tokens`, `cache_read_tokens` etc. columns are continuously updated even while a session is still running (`ended_at IS NULL`). However, the current Hermes parser has two bugs:

### Bug 1: Active sessions are skipped after the cursor advances

The SQL query uses `WHERE started_at > ${cursor}`. After the first sync reads an active session, the cursor jumps to its `started_at` value. All subsequent syncs skip that session entirely, so token growth from continued conversation is never captured.

**Example:** A session starts at 19:56 and runs for 39 minutes. The first sync reads 100K tokens. By the time it ends at 20:35, it has accumulated 950K input tokens. TokenTracker only ever records the 100K snapshot.

### Bug 2: No delta computation causes double-counting

If a session is somehow re-read (e.g. after a cursor reset), the full cumulative token count is added again as if it were new usage, leading to inflated numbers.

---

## Fix

### 1. Include active sessions in every sync

```sql
-- Before
WHERE started_at > ${cursor}

-- After
WHERE (started_at > ${cursor} OR ended_at IS NULL)
```

Active sessions (`ended_at IS NULL`) are now re-fetched on every sync regardless of cursor position.

### 2. Per-session snapshot delta

A `snapshots` object is stored in `cursors.hermes` mapping session IDs to their last-seen token counts:

```json
{
  "session_abc": { "in": 950000, "out": 17931, "cacheRead": 4421120, ... }
}
```

On each sync, only the difference (`current - snapshot`) is emitted as a new delta. First-time sessions with no prior snapshot emit their full amount. Sessions with zero delta are skipped entirely.

### 3. Cursor only advances past completed sessions

The cursor is renamed to `lastCompletedStartedAt` and only updates when `row.ended_at` is non-NULL. Active sessions remain within the query window until they end.

---

## Backward Compatibility

- Old cursors that lack `lastCompletedStartedAt` or `snapshots` gracefully fall back to `0` / `{}`, so the first run after upgrade performs a full scan with correct delta logic from that point forward.
- The old `lastStartedAt` key is still written (with the same value) for any external code that may read it.

---

## Testing

Verified against live data on macOS:

| Source | Input Tokens | Output Tokens | Cache Read |
|---|---|---|---|
| `state.db` (ground truth) | 2,287,702 | 41,168 | 6,454,912 |
| TokenTracker **before** fix | ~348K | ~5K | ~215K |
| TokenTracker **after** fix | matches | matches | matches |

After fix, running `tokentracker sync` while a session is active correctly captures only the incremental tokens since the previous sync.

Added 3 new unit tests (88/88 pass):
- `tracks real-time token growth for active sessions` — full lifecycle: active → grows → ends
- `skips active session when delta is zero` — no spurious re-counting
- `backward compat: old cursor without snapshots` — migration from old cursor format

---

## Files Changed

- `src/lib/rollout.js` — `readHermesSessions()` and `parseHermesIncremental()`
- `test/rollout-parser.test.js` — 3 new test cases
