### PR TITLE
Fix menu bar zero-state stats and footer hit areas

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/StatusBarController.swift
@@ -316,7 +316,7 @@ final class StatusBarController: NSObject {
 
         animator = MenuBarAnimator(button: button)
         animator?.onImageUpdated = { [weak self] _ in
-            guard let self, self.showStats, self.viewModel.todayTokens > 0 else { return }
+            guard let self, self.showStats, !self.buildMenuBarDisplayValues().isEmpty else { return }
             self.updateStatsDisplay()
         }
         updateStatsDisplay()
@@ -410,31 +410,31 @@ final class StatusBarController: NSObject {
 
             switch metric {
             case .todayTokens:
-                guard viewModel.todayTokens > 0 else { return nil }
+                guard viewModel.todaySummary != nil else { return nil }
                 return MenuBarDisplayValue(
                     id: id,
                     label: metric.menuLabel,
                     value: TokenFormatter.formatCompact(viewModel.todayTokens)
                 )
             case .todayCost:
-                guard viewModel.todayTokens > 0 else { return nil }
+                guard viewModel.todaySummary != nil else { return nil }
                 return MenuBarDisplayValue(id: id, label: metric.menuLabel, value: viewModel.todayCost)
             case .last7dTokens:
-                guard viewModel.last7dTokens > 0 else { return nil }
+                guard viewModel.rollingSummary != nil else { return nil }
                 return MenuBarDisplayValue(
                     id: id,
                     label: metric.menuLabel,
                     value: TokenFormatter.formatCompact(viewModel.last7dTokens)
                 )
             case .totalTokens:
-                guard viewModel.totalTokens > 0 else { return nil }
+                guard viewModel.totalSummary != nil else { return nil }
                 return MenuBarDisplayValue(
                     id: id,
                     label: metric.menuLabel,
                     value: TokenFormatter.formatCompact(viewModel.totalTokens)
                 )
             case .totalCost:
-                guard viewModel.totalTokens > 0 else { return nil }
+                guard viewModel.totalSummary != nil else { return nil }
                 return MenuBarDisplayValue(id: id, label: metric.menuLabel, value: viewModel.totalCost)
             case .claude5h:
                 guard let window = viewModel.usageLimits?.claude.fiveHour,

--- a/TokenTrackerBar/TokenTrackerBar/Views/FooterView.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Views/FooterView.swift
@@ -18,9 +18,9 @@ struct FooterView: View {
                     .foregroundStyle(hoveringDashboard ? .primary : Color.accentColor)
                     .scaleEffect(hoveringDashboard ? 1.03 : 1.0)
                     .animation(.easeOut(duration: 0.12), value: hoveringDashboard)
+                    .frame(minHeight: 28)
+                    .contentShape(Rectangle())
             }
-            .frame(minHeight: 28)
-            .contentShape(Rectangle())
             .buttonStyle(.plain)
             .onHover { hovering in
                 hoveringDashboard = hovering
@@ -40,9 +40,9 @@ struct FooterView: View {
                     .foregroundStyle(hoveringQuit ? .primary : .secondary)
                     .scaleEffect(hoveringQuit ? 1.03 : 1.0)
                     .animation(.easeOut(duration: 0.12), value: hoveringQuit)
+                    .frame(minHeight: 28)
+                    .contentShape(Rectangle())
             }
-            .frame(minHeight: 28)
-            .contentShape(Rectangle())
             .buttonStyle(.plain)
             .onHover { hovering in
                 hoveringQuit = hovering


### PR DESCRIPTION
## Summary

This PR fixes two small issues I noticed during day-to-day use of the macOS menu bar app.

- Align the footer button click targets with the area that visually reacts to hover.
- Keep menu bar stats visible when usage summaries are successfully loaded but their token values are `0`.

## Details

The footer buttons previously animated over a larger area than the actual clickable button content. That made the UI feel like a click had been ignored when the pointer was inside the active hover area but outside the hit target. Moving the frame and content shape into the button label makes the clickable region match the animated region.

The menu bar stats previously used positive token counts as the visibility gate. Around a day boundary, before any token usage had happened, the app could successfully fetch zero-valued summaries but still hide the daily and rolling stats. The status item width could remain allocated while the values disappeared. The visibility checks now use summary availability instead of `> 0` token values, so a known zero is rendered as `0` while missing data remains hidden.

## Validation

- Ran `xcodebuild -project TokenTrackerBar/TokenTrackerBar.xcodeproj -scheme TokenTrackerBar -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO build`.
- Verified the zero-summary behavior with an isolated local mock server on port `17680`, separate from the real TokenTracker service/data, returning all-zero summary payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced menu bar statistics display to show content based on actual data availability rather than numerical thresholds.

* **Style**
  * Refined footer button styling and layout for improved visual alignment and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->