### PR TITLE
fix: remove sync icon frame and finish spin animation

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/ClawdCompanionView.swift
@@ -10,13 +10,16 @@ struct ClawdCompanionView: View {
     @State private var currentAction: CharacterAction = .none
     @State private var quipIndex = 0
     @State private var armWave = false
-    @State private var syncRotation: Double = 0
+    @State private var syncSpinActive = false
+    @State private var syncSpinStart = Date()
+    @State private var syncSpinStopTask: Task<Void, Never>?
     @State private var hoveringSync = false
     @State private var hoveringCharacter = false
     @State private var tapOverrideState: ClawdState?
     @State private var idleVariant: ClawdState = .idleLiving
 
     private let px: CGFloat = 4.0
+    private let syncSpinPeriod: TimeInterval = 0.8
 
     var body: some View {
         HStack(alignment: .center, spacing: 10) {
@@ -81,31 +84,70 @@ struct ClawdCompanionView: View {
     // MARK: - Sync Button
 
     private var syncButton: some View {
-        Button {
-            Task { await viewModel.triggerSync() }
-        } label: {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
             Image(systemName: "arrow.triangle.2.circlepath")
                 .font(.system(size: 11))
                 .foregroundStyle(viewModel.isSyncing ? .tertiary : (hoveringSync ? .primary : .secondary))
-                .rotationEffect(.degrees(syncRotation))
+                .rotationEffect(.degrees(syncRotationDegrees(at: timeline.date)))
                 .scaleEffect(hoveringSync && !viewModel.isSyncing ? 1.15 : 1.0)
                 .animation(.easeOut(duration: 0.15), value: hoveringSync)
+                .frame(width: 24, height: 24)
+                .contentShape(Rectangle())
+                .onTapGesture { triggerManualSync() }
+                .onHover { h in
+                    hoveringSync = h
+                    if h { NSCursor.pointingHand.push() } else { NSCursor.pop() }
+                }
+                .accessibilityLabel(viewModel.isSyncing ? Strings.syncingUsageData : Strings.syncUsageData)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityAction { triggerManualSync() }
+                .onChange(of: viewModel.isSyncing) { syncing in
+                    if syncing {
+                        startSyncSpin()
+                    } else {
+                        stopSyncSpinAfterCurrentTurn()
+                    }
+                }
+                .onDisappear {
+                    syncSpinStopTask?.cancel()
+                    syncSpinStopTask = nil
+                }
         }
-        .frame(width: 24, height: 24)
-        .contentShape(Rectangle())
-        .buttonStyle(.plain)
-        .onHover { h in
-            hoveringSync = h
-            if h { NSCursor.pointingHand.push() } else { NSCursor.pop() }
-        }
-        .disabled(viewModel.isSyncing)
-        .accessibilityLabel(viewModel.isSyncing ? Strings.syncingUsageData : Strings.syncUsageData)
-        .onChange(of: viewModel.isSyncing) { syncing in
-            if syncing {
-                withAnimation(.linear(duration: 1).repeatForever(autoreverses: false)) { syncRotation = 360 }
-            } else {
-                withAnimation(.default) { syncRotation = 0 }
+    }
+
+    private func triggerManualSync() {
+        guard !viewModel.isSyncing else { return }
+        Task { await viewModel.triggerSync() }
+    }
+
+    private func syncRotationDegrees(at date: Date) -> Double {
+        guard syncSpinActive else { return 0 }
+        let elapsed = max(0, date.timeIntervalSince(syncSpinStart))
+        return (elapsed / syncSpinPeriod * 360).truncatingRemainder(dividingBy: 360)
+    }
+
+    private func startSyncSpin() {
+        syncSpinStopTask?.cancel()
+        syncSpinStopTask = nil
+        syncSpinStart = Date()
+        syncSpinActive = true
+    }
+
+    private func stopSyncSpinAfterCurrentTurn() {
+        guard syncSpinActive else { return }
+        syncSpinStopTask?.cancel()
+
+        let elapsed = max(0, Date().timeIntervalSince(syncSpinStart))
+        let remainder = elapsed.truncatingRemainder(dividingBy: syncSpinPeriod)
+        let delay = remainder == 0 ? 0 : syncSpinPeriod - remainder
+
+        syncSpinStopTask = Task { @MainActor in
+            if delay > 0 {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             }
+            guard !Task.isCancelled, !viewModel.isSyncing else { return }
+            syncSpinActive = false
+            syncSpinStopTask = nil
         }
     }
 


### PR DESCRIPTION
# PR Goal

Remove the visible frame around the menu bar sync icon and make its click feedback complete cleanly.

## Before / After
<img width="927" height="284" alt="download" src="https://github.com/user-attachments/assets/e2ad8ca6-49bd-4e57-b9df-8aaaa25d0593" />
<img width="800" height="107" alt="CleanShot 2026-05-14 at 02 54 54" src="https://github.com/user-attachments/assets/59284549-80ed-46d7-bd02-7995217e3754" />


- Before: the sync icon rendered with native button chrome, so the menu bar popover showed a small highlighted frame around the icon.
- After: the sync icon renders as a plain frameless icon and keeps the same hover/click affordance.
- Before: fast sync completion could snap the rotation back before the icon finished a full turn.
- After: the icon finishes the current spin before stopping, so the click feedback feels complete.

## Scope

- Replaces the sync icon's SwiftUI `Button` wrapper with a frameless interactive image so the popover no longer shows native button chrome.
- Updates the spin feedback so quick syncs still finish the current rotation instead of snapping back mid-turn.
- Keeps the existing hover, cursor, accessibility action, and duplicate-click guard behavior.

## Verification

- [x] `xcodegen generate` — succeeded
- [x] `swiftc -typecheck $(rg --files TokenTrackerBar/TokenTrackerBar TokenTrackerBar/Shared -g '*.swift') -target arm64-apple-macos12.0` — passed with existing unrelated warnings
- [x] `xcodebuild -project TokenTrackerBar.xcodeproj -scheme TokenTrackerBar -configuration Debug -derivedDataPath /tmp/tokentrackerbar-dd CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build` — `BUILD SUCCEEDED`
- [x] `npm --prefix dashboard run build` — passed
- [x] `npm test` — passed, 507/507
- [x] Local visual verification from the Debug app build

## Out of Scope

- Signed release packaging / DMG verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync button animation reliability and responsiveness.
  * Visual feedback now stays aligned with actual sync state (starts/stops predictably).
  * Prevented repeated manual sync actions while a sync is in progress.
  * Ensures spin finishes cleanly at the end of a rotation and cancels pending spin when the view disappears.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/71)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->