### PR TITLE
fix(menubar): prevent updateStatsDisplay recursion on macOS 26

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -142,6 +142,7 @@ final class StatusBarController: NSObject {
     private let menuBarHeight: CGFloat = 22
     private let menuBarIconSize = NSSize(width: 22, height: 22)
     private let emptyAttributedTitle = NSAttributedString(string: "")
+    private var isUpdatingDisplay = false
 
     private static let showStatsKey = "MenuBarShowStats"
     private var showStats: Bool {
@@ -260,6 +261,9 @@ final class StatusBarController: NSObject {
     }
 
     private func updateStatsDisplay() {
+        guard !isUpdatingDisplay else { return }
+        isUpdatingDisplay = true
+        defer { isUpdatingDisplay = false }
         guard let button = statusItem.button else { return }
         let displayItems = buildMenuBarDisplayValues()
 


### PR DESCRIPTION
macOS 26 introduces a synchronous layout callback path (NSStatusBarButtonCell.setTitle: → NSStatusItem._adjustLength) that re-enters StatusBarController.updateStatsDisplay() while it's setting the status item's image or length. The re-entrant call hits the else branch → animator?.applyCurrentState() → setButtonImage() → fires onImageUpdated → updateStatsDisplay() again, causing infinite recursion and a stack-overflow crash (EXC_BAD_ACCESS at the stack guard region, ~7700 frames deep).

The recursion was always coded but the macOS layout callback that triggers re-entry is new in macOS 26; the bug was latent in v0.6.7.

Fix: guard updateStatsDisplay() with an isUpdatingDisplay flag so any re-entrant call returns immediately. defer resets the flag so normal publisher-driven updates still work.

## Test plan
- [x] Build via `xcodebuild -scheme TokenTrackerBar -configuration Release` — succeeds
- [x] Launch on macOS 26 — app stays running, no recursion crash
- [x] Change menu bar slot settings while running — no crash, slots update correctly
- [x] Change configured providers — no crash
- [ ] Reviewer: smoke-test on macOS ≤ 15 to confirm no regression in normal update flow

# PR Goal (one sentence)
Fixes a stack-overflow crash on macOS 26.

## Scope

-

## Codex Context (required when requesting @codex review)

- **Delta since last Codex review:** (commits or summary)
- **Intended behavior / invariants:**
- **Edge cases covered:**
- **Tests run (command + result):**
- **Known gaps / out of scope:**

## Risk Layer Trigger (if any)

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

## Risk Layer Addendum (fill ONLY if any trigger checked)

### Rules / Invariants

-

### Boundary Matrix (must list at least 3)

-

### Evidence (tests or repro)

-

## Public Exposure Checklist (if applicable)

- [ ] Public access rules defined (share token required, non-JWT handling, 401 behavior)
- [ ] Exposed fields explicitly listed and verified
- [ ] Avatar/image policy defined
- [ ] Regression tests cover invalid link and auth fallback
- [ ] Mark N/A if no public exposure

## Regression Test Gate

### Most likely regression surface

-

### Verification method (choose at least one)

- [ ]

### Uncovered scope

-
