### PR TITLE
fix: dedup Claude split content blocks when requestId is missing

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -901,10 +901,10 @@ async function parseClaudeFile({
     if (seenMessageHashes) {
       const msgId = obj?.message?.id;
       const reqId = obj?.requestId;
-      if (msgId && reqId) {
-        const hash = `${msgId}:${reqId}`;
-        if (seenMessageHashes.has(hash)) continue;
-        seenMessageHashes.add(hash);
+      const dedupKey = reqId ? `${msgId}:${reqId}` : msgId;
+      if (dedupKey) {
+        if (seenMessageHashes.has(dedupKey)) continue;
+        seenMessageHashes.add(dedupKey);
       }
     }
 


### PR DESCRIPTION
## Why

Claude Code splits each assistant turn into multiple JSONL entries — one per content block (thinking, text, tool_use). Every entry carries the **identical `usage` object** with the same `message.id`. For a typical reply, this means 3-4 lines all reporting the same token counts.

The dedup hash in `parseClaudeFile` requires `msgId && reqId` to both be truthy, but `requestId` is absent from these entries. The condition evaluates to falsy, dedup never fires, and usage is counted 2-4x.

In a real-world session: **3,352,768 tokens (overcount) vs 1,259,118 tokens (correct) — a 166% inflation**.

## What

```javascript
// Before (src/lib/rollout.js:901-908)
if (msgId && reqId) {
    const hash = `${msgId}:${reqId}`;
    if (seenMessageHashes.has(hash)) continue;
    seenMessageHashes.add(hash);
}

// After
const dedupKey = reqId ? `${msgId}:${reqId}` : msgId;
if (dedupKey) {
    if (seenMessageHashes.has(dedupKey)) continue;
    seenMessageHashes.add(dedupKey);
}
```

Falls back to `msgId`-only dedup when `requestId` is unavailable. Preserves the combined `msgId:reqId` hash when both fields exist (backward compatible).

## Test Plan

- [x] `node --test test/rollout-parser.test.js` — 99 pass, 0 fail
- [x] Verified against a real Claude Code session JSONL — duplicate counting eliminated

## Most Likely Regression Surface

Cross-sync dedup via `seenMessageHashes`. The set persists across sync runs so a session split across two syncs could still see duplicates. The `msgId`-only fallback is actually *stricter* for these entries than before (we now dedup where we previously didn't).

## Verification

- [x] Existing 99 rollout-parser tests pass unchanged
- [x] Manual verification with real session data

## Uncovered Scope

- No new automated test for the split-content-block fixture (would need a test fixture matching real Claude Code output with `message.id` + missing `requestId`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)