### PR TITLE
feat(subscriptions): read Claude Code credentials from ~/.claude/.credentials.json on Linux

### DIFF
--- a/src/lib/subscriptions.js
+++ b/src/lib/subscriptions.js
@@ -10,6 +10,10 @@ const { probeOpenclawSessionPluginState } = require("./openclaw-session-plugin")
 const OPENAI_AUTH_CLAIM = "https://api.openai.com/auth";
 const MACOS_SECURITY_BIN = "/usr/bin/security";
 const CLAUDE_CODE_KEYCHAIN_SERVICES = ["Claude Code-credentials"];
+// On Linux, Claude Code persists the same OAuth payload as a plain JSON file
+// (~/.claude/.credentials.json) instead of the macOS Keychain. The payload
+// shape is identical: { claudeAiOauth: { accessToken, subscriptionType, ... } }
+const CLAUDE_CODE_CREDENTIALS_FILE = ".credentials.json";
 
 function normalizeString(value) {
   if (typeof value !== "string") return null;
@@ -193,25 +197,54 @@ function readMacosKeychainPassword({ service, securityRunner, timeoutMs } = {}) 
   return trimmed.length > 0 ? trimmed : null;
 }
 
-function detectClaudeCodeCredentialsPresence({ platform, securityRunner } = {}) {
-  if (platform !== "darwin") return null;
+function readClaudeCodeCredentialsLinuxFile({ home, fsReader } = {}) {
+  const homeDir = typeof home === "string" && home ? home : os.homedir();
+  const credPath = path.join(homeDir, ".claude", CLAUDE_CODE_CREDENTIALS_FILE);
+  const reader = typeof fsReader === "function" ? fsReader : fs.readFileSync;
+  try {
+    return reader(credPath, "utf8");
+  } catch (_e) {
+    return null;
+  }
+}
 
-  for (const service of CLAUDE_CODE_KEYCHAIN_SERVICES) {
-    const present = probeMacosKeychainGenericPassword({
-      service,
-      securityRunner,
-    });
-    if (!present) continue;
+function detectClaudeCodeCredentialsPresence({ platform, securityRunner, home, fsReader } = {}) {
+  if (platform === "darwin") {
+    for (const service of CLAUDE_CODE_KEYCHAIN_SERVICES) {
+      const present = probeMacosKeychainGenericPassword({
+        service,
+        securityRunner,
+      });
+      if (!present) continue;
 
-    // Existence-only probe: do not read secrets or infer paid tier.
-    return {
-      tool: "claude",
-      provider: "anthropic",
-      product: "credentials",
-      planType: "present",
-    };
+      // Existence-only probe: do not read secrets or infer paid tier.
+      return {
+        tool: "claude",
+        provider: "anthropic",
+        product: "credentials",
+        planType: "present",
+      };
+    }
+    return null;
   }
 
+  // Linux (and any non-darwin) — credentials live in ~/.claude/.credentials.json.
+  // Existence-only: just check that the file is readable and contains the OAuth key.
+  const raw = readClaudeCodeCredentialsLinuxFile({ home, fsReader });
+  if (!raw) return null;
+  try {
+    const payload = JSON.parse(raw);
+    if (payload?.claudeAiOauth && typeof payload.claudeAiOauth === "object") {
+      return {
+        tool: "claude",
+        provider: "anthropic",
+        product: "credentials",
+        planType: "present",
+      };
+    }
+  } catch (_e) {
+    // fall through
+  }
   return null;
 }
 
@@ -228,16 +261,19 @@ function extractClaudeKeychainSubscription(payload) {
   return { subscriptionType, rateLimitTier };
 }
 
-function detectClaudeCodeSubscriptionDetails({ platform, securityRunner } = {}) {
-  if (platform !== "darwin") return null;
+function detectClaudeCodeSubscriptionDetails({ platform, securityRunner, home, fsReader } = {}) {
+  const rawPayloads = [];
+  if (platform === "darwin") {
+    for (const service of CLAUDE_CODE_KEYCHAIN_SERVICES) {
+      const raw = readMacosKeychainPassword({ service, securityRunner });
+      if (raw) rawPayloads.push(raw);
+    }
+  } else {
+    const raw = readClaudeCodeCredentialsLinuxFile({ home, fsReader });
+    if (raw) rawPayloads.push(raw);
+  }
 
-  for (const service of CLAUDE_CODE_KEYCHAIN_SERVICES) {
-    const raw = readMacosKeychainPassword({
-      service,
-      securityRunner,
-    });
-    if (!raw) continue;
-
+  for (const raw of rawPayloads) {
     let payload;
     try {
       payload = JSON.parse(raw);
@@ -277,14 +313,14 @@ async function collectLocalSubscriptions({
   if (opencode) out.push(opencode);
 
   if (probeKeychainDetails) {
-    const claude = detectClaudeCodeSubscriptionDetails({ platform, securityRunner });
+    const claude = detectClaudeCodeSubscriptionDetails({ platform, securityRunner, home });
     if (claude) out.push(claude);
     else if (probeKeychain) {
-      const present = detectClaudeCodeCredentialsPresence({ platform, securityRunner });
+      const present = detectClaudeCodeCredentialsPresence({ platform, securityRunner, home });
       if (present) out.push(present);
     }
   } else if (probeKeychain) {
-    const claude = detectClaudeCodeCredentialsPresence({ platform, securityRunner });
+    const claude = detectClaudeCodeCredentialsPresence({ platform, securityRunner, home });
     if (claude) out.push(claude);
   }
 
@@ -314,20 +350,30 @@ async function detectOpenclawSessionIntegration({ home, env }) {
   };
 }
 
-function readClaudeCodeAccessToken({ platform, securityRunner } = {}) {
-  if (platform !== "darwin") return null;
-
-  for (const service of CLAUDE_CODE_KEYCHAIN_SERVICES) {
-    try {
-      const raw = readMacosKeychainPassword({ service, securityRunner });
-      if (!raw) continue;
-      const payload = JSON.parse(raw);
-      return normalizeString(payload?.claudeAiOauth?.accessToken);
-    } catch (_e) {
-      continue;
+function readClaudeCodeAccessToken({ platform, securityRunner, home, fsReader } = {}) {
+  if (platform === "darwin") {
+    for (const service of CLAUDE_CODE_KEYCHAIN_SERVICES) {
+      try {
+        const raw = readMacosKeychainPassword({ service, securityRunner });
+        if (!raw) continue;
+        const payload = JSON.parse(raw);
+        return normalizeString(payload?.claudeAiOauth?.accessToken);
+      } catch (_e) {
+        continue;
+      }
     }
+    return null;
   }
-  return null;
+
+  // Linux: Claude Code stores the OAuth payload as a JSON file with mode 0600.
+  const raw = readClaudeCodeCredentialsLinuxFile({ home, fsReader });
+  if (!raw) return null;
+  try {
+    const payload = JSON.parse(raw);
+    return normalizeString(payload?.claudeAiOauth?.accessToken);
+  } catch (_e) {
+    return null;
+  }
 }
 
 async function readCodexAccessToken({ home, env } = {}) {

--- a/src/lib/subscriptions.js
+++ b/src/lib/subscriptions.js
@@ -228,7 +228,9 @@ function detectClaudeCodeCredentialsPresence({ platform, securityRunner, home, f
     return null;
   }
 
-  // Linux (and any non-darwin) — credentials live in ~/.claude/.credentials.json.
+  if (platform !== "linux") return null;
+
+  // Linux: credentials live in ~/.claude/.credentials.json (mode 0600).
   // Existence-only: just check that the file is readable and contains the OAuth key.
   const raw = readClaudeCodeCredentialsLinuxFile({ home, fsReader });
   if (!raw) return null;
@@ -268,9 +270,11 @@ function detectClaudeCodeSubscriptionDetails({ platform, securityRunner, home, f
       const raw = readMacosKeychainPassword({ service, securityRunner });
       if (raw) rawPayloads.push(raw);
     }
-  } else {
+  } else if (platform === "linux") {
     const raw = readClaudeCodeCredentialsLinuxFile({ home, fsReader });
     if (raw) rawPayloads.push(raw);
+  } else {
+    return null;
   }
 
   for (const raw of rawPayloads) {
@@ -364,6 +368,8 @@ function readClaudeCodeAccessToken({ platform, securityRunner, home, fsReader } 
     }
     return null;
   }
+
+  if (platform !== "linux") return null;
 
   // Linux: Claude Code stores the OAuth payload as a JSON file with mode 0600.
   const raw = readClaudeCodeCredentialsLinuxFile({ home, fsReader });

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -1531,7 +1531,7 @@ async function getUsageLimits({
   }
 
   const [claudeToken, codexAuth] = await Promise.all([
-    Promise.resolve().then(() => readClaudeCodeAccessToken({ platform, securityRunner })),
+    Promise.resolve().then(() => readClaudeCodeAccessToken({ platform, securityRunner, home })),
     readCodexAuthBundle({ home, env }),
   ]);
 

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -242,6 +242,89 @@ test("collectLocalSubscriptions falls back to Claude Code keychain presence when
   }
 });
 
+test("collectLocalSubscriptions reads Claude Code credentials from ~/.claude/.credentials.json on Linux", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-subscriptions-claude-linux-"));
+
+  try {
+    await writeJson(path.join(tmp, ".claude", ".credentials.json"), {
+      claudeAiOauth: {
+        accessToken: "secret-access",
+        refreshToken: "secret-refresh",
+        subscriptionType: "max",
+        rateLimitTier: "tier-1",
+      },
+    });
+
+    const subs = await collectLocalSubscriptions({
+      home: tmp,
+      env: {},
+      platform: "linux",
+      probeKeychain: true,
+      probeKeychainDetails: true,
+    });
+
+    assert.equal(subs.length, 1);
+    assert.deepEqual(subs[0], {
+      tool: "claude",
+      provider: "anthropic",
+      product: "subscription",
+      planType: "max",
+      rateLimitTier: "tier-1",
+    });
+    assert.ok(!("accessToken" in subs[0]));
+    assert.ok(!("refreshToken" in subs[0]));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("collectLocalSubscriptions reports Linux Claude Code credentials presence when details missing", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-subscriptions-claude-linux-presence-"));
+
+  try {
+    // Payload without subscriptionType — details extractor returns null, fall back to presence.
+    await writeJson(path.join(tmp, ".claude", ".credentials.json"), {
+      claudeAiOauth: { accessToken: "secret-access" },
+    });
+
+    const subs = await collectLocalSubscriptions({
+      home: tmp,
+      env: {},
+      platform: "linux",
+      probeKeychain: true,
+      probeKeychainDetails: true,
+    });
+
+    assert.equal(subs.length, 1);
+    assert.deepEqual(subs[0], {
+      tool: "claude",
+      provider: "anthropic",
+      product: "credentials",
+      planType: "present",
+    });
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("collectLocalSubscriptions hides Claude Code line on Linux when credentials file is absent", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-subscriptions-claude-linux-miss-"));
+
+  try {
+    const subs = await collectLocalSubscriptions({
+      home: tmp,
+      env: {},
+      platform: "linux",
+      probeKeychain: true,
+      probeKeychainDetails: true,
+    });
+
+    assert.deepEqual(subs, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("collectLocalSubscriptions includes OpenClaw when session plugin is configured", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-subscriptions-openclaw-"));
 

--- a/test/subscriptions.test.js
+++ b/test/subscriptions.test.js
@@ -307,6 +307,32 @@ test("collectLocalSubscriptions reports Linux Claude Code credentials presence w
   }
 });
 
+test("collectLocalSubscriptions does not read ~/.claude/.credentials.json on platforms other than Linux/macOS", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-subscriptions-claude-win32-"));
+
+  try {
+    // Real-looking credentials file on disk — but platform is win32, so it must be ignored.
+    await writeJson(path.join(tmp, ".claude", ".credentials.json"), {
+      claudeAiOauth: {
+        accessToken: "should-not-be-read",
+        subscriptionType: "max",
+      },
+    });
+
+    const subs = await collectLocalSubscriptions({
+      home: tmp,
+      env: {},
+      platform: "win32",
+      probeKeychain: true,
+      probeKeychainDetails: true,
+    });
+
+    assert.deepEqual(subs, []);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("collectLocalSubscriptions hides Claude Code line on Linux when credentials file is absent", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-subscriptions-claude-linux-miss-"));
 

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -398,6 +398,89 @@ describe("getUsageLimits", () => {
     }
   });
 
+  it("reads the Claude OAuth access token from ~/.claude/.credentials.json on Linux", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-linux-"));
+    try {
+      const claudeDir = path.join(tmp, ".claude");
+      fs.mkdirSync(claudeDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(claudeDir, ".credentials.json"),
+        JSON.stringify({
+          claudeAiOauth: {
+            accessToken: "linux-claude-token",
+            subscriptionType: "max",
+            rateLimitTier: "tier-1",
+          },
+        }),
+      );
+
+      let observedAuth = null;
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 1000,
+        securityRunner() {
+          // No keychain on Linux; if the macOS path is taken by mistake this would be the wrong token.
+          return { status: 1, stdout: "" };
+        },
+        commandRunner() {
+          return { status: 1, stdout: "" };
+        },
+        fetchImpl(url, opts) {
+          if (typeof url === "string" && url === "https://api.anthropic.com/api/oauth/usage") {
+            observedAuth = opts?.headers?.Authorization || null;
+            return Promise.resolve({
+              ok: true,
+              status: 200,
+              json: async () => ({
+                five_hour: { utilization: 0.4 },
+                seven_day: { utilization: 0.12 },
+                seven_day_opus: null,
+              }),
+            });
+          }
+          return new Promise(() => {});
+        },
+      });
+
+      assert.equal(observedAuth, "Bearer linux-claude-token");
+      assert.equal(result.claude.configured, true);
+      assert.equal(result.claude.error, null);
+      assert.deepEqual(result.claude.five_hour, { utilization: 0.4 });
+      assert.deepEqual(result.claude.seven_day, { utilization: 0.12 });
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("reports Claude unconfigured on Linux when the credentials file is missing", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-linux-missing-"));
+    try {
+      const result = await getUsageLimits({
+        home: tmp,
+        platform: "linux",
+        providerTimeoutMs: 1000,
+        securityRunner() {
+          return { status: 1, stdout: "" };
+        },
+        commandRunner() {
+          return { status: 1, stdout: "" };
+        },
+        fetchImpl() {
+          return new Promise(() => {});
+        },
+      });
+
+      assert.equal(result.claude.configured, false);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("does not block the whole response when Claude usage hangs", async () => {
     resetUsageLimitsCache();
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-timeout-"));


### PR DESCRIPTION
## Summary

The Limits page shows `claude: not connected` for Linux users even when they're logged in to Claude Code. Root cause: `readClaudeCodeAccessToken` (and the two related subscription probes) return `null` on any non-darwin platform, because they only read from the macOS Keychain.

Claude Code on Linux persists the same OAuth payload as a plain JSON file at `~/.claude/.credentials.json`. The shape is identical to the Keychain payload:

```json
{ "claudeAiOauth": { "accessToken": "…", "subscriptionType": "…", "rateLimitTier": "…" } }
```

This PR routes the three Claude credential functions through a shared `readClaudeCodeCredentialsLinuxFile` helper for non-darwin platforms. macOS behavior is unchanged — the Keychain path is taken first for `platform === "darwin"`.

## Changes

- `src/lib/subscriptions.js` — add Linux fallback to `readClaudeCodeAccessToken`, `detectClaudeCodeCredentialsPresence`, `detectClaudeCodeSubscriptionDetails`. New helper `readClaudeCodeCredentialsLinuxFile` accepts an injectable `fsReader` for tests.
- `src/lib/usage-limits.js` — thread `home` through to `readClaudeCodeAccessToken` so the Linux file reader has a home directory to resolve against (already passed to other token readers like `readCodexAuthBundle`).
- `test/subscriptions.test.js` — +3 tests: subscription details from `.credentials.json`, presence-only fallback, missing-file path.
- `test/usage-limits.test.js` — +2 tests: full `getUsageLimits` flow on Linux successfully sends `Authorization: Bearer …` to `api.anthropic.com/api/oauth/usage`, and reports `configured: false` when the file is missing.

## Test plan

- [x] `node --test test/subscriptions.test.js test/usage-limits.test.js` — 40/40 pass (added 5)
- [x] `npm test` — no new failures vs `main` (pre-existing failures in `details-*`, `mock-*`, `graph-*`, etc. are unrelated)
- [x] Manually verified on Ubuntu 24.04: applied the patch to a running installation, hit `GET /functions/tokentracker-usage-limits`, observed `claude.configured: true` with real `five_hour` / `seven_day` utilization numbers (was `configured: false` before the patch).

## Notes

- Scope intentionally limited to Linux. Windows uses DPAPI/wincred and would need a separate implementation.
- Does not honor `CLAUDE_CONFIG_DIR` because the rest of the codebase (e.g. `activation-check.js`, `claude-categorizer.js`) also hard-codes `path.join(home, ".claude", …)`. Honoring it across the codebase would be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code credential detection extended to Linux, allowing local OAuth tokens and subscription details to be recognized on Linux systems.

* **Enhancements**
  * Usage reporting now reads Linux Claude credentials when present and uses the token for provider requests, improving Claude usage normalization.

* **Tests**
  * Added Linux-focused tests covering credential presence, subscription detection, token-based usage calls, and missing-file behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->