### PR TITLE
Use generic Context Breakdown loading copy

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -536,7 +536,7 @@ dashboard.context_breakdown.category.custom_agents,dashboard,DashboardPage,Conte
 dashboard.context_breakdown.category.reasoning,dashboard,DashboardPage,ContextBreakdownPanel,cat,"Reasoning",,active
 dashboard.context_breakdown.category.skills,dashboard,DashboardPage,ContextBreakdownPanel,cat,"Skills",,active
 dashboard.context_breakdown.loading_aria,dashboard,DashboardPage,ContextBreakdownPanel,loading_aria,"Loading context breakdown",,active
-dashboard.context_breakdown.loading_hint,dashboard,DashboardPage,ContextBreakdownPanel,loading_hint,"Scanning Claude Code session logs…",,active
+dashboard.context_breakdown.loading_hint,dashboard,DashboardPage,ContextBreakdownPanel,loading_hint,"Scanning session logs…",,active
 dashboard.context_breakdown.tool_details.total_column,dashboard,DashboardPage,ContextBreakdownPanel,tool_details_total_column,"Total",,active
 dashboard.context_breakdown.tool_details.unavailable_codex,dashboard,DashboardPage,ContextBreakdownPanel,tool_details_unavailable_codex,"Tool-level Codex details are unavailable for this period; showing queue totals only.",,active
 dashboard.context_breakdown.message_details.title,dashboard,DashboardPage,ContextBreakdownPanel,message_details_title,"Message details",,active

--- a/dashboard/src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx
+++ b/dashboard/src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx
@@ -14,6 +14,16 @@ vi.mock("../../../../lib/timezone", () => ({
 }));
 
 describe("ContextBreakdownPanel", () => {
+  it("uses generic loading copy while session logs are being scanned", async () => {
+    getUsageCategoryBreakdown.mockReturnValueOnce(new Promise(() => {}));
+
+    render(<ContextBreakdownPanel from="2026-05-09" to="2026-05-09" source="codex" />);
+
+    expect(await screen.findByText(copy("dashboard.context_breakdown.loading_hint"))).toBeInTheDocument();
+    expect(screen.queryByText("Scanning Claude Code session logs…")).not.toBeInTheDocument();
+    expect(screen.queryByText("Scanning Codex session logs…")).not.toBeInTheDocument();
+  });
+
   it("renders Codex tool calls from total token attribution", async () => {
     getUsageCategoryBreakdown.mockResolvedValueOnce({
       source: "codex",


### PR DESCRIPTION
## Summary
- Use a generic Context Breakdown loading message instead of naming Claude Code.
- Add regression coverage for the Codex loading state so provider-specific loading copy does not come back.

## Testing
- `npm --prefix dashboard test -- src/ui/dashboard/components/__tests__/ContextBreakdownPanel.test.jsx`
- `npm run validate:copy`
- `git diff --check`
- `npm --prefix dashboard run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for loading state behavior in the dashboard.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/73)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->