### PR TITLE
feat(pi): add support for @mariozechner/pi-coding-agent sessions

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -403,6 +403,7 @@ leaderboard.column.copilot,dashboard,LeaderboardPage,LeaderboardPage,column_copi
 leaderboard.column.kimi,dashboard,LeaderboardPage,LeaderboardPage,column_kimi,"Kimi Code",,active
 leaderboard.column.codebuddy,dashboard,LeaderboardPage,LeaderboardPage,column_codebuddy,"CodeBuddy",,active
 leaderboard.column.omp,dashboard,LeaderboardPage,LeaderboardPage,column_omp,"oh-my-pi",,active
+leaderboard.column.pi,dashboard,LeaderboardPage,LeaderboardPage,column_pi,"pi",,active
 limits.copilot.otelHint.title,dashboard,LimitsPage,LimitsPage,otel_hint_title,"Track Copilot token usage",,active
 limits.copilot.otelHint.body,dashboard,LimitsPage,LimitsPage,otel_hint_body,"Limits load via your GitHub OAuth token. To also record per-token usage, enable Copilot's OpenTelemetry export and add these lines to your shell profile (~/.zshrc or ~/.bashrc):",,active
 limits.copilot.otelHint.copy,dashboard,LimitsPage,LimitsPage,otel_hint_copy,"Copy",,active

--- a/dashboard/src/ui/matrix-a/components/ProviderIcon.jsx
+++ b/dashboard/src/ui/matrix-a/components/ProviderIcon.jsx
@@ -158,6 +158,16 @@ function OmpIcon({ size = 16, className = "" }) {
   );
 }
 
+function PiIcon({ size = 16, className = "" }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 120 90" fill="currentColor" className={className}>
+      <rect x="10" y="8" width="100" height="12" rx="2" />
+      <rect x="25" y="20" width="12" height="62" rx="2" />
+      <rect x="83" y="20" width="12" height="62" rx="2" />
+    </svg>
+  );
+}
+
 const PROVIDER_ICON_MAP = {
   CLAUDE: ClaudeIcon,
   CODEBUDDY: CodeBuddyIcon,
@@ -172,6 +182,7 @@ const PROVIDER_ICON_MAP = {
   KIRO: KiroIcon,
   OPENCODE: OpenCodeIcon,
   OMP: OmpIcon,
+  PI: PiIcon,
 };
 
 // Multi-color brand SVG assets in /public/brand-logos/. Only logos that have

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tokentracker-cli",
   "version": "0.6.7",
-  "description": "Token usage tracker for AI agent CLIs (Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, OpenClaw, Every Code, Hermes, GitHub Copilot, Kimi Code, CodeBuddy, oh-my-pi, Craft Agents)",
+  "description": "Token usage tracker for AI agent CLIs (Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, OpenClaw, Every Code, Hermes, GitHub Copilot, Kimi Code, CodeBuddy, oh-my-pi, pi, Craft Agents)",
   "main": "src/cli.js",
   "bin": {
     "tokentracker-cli": "bin/tracker.js",

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -44,6 +44,7 @@ const {
   probeOpenclawSessionPluginState,
 } = require("../lib/openclaw-session-plugin");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
+const { resolvePiAgentDir } = require("../lib/rollout");
 const { resolveRuntimeConfig, DEFAULT_BASE_URL } = require("../lib/runtime-config");
 const {
   BOLD,
@@ -430,10 +431,18 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
   {
     const ompHome = process.env.OMP_HOME ||
       (process.env.PI_CONFIG_DIR ? path.join(home, process.env.PI_CONFIG_DIR) : path.join(home, ".omp"));
-    const ompAgentDir = process.env.PI_CODING_AGENT_DIR || path.join(ompHome, "agent");
-    const ompSessions = path.join(ompAgentDir, "sessions");
+    const ompSessions = path.join(ompHome, "agent", "sessions");
     if (fssync.existsSync(ompSessions)) {
       summary.push({ label: "oh-my-pi", status: "detected", detail: "Passive reader (no hook needed)" });
+    }
+  }
+
+  // pi (@mariozechner/pi-coding-agent): passive reader — no hook installation needed.
+  // TokenTracker reads ~/.pi/agent/sessions/**/*.jsonl directly.
+  {
+    const piSessions = path.join(resolvePiAgentDir(process.env), "sessions");
+    if (fssync.existsSync(piSessions)) {
+      summary.push({ label: "pi", status: "detected", detail: "Passive reader (no hook needed)" });
     }
   }
 

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -44,7 +44,11 @@ const {
   probeOpenclawSessionPluginState,
 } = require("../lib/openclaw-session-plugin");
 const { resolveTrackerPaths } = require("../lib/tracker-paths");
-const { resolvePiAgentDir } = require("../lib/rollout");
+const {
+  resolveOmpAgentDir,
+  resolvePiAgentDir,
+  piAgentDirCollidesWithOmp,
+} = require("../lib/rollout");
 const { resolveRuntimeConfig, DEFAULT_BASE_URL } = require("../lib/runtime-config");
 const {
   BOLD,
@@ -429,17 +433,16 @@ async function applyIntegrationSetup({ home, trackerDir, notifyPath, notifyOrigi
   // oh-my-pi: passive reader — no hook installation needed.
   // TokenTracker reads ~/.omp/agent/sessions/**/*.jsonl directly.
   {
-    const ompHome = process.env.OMP_HOME ||
-      (process.env.PI_CONFIG_DIR ? path.join(home, process.env.PI_CONFIG_DIR) : path.join(home, ".omp"));
-    const ompSessions = path.join(ompHome, "agent", "sessions");
+    const ompSessions = path.join(resolveOmpAgentDir(process.env), "sessions");
     if (fssync.existsSync(ompSessions)) {
       summary.push({ label: "oh-my-pi", status: "detected", detail: "Passive reader (no hook needed)" });
     }
   }
 
   // pi (@mariozechner/pi-coding-agent): passive reader — no hook installation needed.
-  // TokenTracker reads ~/.pi/agent/sessions/**/*.jsonl directly.
-  {
+  // TokenTracker reads ~/.pi/agent/sessions/**/*.jsonl directly. Skip when its
+  // agent dir collides with omp's so the summary matches what sync will scan.
+  if (!piAgentDirCollidesWithOmp(process.env)) {
     const piSessions = path.join(resolvePiAgentDir(process.env), "sessions");
     if (fssync.existsSync(piSessions)) {
       summary.push({ label: "pi", status: "detected", detail: "Passive reader (no hook needed)" });

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -43,6 +43,7 @@ const {
   resolveOmpAgentDir,
   resolvePiSessionFiles,
   resolvePiAgentDir,
+  piAgentDirCollidesWithOmp,
   resolveCraftSessionFiles,
   resolveCraftConfigDir,
 } = require("../lib/rollout");
@@ -188,8 +189,10 @@ async function cmdStatus(argv = []) {
   const ompFiles = ompInstalled ? resolveOmpSessionFiles(process.env) : [];
 
   // pi (@mariozechner/pi-coding-agent) — passive scan only (no hooks).
+  // Skip when its agent dir collides with omp's; sync would dedupe anyway.
+  const piCollides = piAgentDirCollidesWithOmp(process.env);
   const piAgentDir = resolvePiAgentDir(process.env);
-  const piInstalled = fssync.existsSync(path.join(piAgentDir, "sessions"));
+  const piInstalled = !piCollides && fssync.existsSync(path.join(piAgentDir, "sessions"));
   const piFiles = piInstalled ? resolvePiSessionFiles(process.env) : [];
 
   // Craft Agents — passive scan only (no hooks).

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -41,6 +41,8 @@ const {
   resolveCodebuddyProjectFiles,
   resolveOmpSessionFiles,
   resolveOmpAgentDir,
+  resolvePiSessionFiles,
+  resolvePiAgentDir,
   resolveCraftSessionFiles,
   resolveCraftConfigDir,
 } = require("../lib/rollout");
@@ -185,6 +187,11 @@ async function cmdStatus(argv = []) {
   const ompInstalled = fssync.existsSync(path.join(ompAgentDir, "sessions"));
   const ompFiles = ompInstalled ? resolveOmpSessionFiles(process.env) : [];
 
+  // pi (@mariozechner/pi-coding-agent) — passive scan only (no hooks).
+  const piAgentDir = resolvePiAgentDir(process.env);
+  const piInstalled = fssync.existsSync(path.join(piAgentDir, "sessions"));
+  const piFiles = piInstalled ? resolvePiSessionFiles(process.env) : [];
+
   // Craft Agents — passive scan only (no hooks).
   const craftConfigDir = resolveCraftConfigDir(process.env);
   const craftInstalled = fssync.existsSync(craftConfigDir);
@@ -230,6 +237,9 @@ async function cmdStatus(argv = []) {
         : null,
       ompInstalled
         ? `- oh-my-pi: passive reader (${ompFiles.length} session jsonl file${ompFiles.length !== 1 ? "s" : ""} found)`
+        : null,
+      piInstalled
+        ? `- pi: passive reader (${piFiles.length} session jsonl file${piFiles.length !== 1 ? "s" : ""} found)`
         : null,
       craftInstalled
         ? `- Craft Agents: passive reader (${craftFiles.length} session jsonl file${craftFiles.length !== 1 ? "s" : ""} found)`

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -31,6 +31,7 @@ const {
   parseOmpIncremental,
   resolvePiSessionFiles,
   parsePiIncremental,
+  piAgentDirCollidesWithOmp,
   resolveCraftSessionFiles,
   parseCraftIncremental,
   resolveCodebuddyProjectFiles,
@@ -476,8 +477,13 @@ async function cmdSync(argv) {
     }
 
     // ── pi (@mariozechner/pi-coding-agent) — passive ~/.pi/agent/sessions/**/*.jsonl reader ──
+    // Skip pi parse if its agent dir resolves to the same path as omp's. This
+    // prevents double-counting when explicit overrides (TOKENTRACKER_OMP_AGENT_DIR /
+    // TOKENTRACKER_PI_AGENT_DIR) bypass the install-signal disambiguator.
     let piResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const piFiles = resolvePiSessionFiles(process.env);
+    const piFiles = piAgentDirCollidesWithOmp(process.env)
+      ? []
+      : resolvePiSessionFiles(process.env);
     if (piFiles.length > 0) {
       if (progress?.enabled) {
         progress.start(`Parsing pi ${renderBar(0)} | buckets 0`);

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -29,6 +29,8 @@ const {
   parseKimiIncremental,
   resolveOmpSessionFiles,
   parseOmpIncremental,
+  resolvePiSessionFiles,
+  parsePiIncremental,
   resolveCraftSessionFiles,
   parseCraftIncremental,
   resolveCodebuddyProjectFiles,
@@ -473,6 +475,28 @@ async function cmdSync(argv) {
       });
     }
 
+    // ── pi (@mariozechner/pi-coding-agent) — passive ~/.pi/agent/sessions/**/*.jsonl reader ──
+    let piResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+    const piFiles = resolvePiSessionFiles(process.env);
+    if (piFiles.length > 0) {
+      if (progress?.enabled) {
+        progress.start(`Parsing pi ${renderBar(0)} | buckets 0`);
+      }
+      piResult = await parsePiIncremental({
+        sessionFiles: piFiles,
+        cursors,
+        queuePath,
+        env: process.env,
+        onProgress: (p) => {
+          if (!progress?.enabled) return;
+          const pct = p.total > 0 ? p.index / p.total : 1;
+          progress.update(
+            `Parsing pi ${renderBar(pct)} ${formatNumber(p.index)}/${formatNumber(p.total)} files | buckets ${formatNumber(p.bucketsQueued)}`,
+          );
+        },
+      });
+    }
+
     // ── Craft Agents (passive ~/.craft-agent + workspaces session.jsonl reader) ──
     let craftResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     const craftFiles = resolveCraftSessionFiles(process.env);
@@ -615,6 +639,7 @@ async function cmdSync(argv) {
         kimiResult.recordsProcessed +
         codebuddyResult.recordsProcessed +
         ompResult.recordsProcessed +
+        piResult.recordsProcessed +
         craftResult.recordsProcessed +
         copilotResult.recordsProcessed;
       const totalBuckets =
@@ -630,6 +655,7 @@ async function cmdSync(argv) {
         kimiResult.bucketsQueued +
         codebuddyResult.bucketsQueued +
         ompResult.bucketsQueued +
+        piResult.bucketsQueued +
         craftResult.bucketsQueued +
         copilotResult.bucketsQueued;
       process.stdout.write(

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -4479,7 +4479,6 @@ function resolveOmpHome(env = process.env) {
 }
 
 function resolveOmpAgentDir(env = process.env) {
-  if (env.PI_CODING_AGENT_DIR) return env.PI_CODING_AGENT_DIR;
   return path.join(resolveOmpHome(env), "agent");
 }
 
@@ -4684,6 +4683,231 @@ async function parseOmpIncremental({
   cursors.hourly = hourlyState;
   cursors.omp = {
     ...ompState,
+    seenIds: cappedSeen,
+    fileOffsets,
+    updatedAt,
+  };
+
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// pi (@mariozechner/pi-coding-agent) — passive JSONL reader
+// (~/.pi/agent/sessions/**/*.jsonl)
+//
+// Same on-disk session format as oh-my-pi (omp): one JSONL file per session,
+// first line type:"session" header, then a tree of message/model_change/etc.
+// records. Token usage lives on type:"message" entries with role:"assistant"
+// under message.usage. Honors PI_CODING_AGENT_DIR to override the agent dir
+// (matches pi's own getAgentDir()).
+// ─────────────────────────────────────────────────────────────────────────────
+
+function resolvePiHome(env = process.env) {
+  const home = env.HOME || require("node:os").homedir();
+  return path.join(home, ".pi");
+}
+
+function resolvePiAgentDir(env = process.env) {
+  if (env.PI_CODING_AGENT_DIR) {
+    const dir = env.PI_CODING_AGENT_DIR;
+    if (dir.startsWith("~/")) {
+      return path.join(env.HOME || require("node:os").homedir(), dir.slice(2));
+    }
+    return dir;
+  }
+  return path.join(resolvePiHome(env), "agent");
+}
+
+function resolvePiSessionFiles(env = process.env) {
+  const sessionsDir = path.join(resolvePiAgentDir(env), "sessions");
+  if (!fssync.existsSync(sessionsDir)) return [];
+  const files = [];
+  try {
+    for (const cwdDir of fssync.readdirSync(sessionsDir)) {
+      const cwdPath = path.join(sessionsDir, cwdDir);
+      let stat;
+      try { stat = fssync.statSync(cwdPath); } catch { continue; }
+      if (!stat.isDirectory()) continue;
+      let entries;
+      try { entries = fssync.readdirSync(cwdPath); } catch { continue; }
+      for (const entry of entries) {
+        if (!entry.endsWith(".jsonl")) continue;
+        files.push(path.join(cwdPath, entry));
+      }
+    }
+  } catch {
+    // ignore — return what we have
+  }
+  files.sort((a, b) => a.localeCompare(b));
+  return files;
+}
+
+function resolvePiDefaultModel() {
+  // pi has no global default model; model is per-message.
+  return "pi-unknown";
+}
+
+async function parsePiIncremental({
+  sessionFiles,
+  cursors,
+  queuePath,
+  onProgress,
+  env,
+  defaultModel,
+} = {}) {
+  await ensureDir(path.dirname(queuePath));
+  const piState = cursors.pi && typeof cursors.pi === "object" ? cursors.pi : {};
+  const seenIds = new Set(Array.isArray(piState.seenIds) ? piState.seenIds : []);
+  const fileOffsets =
+    piState.fileOffsets && typeof piState.fileOffsets === "object"
+      ? { ...piState.fileOffsets }
+      : {};
+
+  const files = Array.isArray(sessionFiles)
+    ? sessionFiles
+    : resolvePiSessionFiles(env || process.env);
+  const fallbackModel = defaultModel || resolvePiDefaultModel();
+
+  if (files.length === 0) {
+    cursors.pi = {
+      ...piState,
+      seenIds: Array.from(seenIds),
+      fileOffsets,
+      updatedAt: new Date().toISOString(),
+    };
+    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
+  }
+
+  const hourlyState = normalizeHourlyState(cursors?.hourly);
+  const touchedBuckets = new Set();
+  const cb = typeof onProgress === "function" ? onProgress : null;
+  let recordsProcessed = 0;
+  let eventsAggregated = 0;
+
+  for (let fileIdx = 0; fileIdx < files.length; fileIdx++) {
+    const filePath = files[fileIdx];
+    let stat;
+    try { stat = fssync.statSync(filePath); } catch { continue; }
+
+    const prevEntry = fileOffsets[filePath] || {};
+    const prevSize = Number(prevEntry.size) || 0;
+    const prevIno = prevEntry.ino;
+    const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
+    const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
+    if (stat.size <= startOffset) continue;
+
+    let stream;
+    try {
+      stream = fssync.createReadStream(filePath, {
+        encoding: "utf8",
+        start: startOffset,
+      });
+    } catch { continue; }
+    const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+
+    for await (const line of rl) {
+      if (!line || !line.trim()) continue;
+      let entry;
+      try { entry = JSON.parse(line); } catch { continue; }
+
+      if (!entry || entry.type !== "message") continue;
+
+      const msg = entry.message;
+      if (!msg || msg.role !== "assistant") continue;
+
+      const usage = msg.usage;
+      if (!usage || typeof usage !== "object") continue;
+
+      const entryId = typeof entry.id === "string" && entry.id ? entry.id : null;
+      if (!entryId) continue;
+      if (seenIds.has(entryId)) continue;
+
+      recordsProcessed++;
+
+      const input = toNonNegativeInt(usage.input);
+      const output = toNonNegativeInt(usage.output);
+      const cacheRead = toNonNegativeInt(usage.cacheRead);
+      const cacheWrite = toNonNegativeInt(usage.cacheWrite);
+      const reasoningTokens = toNonNegativeInt(usage.reasoningTokens);
+
+      if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) {
+        seenIds.add(entryId);
+        continue;
+      }
+
+      let tsMs = null;
+      if (Number.isFinite(Number(msg.timestamp)) && Number(msg.timestamp) > 0) {
+        tsMs = Number(msg.timestamp);
+      } else if (typeof entry.timestamp === "string" && entry.timestamp) {
+        const parsed = Date.parse(entry.timestamp);
+        if (Number.isFinite(parsed) && parsed > 0) tsMs = parsed;
+      }
+      if (tsMs == null) {
+        seenIds.add(entryId);
+        continue;
+      }
+
+      const tsIso = new Date(tsMs).toISOString();
+      const bucketStart = toUtcHalfHourStart(tsIso);
+      if (!bucketStart) continue;
+
+      const totalTokens =
+        Number.isFinite(Number(usage.totalTokens)) && Number(usage.totalTokens) > 0
+          ? toNonNegativeInt(usage.totalTokens)
+          : input + output + cacheRead + cacheWrite + reasoningTokens;
+
+      const model = normalizeModelInput(msg.model) || fallbackModel;
+
+      const delta = {
+        input_tokens: input,
+        cached_input_tokens: cacheRead,
+        cache_creation_input_tokens: cacheWrite,
+        output_tokens: output,
+        reasoning_output_tokens: reasoningTokens,
+        total_tokens: totalTokens,
+        conversation_count: 1,
+      };
+
+      const bucket = getHourlyBucket(hourlyState, "pi", model, bucketStart);
+      addTotals(bucket.totals, delta);
+      touchedBuckets.add(bucketKey("pi", model, bucketStart));
+      seenIds.add(entryId);
+      eventsAggregated++;
+
+      if (cb) {
+        cb({
+          index: fileIdx + 1,
+          total: files.length,
+          recordsProcessed,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
+    }
+
+    let postStat = stat;
+    try { postStat = fssync.statSync(filePath); } catch {}
+    fileOffsets[filePath] = {
+      size: postStat.size,
+      mtimeMs: postStat.mtimeMs,
+      ino: postStat.ino,
+    };
+  }
+
+  const seenArr = Array.from(seenIds);
+  const cappedSeen =
+    seenArr.length > 10_000 ? seenArr.slice(seenArr.length - 10_000) : seenArr;
+
+  const bucketsQueued = await enqueueTouchedBuckets({
+    queuePath,
+    hourlyState,
+    touchedBuckets,
+  });
+  const updatedAt = new Date().toISOString();
+  hourlyState.updatedAt = updatedAt;
+  cursors.hourly = hourlyState;
+  cursors.pi = {
+    ...piState,
     seenIds: cappedSeen,
     fileOffsets,
     updatedAt,
@@ -5248,6 +5472,11 @@ module.exports = {
   resolveOmpSessionFiles,
   resolveOmpDefaultModel,
   parseOmpIncremental,
+  resolvePiHome,
+  resolvePiAgentDir,
+  resolvePiSessionFiles,
+  resolvePiDefaultModel,
+  parsePiIncremental,
   resolveCraftConfigDir,
   resolveCraftWorkspaceRoots,
   resolveCraftSessionFiles,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -4478,7 +4478,40 @@ function resolveOmpHome(env = process.env) {
   return path.join(home, ".omp");
 }
 
+// PI_CODING_AGENT_DIR is documented by both pi-coding-agent and oh-my-pi as
+// their agent directory override. When set, attribute it to whichever tool the
+// user actually has installed: ~/.pi present → "pi", otherwise "omp" (the
+// historical default in this codebase, preserved for back-compat).
+//
+// Users with both tools installed can disambiguate explicitly with
+// TOKENTRACKER_PI_AGENT_DIR / TOKENTRACKER_OMP_AGENT_DIR, which take
+// precedence in their respective resolvers.
+function decidePiCodingAgentDirOwner(env = process.env) {
+  const home = env.HOME || require("node:os").homedir();
+  // Require an actual directory — a stray file (lockfile, junk) at ~/.pi
+  // shouldn't reroute an existing oh-my-pi user's PI_CODING_AGENT_DIR override.
+  try {
+    if (fssync.statSync(path.join(home, ".pi")).isDirectory()) return "pi";
+  } catch {
+    // ENOENT or EACCES — treat as "no pi install signal".
+  }
+  return "omp";
+}
+
+function expandHomePath(dir, env = process.env) {
+  if (typeof dir !== "string" || !dir) return dir;
+  if (dir !== "~" && !dir.startsWith("~/")) return dir;
+  const home = env.HOME || require("node:os").homedir();
+  return dir === "~" ? home : path.join(home, dir.slice(2));
+}
+
 function resolveOmpAgentDir(env = process.env) {
+  if (env.TOKENTRACKER_OMP_AGENT_DIR) {
+    return expandHomePath(env.TOKENTRACKER_OMP_AGENT_DIR, env);
+  }
+  if (env.PI_CODING_AGENT_DIR && decidePiCodingAgentDirOwner(env) === "omp") {
+    return expandHomePath(env.PI_CODING_AGENT_DIR, env);
+  }
   return path.join(resolveOmpHome(env), "agent");
 }
 
@@ -4698,8 +4731,12 @@ async function parseOmpIncremental({
 // Same on-disk session format as oh-my-pi (omp): one JSONL file per session,
 // first line type:"session" header, then a tree of message/model_change/etc.
 // records. Token usage lives on type:"message" entries with role:"assistant"
-// under message.usage. Honors PI_CODING_AGENT_DIR to override the agent dir
-// (matches pi's own getAgentDir()).
+// under message.usage.
+//
+// PI_CODING_AGENT_DIR is shared with omp (both upstream tools document it).
+// resolvePiAgentDir / resolveOmpAgentDir use decidePiCodingAgentDirOwner to
+// route the override to exactly one provider so the same sessions dir is
+// never scanned twice.
 // ─────────────────────────────────────────────────────────────────────────────
 
 function resolvePiHome(env = process.env) {
@@ -4708,14 +4745,22 @@ function resolvePiHome(env = process.env) {
 }
 
 function resolvePiAgentDir(env = process.env) {
-  if (env.PI_CODING_AGENT_DIR) {
-    const dir = env.PI_CODING_AGENT_DIR;
-    if (dir.startsWith("~/")) {
-      return path.join(env.HOME || require("node:os").homedir(), dir.slice(2));
-    }
-    return dir;
+  if (env.TOKENTRACKER_PI_AGENT_DIR) {
+    return expandHomePath(env.TOKENTRACKER_PI_AGENT_DIR, env);
+  }
+  if (env.PI_CODING_AGENT_DIR && decidePiCodingAgentDirOwner(env) === "pi") {
+    return expandHomePath(env.PI_CODING_AGENT_DIR, env);
   }
   return path.join(resolvePiHome(env), "agent");
+}
+
+// Defense in depth for invariant 2 (no double-count). Two explicit overrides
+// pointing at the same path (e.g. TOKENTRACKER_OMP_AGENT_DIR === TOKENTRACKER_PI_AGENT_DIR,
+// or TOKENTRACKER_OMP_AGENT_DIR === PI_CODING_AGENT_DIR with ~/.pi present) bypass
+// the install-signal disambiguator and would otherwise have both providers scan
+// the same sessions directory under different `source` tags.
+function piAgentDirCollidesWithOmp(env = process.env) {
+  return path.resolve(resolvePiAgentDir(env)) === path.resolve(resolveOmpAgentDir(env));
 }
 
 function resolvePiSessionFiles(env = process.env) {
@@ -5477,6 +5522,7 @@ module.exports = {
   resolvePiSessionFiles,
   resolvePiDefaultModel,
   parsePiIncremental,
+  piAgentDirCollidesWithOmp,
   resolveCraftConfigDir,
   resolveCraftWorkspaceRoots,
   resolveCraftSessionFiles,

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -22,6 +22,8 @@ const {
   resolveOmpSessionFiles,
   parsePiIncremental,
   resolvePiSessionFiles,
+  resolvePiAgentDir,
+  piAgentDirCollidesWithOmp,
   parseCraftIncremental,
   resolveCraftSessionFiles,
   resolveCraftWorkspaceRoots,
@@ -4185,39 +4187,161 @@ test("resolvePiSessionFiles returns empty when ~/.pi/agent/sessions missing", as
   assert.deepEqual(result, []);
 });
 
-test("PI_CODING_AGENT_DIR env override redirects discovery", async () => {
+// PI_CODING_AGENT_DIR is documented by both pi-coding-agent and oh-my-pi.
+// Routing is decided by the install-signal disambiguator: ~/.pi present → pi,
+// otherwise omp (back-compat).
+
+test("PI_CODING_AGENT_DIR redirects pi discovery when ~/.pi install signal exists", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-home-"));
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-"));
   try {
+    await fs.mkdir(path.join(home, ".pi"), { recursive: true });
     const sessionsDir = path.join(tmp, "sessions", "--myproject--");
     await fs.mkdir(sessionsDir, { recursive: true });
     const filePath = path.join(sessionsDir, "session.jsonl");
     await fs.writeFile(filePath, buildOmpSessionHeader() + "\n", "utf8");
 
-    const result = resolvePiSessionFiles({ PI_CODING_AGENT_DIR: tmp });
+    const result = resolvePiSessionFiles({ HOME: home, PI_CODING_AGENT_DIR: tmp });
     assert.equal(result.length, 1);
     assert.ok(result[0].endsWith(".jsonl"));
   } finally {
+    await fs.rm(home, { recursive: true, force: true });
     await fs.rm(tmp, { recursive: true, force: true });
   }
 });
 
-// PI_CODING_AGENT_DIR belongs to pi-coding-agent only; omp must not claim it,
-// otherwise a pi user would have their sessions double-counted under both
-// sources.
-test("PI_CODING_AGENT_DIR does not redirect omp discovery", async () => {
-  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-collision-"));
+test("PI_CODING_AGENT_DIR redirects omp discovery when no ~/.pi install signal exists", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-omp-home-"));
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-omp-"));
   try {
     const sessionsDir = path.join(tmp, "sessions", "--myproject--");
     await fs.mkdir(sessionsDir, { recursive: true });
     await fs.writeFile(path.join(sessionsDir, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
 
-    const ompResult = resolveOmpSessionFiles({
-      PI_CODING_AGENT_DIR: tmp,
-      OMP_HOME: path.join(os.tmpdir(), "no-such-omp"),
-    });
+    const ompResult = resolveOmpSessionFiles({ HOME: home, PI_CODING_AGENT_DIR: tmp });
+    assert.equal(ompResult.length, 1);
+    assert.ok(ompResult[0].endsWith(".jsonl"));
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("PI_CODING_AGENT_DIR is owned by pi when ~/.pi exists; omp falls back to default", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-both-home-"));
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-shared-"));
+  try {
+    await fs.mkdir(path.join(home, ".pi"), { recursive: true });
+    const sessionsDir = path.join(tmp, "sessions", "--proj--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(path.join(sessionsDir, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+
+    const piResult = resolvePiSessionFiles({ HOME: home, PI_CODING_AGENT_DIR: tmp });
+    const ompResult = resolveOmpSessionFiles({ HOME: home, PI_CODING_AGENT_DIR: tmp });
+    assert.equal(piResult.length, 1);
     assert.deepEqual(ompResult, []);
   } finally {
+    await fs.rm(home, { recursive: true, force: true });
     await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("TOKENTRACKER_PI_AGENT_DIR overrides PI_CODING_AGENT_DIR and the default for pi", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-tt-home-"));
+  const ttPiTmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-explicit-"));
+  const sharedTmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-shared-"));
+  try {
+    const sessionsDir = path.join(ttPiTmp, "sessions", "--proj--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(path.join(sessionsDir, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+
+    const result = resolvePiSessionFiles({
+      HOME: home,
+      PI_CODING_AGENT_DIR: sharedTmp,
+      TOKENTRACKER_PI_AGENT_DIR: ttPiTmp,
+    });
+    assert.equal(result.length, 1);
+    assert.ok(result[0].startsWith(ttPiTmp));
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+    await fs.rm(ttPiTmp, { recursive: true, force: true });
+    await fs.rm(sharedTmp, { recursive: true, force: true });
+  }
+});
+
+test("TOKENTRACKER_PI_AGENT_DIR expands a bare '~' to HOME", () => {
+  const home = "/tmp/tt-tilde-home";
+  const dir = resolvePiAgentDir({ HOME: home, TOKENTRACKER_PI_AGENT_DIR: "~" });
+  assert.equal(dir, home);
+  const sub = resolvePiAgentDir({ HOME: home, TOKENTRACKER_PI_AGENT_DIR: "~/relocated" });
+  assert.equal(sub, path.join(home, "relocated"));
+});
+
+test("decidePiCodingAgentDirOwner ignores a stray FILE at ~/.pi", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-stray-home-"));
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-stray-omp-"));
+  try {
+    await fs.writeFile(path.join(home, ".pi"), "not a dir", "utf8");
+    const ompSessions = path.join(tmp, "sessions", "--proj--");
+    await fs.mkdir(ompSessions, { recursive: true });
+    await fs.writeFile(path.join(ompSessions, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+
+    const ompResult = resolveOmpSessionFiles({ HOME: home, PI_CODING_AGENT_DIR: tmp });
+    assert.equal(ompResult.length, 1, "stray file at ~/.pi must not steal PI_CODING_AGENT_DIR from omp");
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("piAgentDirCollidesWithOmp detects shared explicit overrides", () => {
+  const home = "/tmp/tt-collision-home";
+  const shared = "/tmp/tt-shared";
+  assert.equal(
+    piAgentDirCollidesWithOmp({
+      HOME: home,
+      TOKENTRACKER_OMP_AGENT_DIR: shared,
+      TOKENTRACKER_PI_AGENT_DIR: shared,
+    }),
+    true,
+  );
+  assert.equal(
+    piAgentDirCollidesWithOmp({ HOME: home }),
+    false,
+  );
+});
+
+test("TOKENTRACKER_OMP_AGENT_DIR forces omp ownership even when ~/.pi exists", async () => {
+  const home = await fs.mkdtemp(path.join(os.tmpdir(), "tt-force-home-"));
+  const ompTmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-omp-explicit-"));
+  const sharedTmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-shared-explicit-"));
+  try {
+    await fs.mkdir(path.join(home, ".pi"), { recursive: true });
+    const ompSessions = path.join(ompTmp, "sessions", "--proj--");
+    await fs.mkdir(ompSessions, { recursive: true });
+    await fs.writeFile(path.join(ompSessions, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+    const sharedSessions = path.join(sharedTmp, "sessions", "--proj--");
+    await fs.mkdir(sharedSessions, { recursive: true });
+    await fs.writeFile(path.join(sharedSessions, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+
+    const ompResult = resolveOmpSessionFiles({
+      HOME: home,
+      PI_CODING_AGENT_DIR: sharedTmp,
+      TOKENTRACKER_OMP_AGENT_DIR: ompTmp,
+    });
+    const piResult = resolvePiSessionFiles({
+      HOME: home,
+      PI_CODING_AGENT_DIR: sharedTmp,
+      TOKENTRACKER_OMP_AGENT_DIR: ompTmp,
+    });
+    assert.equal(ompResult.length, 1);
+    assert.ok(ompResult[0].startsWith(ompTmp));
+    assert.equal(piResult.length, 1);
+    assert.ok(piResult[0].startsWith(sharedTmp));
+  } finally {
+    await fs.rm(home, { recursive: true, force: true });
+    await fs.rm(ompTmp, { recursive: true, force: true });
+    await fs.rm(sharedTmp, { recursive: true, force: true });
   }
 });
 

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -20,6 +20,8 @@ const {
   resolveCodebuddyProjectFiles,
   parseOmpIncremental,
   resolveOmpSessionFiles,
+  parsePiIncremental,
+  resolvePiSessionFiles,
   parseCraftIncremental,
   resolveCraftSessionFiles,
   resolveCraftWorkspaceRoots,
@@ -4108,6 +4110,112 @@ test("parseOmpIncremental computes totalTokens fallback when usage.totalTokens m
     assert.equal(queued[0].total_tokens, 98);
     assert.equal(queued[0].cached_input_tokens, 10);
     assert.equal(queued[0].cache_creation_input_tokens, 5);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// ─── pi (@mariozechner/pi-coding-agent) tests — same on-disk format as omp ───
+
+test("parsePiIncremental parses a single session and queues with source 'pi'", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "--test--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const filePath = path.join(sessionsDir, "session.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const ts = Date.UTC(2026, 3, 5, 14, 10, 0);
+    const lines = [
+      buildOmpSessionHeader(),
+      buildOmpAssistantLine({ id: "msg-1", model: "mimo-v2.5-pro", input: 100, output: 20, cacheRead: 0, cacheWrite: 0, timestamp: ts, totalTokens: 120 }),
+    ];
+    await fs.writeFile(filePath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parsePiIncremental({ sessionFiles: [filePath], cursors, queuePath });
+    assert.equal(res.eventsAggregated, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].source, "pi");
+    assert.equal(queued[0].model, "mimo-v2.5-pro");
+    assert.equal(queued[0].input_tokens, 100);
+    assert.equal(queued[0].output_tokens, 20);
+    assert.equal(queued[0].total_tokens, 120);
+    assert.equal(queued[0].hour_start, "2026-04-05T14:00:00.000Z");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parsePiIncremental dedupes by entry id across two runs (state under cursors.pi)", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "--test--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const filePath = path.join(sessionsDir, "session.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const ts1 = Date.UTC(2026, 3, 5, 14, 0, 0);
+    const ts2 = Date.UTC(2026, 3, 5, 14, 35, 0);
+    const lines = [
+      buildOmpSessionHeader(),
+      buildOmpAssistantLine({ id: "aaaaaaaa", model: "mimo-v2.5-pro", input: 10, output: 10, timestamp: ts1, totalTokens: 20 }),
+      buildOmpAssistantLine({ id: "bbbbbbbb", model: "mimo-v2.5-pro", input: 20, output: 20, timestamp: ts2, totalTokens: 40 }),
+      buildOmpAssistantLine({ id: "aaaaaaaa", model: "mimo-v2.5-pro", input: 10, output: 10, timestamp: ts1, totalTokens: 20 }),
+    ];
+    await fs.writeFile(filePath, lines.join("\n") + "\n", "utf8");
+
+    const res1 = await parsePiIncremental({ sessionFiles: [filePath], cursors, queuePath });
+    assert.equal(res1.eventsAggregated, 2);
+    assert.ok(cursors.pi.seenIds.includes("aaaaaaaa"));
+    assert.ok(cursors.pi.seenIds.includes("bbbbbbbb"));
+
+    const res2 = await parsePiIncremental({ sessionFiles: [filePath], cursors, queuePath });
+    assert.equal(res2.eventsAggregated, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolvePiSessionFiles returns empty when ~/.pi/agent/sessions missing", async () => {
+  const result = resolvePiSessionFiles({ HOME: path.join(os.tmpdir(), "no-such-pi-home") });
+  assert.deepEqual(result, []);
+});
+
+test("PI_CODING_AGENT_DIR env override redirects discovery", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-pi-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "--myproject--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    const filePath = path.join(sessionsDir, "session.jsonl");
+    await fs.writeFile(filePath, buildOmpSessionHeader() + "\n", "utf8");
+
+    const result = resolvePiSessionFiles({ PI_CODING_AGENT_DIR: tmp });
+    assert.equal(result.length, 1);
+    assert.ok(result[0].endsWith(".jsonl"));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// PI_CODING_AGENT_DIR belongs to pi-coding-agent only; omp must not claim it,
+// otherwise a pi user would have their sessions double-counted under both
+// sources.
+test("PI_CODING_AGENT_DIR does not redirect omp discovery", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-collision-"));
+  try {
+    const sessionsDir = path.join(tmp, "sessions", "--myproject--");
+    await fs.mkdir(sessionsDir, { recursive: true });
+    await fs.writeFile(path.join(sessionsDir, "session.jsonl"), buildOmpSessionHeader() + "\n", "utf8");
+
+    const ompResult = resolveOmpSessionFiles({
+      PI_CODING_AGENT_DIR: tmp,
+      OMP_HOME: path.join(os.tmpdir(), "no-such-omp"),
+    });
+    assert.deepEqual(ompResult, []);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Adds a passive JSONL reader for the standard pi coding agent (`@mariozechner/pi-coding-agent`) at `~/.pi/agent/sessions/**/*.jsonl`. This is distinct from the existing oh-my-pi reader (`~/.omp/`) — same on-disk session format, different install location and namespace.

- New parser `parsePiIncremental` in `src/lib/rollout.js`, emits `source="pi"` with dedup state under `cursors.pi` (capped at 10k seen IDs, mirrors omp).
- Wired into `sync`, `init` (detection), and `status` (reporter line).
- Honors `PI_CODING_AGENT_DIR` env override (matches pi's own `getAgentDir()`), with tilde expansion.
- Adds `leaderboard.column.pi` copy entry for parity with the omp column copy.

## Bug fix included

`resolveOmpAgentDir` and the omp init-detection block previously honored `PI_CODING_AGENT_DIR`, but that env var actually belongs to pi-coding-agent (per upstream `getAgentDir()`). Once both providers exist, a pi user setting the variable would have had every assistant message queued twice — once as `source:"omp"`, once as `source:"pi"` — inflating totals 2×. Removed it from the omp side; reserved for pi only. A regression test asserts omp does **not** pick up sessions when `PI_CODING_AGENT_DIR` is set.

## Test plan

- [x] `node --test test/rollout-parser.test.js` — 93 pass / 0 fail (88 pre-existing + 5 new pi tests covering parse / dedup / missing dir / env override / collision regression)
- [x] `npm run validate:copy` — passes
- [x] `npm run validate:ui-hardcode` — no new warnings introduced
- [x] `npm run validate:guardrails` — passes
- [x] Verified locally against real pi sessions at `~/.pi/agent/sessions/--Users-season-Personal-pi-mono--/*.jsonl` (the session that produced this PR is the first ingested example)

5 pre-existing test failures in the broader suite (`tsc validates migrated TS files`, `graph-auto-index-*` ×3, `installLocalTrackerApp replaces stale installed runtime`) are environmental/infrastructure — they need `dashboard/node_modules`, `scip-typescript`, and `dashboard/dist/index.html` respectively. None are touched by this change.

## Notes

- ~225 lines of the pi parser duplicate the omp parser. I considered unifying them via a shared parameterized helper, but every other passive-reader provider in the repo (Hermes, Kimi, CodeBuddy, Craft) is isolated as a self-contained block — keeping the same convention here for reviewability and to avoid an out-of-scope refactor.
- No version bump in this PR; happy to bump `package.json` separately when the maintainer wants to ship.

Closes #56