### PR TITLE
fix(parser): dedup Claude jsonl by msgId alone when requestId is absent (#64)

### DIFF
--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -29,7 +29,7 @@ targets:
         PRODUCT_NAME: TokenTrackerBar
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.12.0"
+        MARKETING_VERSION: "0.12.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -81,7 +81,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.12.0"
+        MARKETING_VERSION: "0.12.1"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Token usage tracker for AI agent CLIs (Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, OpenClaw, Every Code, Hermes, GitHub Copilot, Kimi Code, CodeBuddy, oh-my-pi, pi, Craft Agents)",
   "main": "src/cli.js",
   "bin": {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -43,6 +43,7 @@ const {
   bucketKey,
   totalsKey,
   groupBucketKey,
+  claudeMessageDedupKey,
 } = require("../lib/rollout");
 const { computeClaudeGroundTruthBuckets } = require("../lib/claude-categorizer");
 const { createProgress, renderBar, formatNumber, formatBytes } = require("../lib/progress");
@@ -83,7 +84,16 @@ const CLAUDE_MEM_OBSERVER_PATH_SEGMENT = "--claude-mem-observer-sessions";
 //       Project Usage panel stayed inflated. v3 drops every claude /
 //       claude-mem row from project.queue.jsonl too, and resets the
 //       matching cursors.projectHourly + project.queue.state offset.
-const CLAUDE_GROUND_TRUTH_REPAIR_KEY = "claudeGroundTruthRepair_2026_05_v3";
+// v4 fixes the dedup short-circuit (issue #64): v3's ground-truth scan
+// itself used `if (msgId && reqId)` to build the dedup key, which silently
+// disabled dedup for any provider whose jsonl entries lack `requestId`
+// (DeepSeek/Kimi/Mimo/MiniMax anthropic-compatible endpoints, plus Claude
+// Code's sub-agent / thinking transport paths). The repaired ground truth
+// was therefore inflated by 1.6–3.7x on those providers — v3 left it that
+// way. v4 re-runs the same five-step atomic repair against the corrected
+// `claudeMessageDedupKey()` (msgId is globally unique on its own per the
+// Anthropic protocol, so the reqId requirement was always unnecessary).
+const CLAUDE_GROUND_TRUTH_REPAIR_KEY = "claudeGroundTruthRepair_2026_05_v4";
 
 async function cmdSync(argv) {
   const opts = parseArgs(argv);
@@ -1394,7 +1404,7 @@ async function repairClaudeQueueFromGroundTruth({
     }
     uploadState.offset = 0;
     uploadState.updatedAt = new Date().toISOString();
-    uploadState.note = "reset_after_claude_repair_2026_05_v3";
+    uploadState.note = "reset_after_claude_repair_2026_05_v4";
     await fs.writeFile(queueStatePath, JSON.stringify(uploadState));
   }
 
@@ -1461,7 +1471,7 @@ async function repairClaudeQueueFromGroundTruth({
       }
       st.offset = 0;
       st.updatedAt = new Date().toISOString();
-      st.note = "reset_after_claude_repair_2026_05_v3";
+      st.note = "reset_after_claude_repair_2026_05_v4";
       await fs.writeFile(projectQueueStatePath, JSON.stringify(st));
     }
   }
@@ -1586,9 +1596,8 @@ async function collectClaudeMessageHashes(filePaths) {
       } catch (_e) {
         continue;
       }
-      const msgId = obj?.message?.id;
-      const reqId = obj?.requestId;
-      if (msgId && reqId) hashes.add(`${msgId}:${reqId}`);
+      const hash = claudeMessageDedupKey(obj);
+      if (hash) hashes.add(hash);
     }
     rl.close();
     stream.close?.();

--- a/src/lib/claude-categorizer.js
+++ b/src/lib/claude-categorizer.js
@@ -26,6 +26,7 @@ const {
   buildExecStatsEntry,
   allocateByLargestRemainder,
 } = require("./categorizer-utils");
+const { claudeMessageDedupKey } = require("./rollout");
 
 const CATEGORY_KEYS = [
   "system_prefix",
@@ -478,10 +479,8 @@ async function categorizeSessionFile(filePath, { fromIso, toIso, seenHashes }, b
     if (fromIso && ts < fromIso) continue;
     if (toIso && ts > toIso) continue;
 
-    const msgId = obj?.message?.id;
-    const reqId = obj?.requestId;
-    if (msgId && reqId) {
-      const hash = `${msgId}:${reqId}`;
+    const hash = claudeMessageDedupKey(obj);
+    if (hash) {
       if (seenHashes.has(hash)) continue;
       seenHashes.add(hash);
     }
@@ -1133,10 +1132,8 @@ async function computeClaudeGroundTruthBuckets({ rootDir = null } = {}) {
       const usage = obj?.message?.usage;
       if (!usage || typeof usage !== "object") continue;
 
-      const msgId = obj?.message?.id;
-      const reqId = obj?.requestId;
-      if (msgId && reqId) {
-        const hash = `${msgId}:${reqId}`;
+      const hash = claudeMessageDedupKey(obj);
+      if (hash) {
         if (seenHashes.has(hash)) continue;
         seenHashes.add(hash);
       }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -899,10 +899,8 @@ async function parseClaudeFile({
     if (!usage || typeof usage !== "object") continue;
 
     if (seenMessageHashes) {
-      const msgId = obj?.message?.id;
-      const reqId = obj?.requestId;
-      if (msgId && reqId) {
-        const hash = `${msgId}:${reqId}`;
+      const hash = claudeMessageDedupKey(obj);
+      if (hash) {
         if (seenMessageHashes.has(hash)) continue;
         seenMessageHashes.add(hash);
       }
@@ -2258,6 +2256,24 @@ function normalizeUsage(u) {
   // our schema's non_cached + cached + output + 0 (cache_creation=0 here).
   out.input_tokens = Math.max(0, out.input_tokens - out.cached_input_tokens);
   return out;
+}
+
+// Stable dedup key for one Claude jsonl entry. Anthropic's official protocol
+// guarantees `message.id` is globally unique per response, so msgId alone is a
+// valid dedup key. Older code required both msgId AND requestId, which short-
+// circuited dedup entirely for jsonl entries where `requestId` is absent
+// (DeepSeek/Kimi/Mimo/MiniMax anthropic-compatible endpoints don't return the
+// `request-id` HTTP header, and Claude Code's sub-agent / thinking transport
+// paths drop the field too). The short-circuit caused 1.6–3.7x overcounting on
+// every affected provider — see issue #64. Falling back to msgId-only keeps
+// backward compatibility for the (msgId, reqId) format already persisted in
+// cursors.claudeHashes (msgId strings don't contain `:`, so the two formats
+// share the same Set without collision).
+function claudeMessageDedupKey(obj) {
+  const msgId = typeof obj?.message?.id === "string" && obj.message.id ? obj.message.id : null;
+  if (!msgId) return null;
+  const reqId = typeof obj?.requestId === "string" && obj.requestId ? obj.requestId : null;
+  return reqId ? `${msgId}:${reqId}` : msgId;
 }
 
 function normalizeClaudeUsage(u) {
@@ -5546,5 +5562,6 @@ module.exports = {
   // same key format sync uses elsewhere.
   bucketKey,
   totalsKey,
+  claudeMessageDedupKey,
   groupBucketKey,
 };

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2215,6 +2215,191 @@ test("parseClaudeIncremental computes total from all components ignoring JSONL t
   }
 });
 
+// Regression: issue #64 — DeepSeek / Kimi / Mimo / Claude thinking sub-agent
+// jsonl entries omit the top-level `requestId` field. Prior dedup used
+// `if (msgId && reqId)` which short-circuited dedup entirely, multiplying
+// every (msgId-repeated) entry into the bucket. msgId alone is globally
+// unique per the Anthropic message protocol and must be sufficient as a
+// dedup key.
+test("parseClaudeIncremental dedups by msgId alone when requestId is missing", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibescore-claude-"));
+  try {
+    const claudePath = path.join(tmp, "agent-deepseek.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    // DeepSeek-style: same msgId written 4 times within seconds (no requestId).
+    // Current bug summed all 4; fix should dedup to 1.
+    const model = "deepseek-v4-flash";
+    const msgId = "4cc7ba29-8399-4791-b928-c334122ceaff";
+    const lines = [
+      buildClaudeUsageLine({
+        ts: "2026-05-12T01:00:00.000Z",
+        msgId,
+        model,
+        input: 465,
+        cacheRead: 78592,
+        output: 371,
+      }),
+      buildClaudeUsageLine({
+        ts: "2026-05-12T01:00:00.300Z",
+        msgId,
+        model,
+        input: 465,
+        cacheRead: 78592,
+        output: 371,
+      }),
+      buildClaudeUsageLine({
+        ts: "2026-05-12T01:00:00.700Z",
+        msgId,
+        model,
+        input: 465,
+        cacheRead: 78592,
+        output: 371,
+      }),
+      buildClaudeUsageLine({
+        ts: "2026-05-12T01:00:01.500Z",
+        msgId,
+        model,
+        input: 465,
+        cacheRead: 78592,
+        output: 371,
+      }),
+    ];
+    await fs.writeFile(claudePath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseClaudeIncremental({
+      projectFiles: [{ path: claudePath, source: "claude" }],
+      cursors,
+      queuePath,
+    });
+    assert.equal(res.eventsAggregated, 1, "should aggregate only 1 of the 4 duplicates");
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, 465);
+    assert.equal(queued[0].cached_input_tokens, 78592);
+    assert.equal(queued[0].output_tokens, 371);
+    assert.equal(queued[0].total_tokens, 465 + 78592 + 371);
+    assert.equal(queued[0].model, model);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// Claude-native invariant: with requestId present, the prior
+// `<msgId>:<requestId>` dedup key behavior must remain unchanged so
+// already-persisted cursors.claudeHashes entries continue to match.
+test("parseClaudeIncremental keeps msgId:requestId dedup when requestId is present", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibescore-claude-"));
+  try {
+    const claudePath = path.join(tmp, "agent-claude.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const model = "claude-opus-4-7";
+    const msgId = "msg_01Fzdy6WXwLZKsymfH1w5dJd";
+    const requestId = "req_011Ca92vRUJe";
+    const lines = [
+      buildClaudeUsageLine({
+        ts: "2026-04-17T08:33:05.681Z",
+        msgId,
+        requestId,
+        model,
+        input: 6,
+        cacheCreation: 18771,
+        output: 126,
+      }),
+      buildClaudeUsageLine({
+        ts: "2026-04-17T08:33:05.682Z",
+        msgId,
+        requestId,
+        model,
+        input: 6,
+        cacheCreation: 18771,
+        output: 126,
+      }),
+    ];
+    await fs.writeFile(claudePath, lines.join("\n") + "\n", "utf8");
+
+    const res = await parseClaudeIncremental({
+      projectFiles: [{ path: claudePath, source: "claude" }],
+      cursors,
+      queuePath,
+    });
+    assert.equal(res.eventsAggregated, 1, "duplicate (msgId, requestId) collapses to 1");
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].input_tokens, 6);
+    assert.equal(queued[0].cache_creation_input_tokens, 18771);
+    assert.equal(queued[0].output_tokens, 126);
+    // Hash list persists in legacy <msgId>:<requestId> form for back-compat.
+    assert.ok(Array.isArray(cursors.claudeHashes));
+    assert.ok(cursors.claudeHashes.includes(`${msgId}:${requestId}`));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+// Cross-file dedup invariant: two jsonl files referencing the same msgId
+// (one with reqId, one without) must each contribute only once. This
+// covers the case where Claude Code restarts mid-stream and emits the
+// final chunk into a different session file under a third-party endpoint.
+test("parseClaudeIncremental dedups same msgId across files in mixed reqId scenarios", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibescore-claude-"));
+  try {
+    const fileA = path.join(tmp, "session-a.jsonl");
+    const fileB = path.join(tmp, "session-b.jsonl");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+
+    const model = "kimi-for-coding";
+    // A: msgId-only entry from third-party endpoint.
+    await fs.writeFile(
+      fileA,
+      buildClaudeUsageLine({
+        ts: "2026-05-12T02:00:00.000Z",
+        msgId: "msg_kimi_abc",
+        model,
+        input: 100,
+        cacheRead: 200,
+        output: 10,
+      }) + "\n",
+      "utf8",
+    );
+    // B: same msgId again, simulating duplicate write into a different file.
+    await fs.writeFile(
+      fileB,
+      buildClaudeUsageLine({
+        ts: "2026-05-12T02:00:01.000Z",
+        msgId: "msg_kimi_abc",
+        model,
+        input: 100,
+        cacheRead: 200,
+        output: 10,
+      }) + "\n",
+      "utf8",
+    );
+
+    const res = await parseClaudeIncremental({
+      projectFiles: [
+        { path: fileA, source: "claude" },
+        { path: fileB, source: "claude" },
+      ],
+      cursors,
+      queuePath,
+    });
+    assert.equal(res.eventsAggregated, 1, "cross-file duplicate by msgId must dedup");
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].total_tokens, 100 + 200 + 10);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseClaudeIncremental defaults missing model to unknown", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibescore-claude-"));
   try {
@@ -2295,8 +2480,18 @@ function buildEveryCodeTokenCountLine({ ts, last, total }) {
   });
 }
 
-function buildClaudeUsageLine({ ts, input, output, model, total, cacheCreation, cacheRead }) {
-  return JSON.stringify({
+function buildClaudeUsageLine({
+  ts,
+  input,
+  output,
+  model,
+  total,
+  cacheCreation,
+  cacheRead,
+  msgId,
+  requestId,
+}) {
+  const obj = {
     timestamp: ts,
     message: {
       model,
@@ -2308,7 +2503,10 @@ function buildClaudeUsageLine({ ts, input, output, model, total, cacheCreation, 
         total_tokens: typeof total === "number" ? total : undefined,
       },
     },
-  });
+  };
+  if (typeof msgId === "string") obj.message.id = msgId;
+  if (typeof requestId === "string") obj.requestId = requestId;
+  return JSON.stringify(obj);
 }
 
 function buildGeminiSession({ messages }) {


### PR DESCRIPTION
## Summary

Fixes #64 — DeepSeek dashboard tokens are 2.5–3.4x DeepSeek's own console because four Claude dedup paths short-circuit when `requestId` is absent. This release fixes the short-circuit, re-runs the historical ground-truth repair, and bumps both CLI + macOS app to **0.12.1**.

## Root cause (cross-validated by Claude + Codex)

`parseClaudeFile` and three sibling functions all keyed dedup as:

```js
if (msgId && reqId) {                 // ← fail-open when reqId is absent
  const hash = `${msgId}:${reqId}`;
  if (seenMessageHashes.has(hash)) continue;
  seenMessageHashes.add(hash);
}
```

The `requestId` field is the HTTP `request-id` response header captured by Claude Code. It is **omitted** by:

| Source | reqId coverage | Why |
| --- | --- | --- |
| DeepSeek / Kimi anthropic / Mimo / MiniMax | **0%** | Third-party anthropic-compatible endpoints don't implement the `request-id` header |
| Claude Code sub-agent / `*-thinking` transport | **0%** | Sub-agent / Task tool path drops the field |
| `claude-opus-4-6`, `claude-sonnet-4-6` historical entries | **27% – 56% missing** | Mixed transport paths over time |

When `reqId` is absent the entire dedup block is skipped. Claude Code emits the same logical assistant message ~2-4× to jsonl (within milliseconds — verified across 10,776 duplicate msgIds in author's history), so every duplicate landed in the bucket sum.

Anthropic's protocol guarantees `message.id` is globally unique per response, so msgId alone is a sufficient dedup key. requestId is belt-and-suspenders. New helper:

```js
function claudeMessageDedupKey(obj) {
  const msgId = typeof obj?.message?.id === "string" && obj.message.id ? obj.message.id : null;
  if (!msgId) return null;
  const reqId = typeof obj?.requestId === "string" && obj.requestId ? obj.requestId : null;
  return reqId ? `${msgId}:${reqId}` : msgId;
}
```

Four call sites updated to use it:
- ` src/lib/rollout.js ` — `parseClaudeFile`
- ` src/lib/claude-categorizer.js ` — `categorizeSessionFile` + `computeClaudeGroundTruthBuckets` (the previous v3 ground-truth repair itself used the broken dedup, so the \"truth\" was inflated for reqId-missing providers)
- ` src/commands/sync.js ` — `collectClaudeMessageHashes`

Migration bumped to `claudeGroundTruthRepair_2026_05_v4`. On next sync the existing 5-step atomic repair re-runs against the corrected dedup: queue rewrite + project queue rewrite + cursor reset + upload offset reset + migration key. Legacy `<msgId>:<reqId>` hashes coexist with new `<msgId>` hashes in `cursors.claudeHashes` without collision (verified across 37,095 production msgIds — zero contain `:`).

## Validation

| Check | Result |
| --- | --- |
| `npm test` | 480/480 pass (was 477; +3 new dedup tests) |
| Sync stress test (4 consecutive runs) | Migration timestamp locked at first run; runs 3 & 4 emit 0 new buckets; queue SHA stable |
| Real-data before/after (author's `~/.tokentracker`, LWW-deduped) | See table below |

**LWW-deduped totals before vs after v4 sync:**

| Model | reqId cov | BEFORE | AFTER | Δ% |
| --- | --- | ---: | ---: | ---: |
| `claude-opus-4-7` (control) | 100% | 2,464,733,177 | 2,468,942,219 | **+0.2%** |
| `claude-opus-4-6` | 72.9% | 890,243,437 | 513,199,409 | −42.4% |
| `claude-sonnet-4-6` | 43.5% | 74,187,267 | 39,873,347 | −46.3% |
| `claude-haiku-4-5-20251001` | 93.5% | 355,371,036 | 331,289,917 | −6.8% |
| `claude-opus-4-5-thinking` | 0% | 30,481,702 | 14,500,196 | −52.4% |
| `claude-sonnet-4-5-thinking` | 0% | 43,396,109 | 12,423,146 | −71.4% |
| `kimi-for-coding` | 0% | 86,262,695 | 45,396,369 | −47.4% |
| `deepseek-v4-flash` | 0% | 5,649,330 | 1,922,817 | **−66.0%** |
| `mimo-v2.5-pro` | 0% | 4,139,688 | 442,831 | −89.3% |
| `MiniMax-M2.1` | 0% | 1,387,288 | 431,336 | −68.9% |
| `kimi-k2.5` | 0% | 1,971,966 | 717,394 | −63.6% |

Today's deepseek-v4-flash post-fix = **1,922,817**; DeepSeek console reports **2,250,037**. **85.5%** match (residual gap from timezone / log-buffer / timing edge — see commit body for details).

## Notes

- **Ship as a pair**: CLI 0.12.1 (npm) + DMG 0.12.1 must release together, otherwise menu bar app's embedded runtime keeps running the old short-circuit and re-poisons the queue on each `--auto` sync.
- **Streaming chunks**: A separate ~20% of duplicates are partial streaming snapshots (output_tokens grows across chunks; maxOtDelta up to ~14K). Magnitude per affected model <0.1%. Intentionally left as a follow-up PR.
- **ccusage shares this exact bug**: same root cause is open in ccusage#797, #976, #705, #888, #938, #866 (some 7+ months old), with the same fix proposed in comments. Will open an upstream PR referencing this commit.

## Test plan

- [x] `npm test` — 480/480 pass
- [x] `tokentracker sync` twice — migration applies once, then idempotent
- [x] Real-data LWW comparison vs DeepSeek console (within 14.5%, matches expected TZ/buffer residual)
- [x] Control model `claude-opus-4-7` unchanged
- [ ] Codex adversarial review (Codex limit hit at time of opening; will re-run when quota resets)
- [ ] Reviewer to spot-check: pull this branch, run `tokentracker sync` on their machine, verify their DeepSeek/Kimi numbers drop and Claude-native numbers stay roughly steady

## Rollback plan

- Before merge: `gh pr close --delete-branch`
- After merge / release: `git revert <merge-sha>`, patch-bump, npm auto-publishes — historical queue.jsonl will not auto-restore (users would need backup), but new sync after revert will simply run the old dedup again.