### PR TITLE
Fix Grok legacy baseline migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix Grok Build token inflation without silently rewriting local queues; historical repair is now explicit and append-only.
 - Restored `parseResult.filesProcessed` and `parseResult.bucketsQueued` in `sync.js` totals; Codex/Every-Code rollout sources were previously under-counted in the sync summary.
 - `tokentracker serve` now suggests `npx tokentracker-cli serve --port ...` when the requested port is still occupied, matching the published npm package name and avoiding the `E404` path reported in issue #30.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 | **Kimi Code** | ✅ Auto | Passive `wire.jsonl` reader (`~/.kimi/sessions/**/wire.jsonl`) |
 | **oh-my-pi (Pi Coding Agent)** | ✅ Auto | Passive reader (`~/.omp/agent/sessions/**/*.jsonl`) |
 | **CodeBuddy** (Tencent) | ✅ Auto | SessionEnd hook in `~/.codebuddy/settings.json` (Claude-Code fork) |
-| **Grok Build** (xAI) | ✅ Auto | SessionEnd hook + passive `signals.json` scan (`~/.grok/sessions/**/signals.json`) |
+| **Grok Build** (xAI) | ✅ Auto | SessionEnd hook + passive `updates.jsonl` / `signals.json` scan (`~/.grok/sessions/**/`) |
 | **Kilo CLI** (kilo.ai) | ✅ Auto | Passive SQLite reader (`~/.local/share/kilo/kilo.db`, OpenCode-fork schema) |
 | **Kilo Code** (VS Code extension) | ✅ Auto | Passive `ui_messages.json` reader (Cursor/Code/CodeBuddy/Windsurf globalStorage) |
 | **Antigravity** | ✅ Auto | Passive transcript reader (`~/.gemini/{antigravity,antigravity-ide,antigravity-cli}/brain/**/transcript.jsonl`) |
@@ -167,7 +167,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 > - **Hook-based** tools (Claude Code, Codex, Gemini, Every Code, **CodeBuddy**, **Grok Build**) — we write a SessionEnd hook or TOML notify entry into the tool's own config.
 > - **Plugin-based** tools (OpenCode, **OpenClaw**) — the plugin ships inside the npm package (`~/.tokentracker/app/openclaw-plugin/`). We link it via the tool's own CLI (`openclaw plugins install --link …` + `enable`). No download, no drag-and-drop.
 > - **Passive readers** (Cursor, Kiro, Hermes, Kimi Code, Copilot, **Grok Build**, **oh-my-pi**, **Kilo CLI**, **Kilo Code**, **Antigravity**) — nothing is installed into those tools. We only read files they already produce (SQLite DB, JSONL, OTEL export).
-> - **Grok Build estimate** — current `signals.json` data exposes `contextTokensUsed` snapshots, so TokenTracker estimates Grok usage and cost until per-call telemetry is available.
+> - **Grok Build estimate** — current local telemetry exposes cumulative `updates.jsonl` `totalTokens`, but not a stable prompt/output/cache split; `signals.json` remains a fallback with `contextTokensUsed` snapshots. TokenTracker estimates Grok cost until per-call usage details are available.
 >
 > Run `tokentracker status` anytime to verify every integration's state. If something shows `skipped`, the `detail` column explains why (e.g. tool CLI not on `PATH`, config unreadable).
 >

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -159,7 +159,7 @@ brew install mm7894215/tokentracker/tokentracker
 | **Kimi Code** | ✅ 自动 | 被动读取 `wire.jsonl`（`~/.kimi/sessions/**/wire.jsonl`） |
 | **oh-my-pi (Pi Coding Agent)** | ✅ 自动 | 被动读取（`~/.omp/agent/sessions/**/*.jsonl`） |
 | **CodeBuddy** (腾讯) | ✅ 自动 | 写入 `~/.codebuddy/settings.json` 的 SessionEnd hook（Claude-Code fork） |
-| **Grok Build** (xAI) | ✅ 自动 | SessionEnd hook + 被动扫描 `signals.json`（`~/.grok/sessions/**/signals.json`） |
+| **Grok Build** (xAI) | ✅ 自动 | SessionEnd hook + 被动扫描 `updates.jsonl` / `signals.json`（`~/.grok/sessions/**/`） |
 | **Kilo CLI** (kilo.ai) | ✅ 自动 | 被动读取 SQLite（`~/.local/share/kilo/kilo.db`，OpenCode-fork schema） |
 | **Kilo Code** (VS Code 插件) | ✅ 自动 | 被动读取 `ui_messages.json`（Cursor / VS Code / CodeBuddy / Windsurf 的 globalStorage） |
 
@@ -167,7 +167,7 @@ brew install mm7894215/tokentracker/tokentracker
 > - **基于 hook 的工具**（Claude Code、Codex、Gemini、Every Code、**CodeBuddy**、**Grok Build**）—— 我们把 SessionEnd hook 或 TOML notify 条目写入它们自己的配置文件
 > - **基于插件的工具**（OpenCode、**OpenClaw**）—— 插件随 npm 包一起分发（`~/.tokentracker/app/openclaw-plugin/`），通过对应工具自己的 CLI 挂接（`openclaw plugins install --link …` + `enable`）。无需下载、无需拖拽
 > - **被动读取类**（Cursor、Kiro、Hermes、Kimi Code、Copilot、**Grok Build**、**oh-my-pi**、**Kilo CLI**、**Kilo Code**、**Antigravity**）—— 完全不往它们里面塞东西，只读取它们自己产生的文件（SQLite DB、JSONL、OTEL 导出、会话轨迹日志）
-> - **Grok Build 估算说明** —— Grok 当前的 `signals.json` 暴露的是 `contextTokensUsed` 快照，所以在 Grok 提供按调用粒度的遥测之前，TokenTracker 对 Grok 的用量与成本是估算值
+> - **Grok Build 估算说明** —— Grok 当前本地遥测提供 `updates.jsonl` 里的累计 `totalTokens`，但还没有稳定的输入/输出/cache 拆分；`signals.json` 仍作为 `contextTokensUsed` 快照兜底。所以在 Grok 提供按调用粒度的用量明细之前，TokenTracker 对 Grok 成本仍是估算值
 >
 > 任何时候都可以用 `tokentracker status` 查看每个集成的状态。如果显示 `skipped`，`detail` 列会解释原因（例如某工具 CLI 不在 `PATH` 上、config 不可读等）。
 >

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -125,8 +125,6 @@ async function cmdInit(argv) {
     config: existingConfig || {},
     env: process.env,
   });
-  const baseUrl = runtime.baseUrl;
-  let dashboardUrl = runtime.dashboardUrl || DEFAULT_DASHBOARD_URL;
   const notifyPath = path.join(binDir, "notify.cjs");
   const appDir = path.join(trackerDir, "app");
   const trackerBinPath = path.join(appDir, "bin", "tracker.js");
@@ -172,7 +170,6 @@ async function cmdInit(argv) {
     setup = await runSetup({
       opts,
       home,
-      baseUrl,
       trackerDir,
       binDir,
       configPath,
@@ -302,7 +299,6 @@ async function buildDryRunSummary({ opts, home, trackerDir, notifyPath, runtime 
 async function runSetup({
   opts,
   home,
-  baseUrl,
   trackerDir,
   binDir,
   configPath,
@@ -323,10 +319,18 @@ async function runSetup({
 
   await installLocalTrackerApp({ appDir });
 
+  const existingPlainConfig =
+    existingConfig && typeof existingConfig === "object" && !Array.isArray(existingConfig)
+      ? existingConfig
+      : {};
   const config = {
+    ...existingPlainConfig,
     installedAt,
-    baseUrl: DEFAULT_BASE_URL,
+    baseUrl: opts.baseUrl || existingPlainConfig.baseUrl || DEFAULT_BASE_URL,
   };
+  if (opts.dashboardUrl) {
+    config.dashboardUrl = opts.dashboardUrl;
+  }
 
   await writeJson(configPath, config);
   await chmod600IfPossible(configPath);

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -44,18 +44,6 @@ async function cmdServe(argv) {
     process.stdout.write(`Runtime refresh warning: ${e?.message || e}\n`);
   }
 
-  // 0.1 Ensure config.json baseUrl matches the canonical default
-  try {
-    const { DEFAULT_BASE_URL } = require("../lib/runtime-config");
-    const { readJson, writeJson } = require("../lib/fs");
-    const cfgPath = path.join(trackerDir, "config.json");
-    const cfg = await readJson(cfgPath);
-    if (cfg && cfg.baseUrl !== DEFAULT_BASE_URL) {
-      cfg.baseUrl = DEFAULT_BASE_URL;
-      await writeJson(cfgPath, cfg);
-    }
-  } catch { /* ignore */ }
-
   // 1. Optional sync
   if (opts.sync) {
     process.stdout.write("Syncing local data...\n");

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -681,18 +681,32 @@ async function cmdSync(argv) {
           ? grokHookSignal.sessionId.trim()
           : null;
       if (hookSessionId) {
+        const hookContextTokens =
+          grokHookSignal.contextTokensUsed != null
+            ? grokHookSignal.contextTokensUsed
+            : grokHookSignal.totalTokens;
         grokSessionInputs.unshift({
           sessionId: hookSessionId,
+          sessionDir:
+            typeof grokHookSignal.sessionDir === "string" ? grokHookSignal.sessionDir : undefined,
+          updatesPath:
+            typeof grokHookSignal.updatesPath === "string" ? grokHookSignal.updatesPath : undefined,
+          signalsPath:
+            typeof grokHookSignal.signalsPath === "string" ? grokHookSignal.signalsPath : undefined,
+          summaryPath:
+            typeof grokHookSignal.summaryPath === "string" ? grokHookSignal.summaryPath : undefined,
           signals: {
-            contextTokensUsed: grokHookSignal.totalTokens,
+            contextTokensUsed: hookContextTokens,
+            totalTokens: hookContextTokens,
+            totalTokensBeforeCompaction: grokHookSignal.totalTokensBeforeCompaction,
             assistantMessageCount: grokHookSignal.messageCount,
             primaryModelId: grokHookSignal.model,
             lastActiveAt: grokHookSignal.lastActive,
           },
           summary: { updated_at: grokHookSignal.lastActive },
         });
+        grokHookSignalConsumed = true;
       }
-      grokHookSignalConsumed = true;
     }
     if (grokSessionInputs.length > 0) {
       if (progress?.enabled) {

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -685,6 +685,10 @@ async function cmdSync(argv) {
           grokHookSignal.contextTokensUsed != null
             ? grokHookSignal.contextTokensUsed
             : grokHookSignal.totalTokens;
+        const hookTotalTokens =
+          grokHookSignal.totalTokens != null
+            ? grokHookSignal.totalTokens
+            : hookContextTokens;
         grokSessionInputs.unshift({
           sessionId: hookSessionId,
           sessionDir:
@@ -697,7 +701,7 @@ async function cmdSync(argv) {
             typeof grokHookSignal.summaryPath === "string" ? grokHookSignal.summaryPath : undefined,
           signals: {
             contextTokensUsed: hookContextTokens,
-            totalTokens: hookContextTokens,
+            totalTokens: hookTotalTokens,
             totalTokensBeforeCompaction: grokHookSignal.totalTokensBeforeCompaction,
             assistantMessageCount: grokHookSignal.messageCount,
             primaryModelId: grokHookSignal.model,

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -48,7 +48,6 @@ const {
   parseKilocodeIncremental,
   bucketKey,
   totalsKey,
-  groupBucketKey,
   claudeMessageDedupKey,
 } = require("../lib/rollout");
 const { computeClaudeGroundTruthBuckets } = require("../lib/claude-categorizer");
@@ -73,6 +72,7 @@ const { resolveRuntimeConfig } = require("../lib/runtime-config");
 const CURSOR_UNKNOWN_MIGRATION_KEY = "cursorUnknownPurge_2026_04";
 const ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY = "rolloutCumulativeDeltaReparse_2026_05";
 const CLAUDE_MEM_OBSERVER_REINCLUDE_KEY = "claudeMemObserverReinclude_2026_05_v3";
+const GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY = "grokAppendOnlyRepair_2026_05_v4";
 const CLAUDE_MEM_OBSERVER_PATH_SEGMENT = "--claude-mem-observer-sessions";
 // v1 had a cursor-format bug (wrote plain integer instead of {inode, offset,
 // updatedAt}), which made parseClaudeIncremental reread every jsonl from
@@ -735,6 +735,9 @@ async function cmdSync(argv) {
         bucketsQueued: grokResult.bucketsQueued + grokScanResult.bucketsQueued,
       };
     }
+    if (opts.repairGrok) {
+      await repairGrokQueueFromSessionSnapshots({ cursors, queuePath, queueStatePath });
+    }
 
     // ── GitHub Copilot CLI (OTEL JSONL files) ──
     let copilotResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
@@ -917,6 +920,7 @@ function parseArgs(argv) {
     fromRetry: false,
     fromOpenclaw: false,
     drain: false,
+    repairGrok: false,
   };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
@@ -925,6 +929,7 @@ function parseArgs(argv) {
     else if (a === "--from-retry") out.fromRetry = true;
     else if (a === "--from-openclaw") out.fromOpenclaw = true;
     else if (a === "--drain") out.drain = true;
+    else if (a === "--repair-grok") out.repairGrok = true;
     else throw new Error(`Unknown option: ${a}`);
   }
   return out;
@@ -935,9 +940,11 @@ module.exports = {
   migrateCursorUnknownBuckets,
   migrateRolloutCumulativeDeltaBuckets,
   reincludeClaudeMemObserverFiles,
+  repairGrokQueueFromSessionSnapshots,
   CURSOR_UNKNOWN_MIGRATION_KEY,
   ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY,
   CLAUDE_MEM_OBSERVER_REINCLUDE_KEY,
+  GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY,
 };
 
 function normalizeString(value) {
@@ -1305,6 +1312,344 @@ async function readQueueBatch(queuePath, startOffset, maxBuckets) {
   rl.close();
   stream.close?.();
   return { buckets: Array.from(bucketMap.values()), nextOffset: offset };
+}
+
+function normalizeGrokRepairSource(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function normalizeGrokRepairModel(value) {
+  return typeof value === "string" && value.trim() ? value.trim() : "grok-build";
+}
+
+function normalizeGrokRepairNumber(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function toGrokRepairHalfHourStart(value) {
+  if (value == null) return null;
+  const millis =
+    typeof value === "number"
+      ? value < 10_000_000_000
+        ? value * 1000
+        : value
+      : Date.parse(String(value));
+  if (!Number.isFinite(millis)) return null;
+  const halfHourMs = 30 * 60 * 1000;
+  return new Date(Math.floor(millis / halfHourMs) * halfHourMs).toISOString();
+}
+
+function estimateGrokRepairTotals(totalTokens, conversationCount) {
+  const total = Math.trunc(normalizeGrokRepairNumber(totalTokens));
+  const inputTokens = Math.round(total * 0.8);
+  const outputTokens = Math.max(0, total - inputTokens);
+  return {
+    input_tokens: inputTokens,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: outputTokens,
+    reasoning_output_tokens: 0,
+    total_tokens: total,
+    billable_total_tokens: total,
+    conversation_count: Math.trunc(normalizeGrokRepairNumber(conversationCount)),
+  };
+}
+
+function addGrokRepairTotals(target, delta) {
+  target.input_tokens += delta.input_tokens;
+  target.cached_input_tokens += delta.cached_input_tokens;
+  target.cache_creation_input_tokens += delta.cache_creation_input_tokens;
+  target.output_tokens += delta.output_tokens;
+  target.reasoning_output_tokens += delta.reasoning_output_tokens;
+  target.total_tokens += delta.total_tokens;
+  target.billable_total_tokens += delta.billable_total_tokens;
+  target.conversation_count += delta.conversation_count;
+}
+
+function buildGrokRepairRowsFromSnapshots(sessionSnapshots) {
+  if (!sessionSnapshots || typeof sessionSnapshots !== "object") return [];
+
+  const buckets = new Map();
+  for (const snapshot of Object.values(sessionSnapshots)) {
+    if (!snapshot || typeof snapshot !== "object") continue;
+    const totalTokens = Math.trunc(normalizeGrokRepairNumber(snapshot.totalTokens));
+    if (totalTokens <= 0) continue;
+
+    const hourStart = toGrokRepairHalfHourStart(
+      snapshot.lastEventTimestamp || snapshot.updatedAt,
+    );
+    if (!hourStart) continue;
+
+    const model = normalizeGrokRepairModel(snapshot.model);
+    const key = bucketKey("grok", model, hourStart);
+    let totals = buckets.get(key);
+    if (!totals) {
+      totals = {
+        source: "grok",
+        model,
+        hour_start: hourStart,
+        input_tokens: 0,
+        cached_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+        output_tokens: 0,
+        reasoning_output_tokens: 0,
+        total_tokens: 0,
+        billable_total_tokens: 0,
+        conversation_count: 0,
+      };
+      buckets.set(key, totals);
+    }
+    addGrokRepairTotals(
+      totals,
+      estimateGrokRepairTotals(totalTokens, snapshot.messageCount),
+    );
+  }
+
+  return Array.from(buckets.values()).sort((a, b) => {
+    const timeCompare = a.hour_start.localeCompare(b.hour_start);
+    return timeCompare || a.model.localeCompare(b.model);
+  });
+}
+
+function applyGrokRepairHourlyState(cursors, rows) {
+  const hourly = cursors.hourly && typeof cursors.hourly === "object" ? cursors.hourly : {};
+  const buckets = hourly.buckets && typeof hourly.buckets === "object" ? hourly.buckets : {};
+  const groupQueued =
+    hourly.groupQueued && typeof hourly.groupQueued === "object" ? hourly.groupQueued : {};
+
+  for (const key of Object.keys(buckets)) {
+    if (key.startsWith("grok|")) {
+      delete buckets[key];
+    }
+  }
+  for (const key of Object.keys(groupQueued)) {
+    if (key.startsWith("grok|")) {
+      delete groupQueued[key];
+    }
+  }
+
+  for (const row of rows) {
+    const totals = {
+      input_tokens: row.input_tokens,
+      cached_input_tokens: row.cached_input_tokens,
+      cache_creation_input_tokens: row.cache_creation_input_tokens,
+      output_tokens: row.output_tokens,
+      reasoning_output_tokens: row.reasoning_output_tokens,
+      total_tokens: row.total_tokens,
+      billable_total_tokens: row.billable_total_tokens,
+      conversation_count: row.conversation_count,
+    };
+    buckets[bucketKey("grok", row.model, row.hour_start)] = {
+      totals,
+      queuedKey: totalsKey(totals),
+      source: "grok",
+      hour_start: row.hour_start,
+    };
+  }
+
+  cursors.hourly = {
+    ...hourly,
+    version: 3,
+    buckets,
+    groupQueued,
+    updatedAt: typeof hourly.updatedAt === "string" ? hourly.updatedAt : null,
+  };
+}
+
+async function resetGrokRepairUploadOffset(queueStatePath) {
+  if (typeof queueStatePath !== "string" || !queueStatePath) return false;
+  let state = {};
+  try {
+    state = JSON.parse(await fs.readFile(queueStatePath, "utf8"));
+  } catch (_e) {
+    state = {};
+  }
+  state.offset = 0;
+  state.updatedAt = new Date().toISOString();
+  state.note = "reset_after_grok_append_only_repair_2026_05_v4";
+  await ensureDir(path.dirname(queueStatePath));
+  await fs.writeFile(queueStatePath, JSON.stringify(state, null, 2) + "\n", "utf8");
+  return true;
+}
+
+function hasAppliedGrokRepairMigration(value) {
+  if (!value) return false;
+  if (value === true) return true;
+  if (value && typeof value === "object") {
+    if (value.status === "applied" || value.status === "noop") return true;
+    if (value.status) return false;
+    return value.rowsWritten != null || value.rowsRemoved != null;
+  }
+  return false;
+}
+
+function serializeGrokRepairRow(row) {
+  return JSON.stringify({
+    source: "grok",
+    model: normalizeGrokRepairModel(row.model),
+    hour_start: row.hour_start,
+    input_tokens: row.input_tokens || 0,
+    cached_input_tokens: row.cached_input_tokens || 0,
+    cache_creation_input_tokens: row.cache_creation_input_tokens || 0,
+    output_tokens: row.output_tokens || 0,
+    reasoning_output_tokens: row.reasoning_output_tokens || 0,
+    total_tokens: row.total_tokens || 0,
+    billable_total_tokens: row.billable_total_tokens || 0,
+    conversation_count: row.conversation_count || 0,
+  });
+}
+
+async function backupExistingFile(filePath) {
+  if (typeof filePath !== "string" || !filePath) return null;
+  try {
+    const stat = await fs.stat(filePath);
+    if (!stat.isFile()) return null;
+  } catch (e) {
+    if (e?.code === "ENOENT" || e?.code === "ENOTDIR") return null;
+    throw e;
+  }
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const backupPath = `${filePath}.bak.${stamp}`;
+  await fs.copyFile(filePath, backupPath);
+  return backupPath;
+}
+
+async function repairGrokQueueFromSessionSnapshots({ cursors, queuePath, queueStatePath } = {}) {
+  if (!cursors || typeof cursors !== "object") return false;
+  const grokState = (cursors.grok ||= {});
+  const migrations = (grokState.migrations ||= {});
+  if (hasAppliedGrokRepairMigration(migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY])) {
+    return false;
+  }
+
+  let raw = "";
+  try {
+    raw = await fs.readFile(queuePath, "utf8");
+  } catch (e) {
+    if (e?.code !== "ENOENT") throw e;
+  }
+
+  const latestGrokRows = new Map();
+  let existingGrokRows = 0;
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let row;
+    try {
+      row = JSON.parse(line);
+    } catch (_e) {
+      continue;
+    }
+
+    if (normalizeGrokRepairSource(row?.source) === "grok") {
+      const model = normalizeGrokRepairModel(row.model);
+      const hourStart = typeof row.hour_start === "string" ? row.hour_start : null;
+      if (!hourStart) continue;
+      existingGrokRows += 1;
+      latestGrokRows.set(bucketKey("grok", model, hourStart), {
+        ...row,
+        source: "grok",
+        model,
+        hour_start: hourStart,
+      });
+    }
+  }
+
+  if (existingGrokRows === 0) {
+    migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY] = {
+      status: "noop",
+      appliedAt: new Date().toISOString(),
+      existingGrokRows: 0,
+      rowsWritten: 0,
+      snapshotsUsed: 0,
+      uploadOffsetReset: false,
+    };
+    return false;
+  }
+
+  const repairRows = buildGrokRepairRowsFromSnapshots(grokState.sessionSnapshots);
+  if (repairRows.length === 0) {
+    migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY] = {
+      status: "skipped",
+      appliedAt: new Date().toISOString(),
+      reason: "missing-session-snapshots",
+      existingGrokRows,
+      rowsWritten: 0,
+      snapshotsUsed: 0,
+      uploadOffsetReset: false,
+    };
+    return false;
+  }
+
+  applyGrokRepairHourlyState(cursors, repairRows);
+
+  const repairLines = [];
+  const repairKeys = new Set();
+  for (const row of repairRows) {
+    const key = bucketKey("grok", row.model, row.hour_start);
+    repairKeys.add(key);
+    const current = latestGrokRows.get(key);
+    if (current && totalsKey(current) === totalsKey(row)) continue;
+    repairLines.push(serializeGrokRepairRow(row));
+  }
+
+  const zeroTotals = {
+    input_tokens: 0,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    output_tokens: 0,
+    reasoning_output_tokens: 0,
+    total_tokens: 0,
+    billable_total_tokens: 0,
+    conversation_count: 0,
+  };
+  let staleRowsRetracted = 0;
+  for (const [key, row] of latestGrokRows.entries()) {
+    if (repairKeys.has(key)) continue;
+    if (totalsKey(row) === totalsKey(zeroTotals)) continue;
+    staleRowsRetracted += 1;
+    repairLines.push(serializeGrokRepairRow({
+      ...zeroTotals,
+      model: row.model,
+      hour_start: row.hour_start,
+    }));
+  }
+
+  if (repairLines.length === 0) {
+    migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY] = {
+      status: "noop",
+      appliedAt: new Date().toISOString(),
+      existingGrokRows,
+      rowsWritten: 0,
+      staleRowsRetracted,
+      snapshotsUsed: repairRows.length,
+      uploadOffsetReset: false,
+    };
+    return false;
+  }
+
+  await ensureDir(path.dirname(queuePath));
+  const queueBackupPath = await backupExistingFile(queuePath);
+  const queueStateBackupPath = await backupExistingFile(queueStatePath);
+  await fs.appendFile(queuePath, `${repairLines.join("\n")}\n`, "utf8");
+
+  const uploadOffsetReset = await resetGrokRepairUploadOffset(queueStatePath);
+  migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY] = {
+    status: "applied",
+    appliedAt: new Date().toISOString(),
+    existingGrokRows,
+    rowsWritten: repairLines.length,
+    staleRowsRetracted,
+    snapshotsUsed: Object.values(grokState.sessionSnapshots || {}).filter((snapshot) => {
+      if (!snapshot || typeof snapshot !== "object") return false;
+      if (Math.trunc(normalizeGrokRepairNumber(snapshot.totalTokens)) <= 0) return false;
+      return Boolean(toGrokRepairHalfHourStart(snapshot.lastEventTimestamp || snapshot.updatedAt));
+    }).length,
+    uploadOffsetReset,
+    queueBackupPath,
+    queueStateBackupPath,
+  };
+  return true;
 }
 
 async function migrateCursorUnknownBuckets({ cursors, queuePath }) {

--- a/src/lib/grok-hook.js
+++ b/src/lib/grok-hook.js
@@ -207,7 +207,7 @@ async function readUpdateTelemetry(filePath) {
 }
 
 async function main() {
-const contextTokensUsed = toNonNegativeFiniteNumber(signals.contextTokensUsed || signals.totalTokens);
+const contextTokensUsed = toNonNegativeFiniteNumber(signals.contextTokensUsed ?? signals.totalTokens);
 const totalTokensBeforeCompaction = toNonNegativeFiniteNumber(signals.totalTokensBeforeCompaction);
 const signalTotalTokens = totalTokensBeforeCompaction + contextTokensUsed;
 const updateTelemetry = await readUpdateTelemetry(updatesPath);

--- a/src/lib/grok-hook.js
+++ b/src/lib/grok-hook.js
@@ -102,6 +102,7 @@ function buildGrokSessionEndHandler({ trackerDir }) {
 const fs = require('node:fs');
 const path = require('node:path');
 const os = require('node:os');
+const readline = require('node:readline');
 
 const GROK_HOME = process.env.TOKENTRACKER_GROK_HOME || process.env.GROK_HOME || path.join(os.homedir(), '.grok');
 const SESSION_ID = process.env.GROK_SESSION_ID;
@@ -164,47 +165,52 @@ function timestampToIso(value) {
   return null;
 }
 
-function readUpdateTelemetry(filePath) {
-  let text = '';
-  try {
-    text = fs.readFileSync(filePath, 'utf8');
-  } catch {
-    return { totalTokens: 0, lastEventId: null, lastEventTimestamp: null };
-  }
-
+async function readUpdateTelemetry(filePath) {
   let totalTokens = 0;
   let lastEventId = null;
   let lastEventTimestamp = null;
-  const lines = text.split('\\n');
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line || !line.trim()) continue;
-    let record = null;
+  let lineNumber = 0;
+
+  try {
+    const input = fs.createReadStream(filePath, { encoding: 'utf8' });
+    const rl = readline.createInterface({ input, crlfDelay: Infinity });
     try {
-      record = JSON.parse(line);
-    } catch {
-      continue;
+      for await (const line of rl) {
+        lineNumber += 1;
+        if (!line || !line.trim()) continue;
+        let record = null;
+        try {
+          record = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        const meta = record && record.params && record.params._meta ? record.params._meta : record && record._meta;
+        if (!meta || typeof meta !== 'object') continue;
+        const nextTotal = toNonNegativeFiniteNumber(meta.totalTokens);
+        if (nextTotal <= 0) continue;
+        totalTokens = Math.max(totalTokens, nextTotal);
+        lastEventId = meta.eventId != null ? String(meta.eventId) : String(lineNumber);
+        lastEventTimestamp =
+          timestampToIso(meta.agentTimestampMs) ||
+          timestampToIso(meta.timestampMs) ||
+          timestampToIso(record.timestamp_ms) ||
+          timestampToIso(record.timestamp) ||
+          lastEventTimestamp;
+      }
+    } finally {
+      rl.close();
     }
-    const meta = record && record.params && record.params._meta ? record.params._meta : record && record._meta;
-    if (!meta || typeof meta !== 'object') continue;
-    const nextTotal = toNonNegativeFiniteNumber(meta.totalTokens);
-    if (nextTotal <= 0) continue;
-    totalTokens = Math.max(totalTokens, nextTotal);
-    lastEventId = meta.eventId != null ? String(meta.eventId) : String(i + 1);
-    lastEventTimestamp =
-      timestampToIso(meta.agentTimestampMs) ||
-      timestampToIso(meta.timestampMs) ||
-      timestampToIso(record.timestamp_ms) ||
-      timestampToIso(record.timestamp) ||
-      lastEventTimestamp;
+  } catch {
+    return { totalTokens, lastEventId, lastEventTimestamp };
   }
   return { totalTokens, lastEventId, lastEventTimestamp };
 }
 
+async function main() {
 const contextTokensUsed = toNonNegativeFiniteNumber(signals.contextTokensUsed || signals.totalTokens);
 const totalTokensBeforeCompaction = toNonNegativeFiniteNumber(signals.totalTokensBeforeCompaction);
 const signalTotalTokens = totalTokensBeforeCompaction + contextTokensUsed;
-const updateTelemetry = readUpdateTelemetry(updatesPath);
+const updateTelemetry = await readUpdateTelemetry(updatesPath);
 const totalTokens = Math.max(updateTelemetry.totalTokens, signalTotalTokens);
 const messageCount = toNonNegativeFiniteNumber(signals.assistantMessageCount || signals.num_chat_messages);
 const model = signals.primaryModelId || (Array.isArray(signals.modelsUsed) ? signals.modelsUsed[0] : 'grok-build');
@@ -247,6 +253,9 @@ try {
 } catch {}
 
 process.exit(0);
+}
+
+main().catch(() => process.exit(0));
 `;
 }
 

--- a/src/lib/grok-hook.js
+++ b/src/lib/grok-hook.js
@@ -94,8 +94,8 @@ function buildGrokSessionEndHandler({ trackerDir }) {
   // It must be self-contained enough or rely on the copied runtime.
   // For simplicity and reliability we write a small script that:
   // 1. Reads GROK_SESSION_ID + GROK_WORKSPACE_ROOT from env
-  // 2. Locates the signals.json
-  // 3. Extracts usage
+  // 2. Locates the session metadata files
+  // 3. Extracts usage metadata only
   // 4. Writes a signal file under trackerDir that sync.js will pick up on next run
 
   return `#!/usr/bin/env node
@@ -120,14 +120,17 @@ const encodedCwd = encodeGrokCwd(WORKSPACE_ROOT);
 const sessionDir = path.join(GROK_HOME, 'sessions', encodedCwd, SESSION_ID);
 const signalsPath = path.join(sessionDir, 'signals.json');
 const summaryPath = path.join(sessionDir, 'summary.json');
+const updatesPath = path.join(sessionDir, 'updates.jsonl');
 
-let signals = null;
+let signals = {};
 try {
   const raw = fs.readFileSync(signalsPath, 'utf8');
   signals = JSON.parse(raw);
 } catch (err) {
-  // Session may still be active or signals not written yet; exit quietly
-  process.exit(0);
+  signals = {};
+}
+if (!signals || typeof signals !== 'object') {
+  signals = {};
 }
 
 const summary = (() => {
@@ -143,10 +146,69 @@ function toNonNegativeFiniteNumber(value) {
   return Number.isFinite(number) && number > 0 ? number : 0;
 }
 
-const totalTokens = toNonNegativeFiniteNumber(signals.contextTokensUsed);
+function timestampToIso(value) {
+  if (value == null) return null;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return null;
+    const millis = value < 10000000000 ? value * 1000 : value;
+    const dt = new Date(millis);
+    return Number.isFinite(dt.getTime()) ? dt.toISOString() : null;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (/^[0-9]+(?:\\.[0-9]+)?$/.test(trimmed)) return timestampToIso(Number(trimmed));
+    const dt = new Date(trimmed);
+    return Number.isFinite(dt.getTime()) ? dt.toISOString() : null;
+  }
+  return null;
+}
+
+function readUpdateTelemetry(filePath) {
+  let text = '';
+  try {
+    text = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return { totalTokens: 0, lastEventId: null, lastEventTimestamp: null };
+  }
+
+  let totalTokens = 0;
+  let lastEventId = null;
+  let lastEventTimestamp = null;
+  const lines = text.split('\\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line || !line.trim()) continue;
+    let record = null;
+    try {
+      record = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const meta = record && record.params && record.params._meta ? record.params._meta : record && record._meta;
+    if (!meta || typeof meta !== 'object') continue;
+    const nextTotal = toNonNegativeFiniteNumber(meta.totalTokens);
+    if (nextTotal <= 0) continue;
+    totalTokens = Math.max(totalTokens, nextTotal);
+    lastEventId = meta.eventId != null ? String(meta.eventId) : String(i + 1);
+    lastEventTimestamp =
+      timestampToIso(meta.agentTimestampMs) ||
+      timestampToIso(meta.timestampMs) ||
+      timestampToIso(record.timestamp_ms) ||
+      timestampToIso(record.timestamp) ||
+      lastEventTimestamp;
+  }
+  return { totalTokens, lastEventId, lastEventTimestamp };
+}
+
+const contextTokensUsed = toNonNegativeFiniteNumber(signals.contextTokensUsed || signals.totalTokens);
+const totalTokensBeforeCompaction = toNonNegativeFiniteNumber(signals.totalTokensBeforeCompaction);
+const signalTotalTokens = totalTokensBeforeCompaction + contextTokensUsed;
+const updateTelemetry = readUpdateTelemetry(updatesPath);
+const totalTokens = Math.max(updateTelemetry.totalTokens, signalTotalTokens);
 const messageCount = toNonNegativeFiniteNumber(signals.assistantMessageCount || signals.num_chat_messages);
 const model = signals.primaryModelId || (Array.isArray(signals.modelsUsed) ? signals.modelsUsed[0] : 'grok-build');
-const lastActive = signals.lastActiveAt || summary.updated_at || new Date().toISOString();
+const lastActive = signals.lastActiveAt || updateTelemetry.lastEventTimestamp || summary.updated_at || new Date().toISOString();
 
 if (totalTokens <= 0) {
   process.exit(0);
@@ -163,8 +225,16 @@ const signal = {
   cwd: WORKSPACE_ROOT,
   model,
   totalTokens,
+  contextTokensUsed,
+  totalTokensBeforeCompaction,
   messageCount,
   lastActive,
+  sessionDir,
+  updatesPath,
+  signalsPath,
+  summaryPath,
+  lastEventId: updateTelemetry.lastEventId,
+  lastEventTimestamp: updateTelemetry.lastEventTimestamp,
   capturedAt: new Date().toISOString()
 };
 

--- a/src/lib/pricing/curated-overrides.json
+++ b/src/lib/pricing/curated-overrides.json
@@ -18,7 +18,7 @@
     "deepseek-v4-flash":{ "input": 0.14, "output": 0.28, "cache_read": 0.0028, "cache_write": 0.14 },
     "deepseek-v4-pro":  { "input": 0.435,"output": 0.87, "cache_read": 0.003625, "cache_write": 0.435 },
     "deepseek-chat":    { "input": 0.14, "output": 0.28, "cache_read": 0.0028, "cache_write": 0.14 },
-    "grok-build":       { "input": 1.25, "output": 2.50, "cache_read": 0.20, "note": "Grok Build TUI estimate. signals.json currently exposes contextTokensUsed snapshots, so TokenTracker estimates input/output split until Grok exposes per-call telemetry." },
+    "grok-build":       { "input": 1.25, "output": 2.50, "cache_read": 0.20, "note": "Grok Build TUI estimate. Local telemetry currently exposes totalTokens without a stable prompt/output/cache split, so TokenTracker estimates input/output split until Grok exposes per-call usage details." },
     "grok-4-0709":      { "input": 3.00, "output": 15.00, "cache_read": 0.75 },
     "grok-4":           { "input": 3.00, "output": 15.00, "cache_read": 0.75 },
     "grok-4-latest":    { "input": 3.00, "output": 15.00, "cache_read": 0.75 },

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5893,15 +5893,15 @@ async function parseCopilotIncremental({ otelPaths, cursors, queuePath, onProgre
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Grok Build (xAI) — passive reader for ~/.grok/sessions/**/signals.json + summary.json
+// Grok Build (xAI) — passive reader for ~/.grok/sessions/**/updates.jsonl + signals.json
 // Triggered either by full scan in sync or by the SessionEnd hook writing a signal.
-// Grok exposes contextTokensUsed, which appears to be a snapshot rather than
-// per-call telemetry, so these rows are estimates and only enqueue observed
-// increases for a session.
+// updates.jsonl exposes cumulative totalTokens metadata. Grok still does not
+// expose a stable prompt/output/cache split locally, so these rows keep the
+// estimated input/output split while using better local telemetry for totals.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const GROK_ESTIMATED_INPUT_RATIO = 0.8;
-const GROK_CURSOR_VERSION = 2;
+const GROK_CURSOR_VERSION = 3;
 
 function resolveGrokBuildHome(env = process.env) {
   return (
@@ -5936,9 +5936,11 @@ function resolveGrokBuildSessions(env = process.env) {
     for (const sid of sessionIds) {
       const sessionDir = path.join(cwdPath, sid);
       const signalsPath = path.join(sessionDir, "signals.json");
-      if (fssync.existsSync(signalsPath)) {
+      const updatesPath = path.join(sessionDir, "updates.jsonl");
+      if (fssync.existsSync(signalsPath) || fssync.existsSync(updatesPath)) {
         results.push({
           sessionDir,
+          updatesPath,
           signalsPath,
           summaryPath: path.join(sessionDir, "summary.json"),
           sessionId: sid,
@@ -5961,6 +5963,9 @@ function normalizeGrokSessionSnapshots(grokState) {
         totalTokens,
         messageCount: normalizeNonNegativeNumber(snapshot.messageCount),
         model: normalizeModelInput(snapshot.model) || null,
+        source: normalizeModelInput(snapshot.source) || null,
+        lastEventId: normalizeModelInput(snapshot.lastEventId) || null,
+        lastEventTimestamp: normalizeModelInput(snapshot.lastEventTimestamp) || null,
         updatedAt: normalizeModelInput(snapshot.updatedAt) || null,
       };
     }
@@ -5971,7 +5976,7 @@ function normalizeGrokSessionSnapshots(grokState) {
       const safeSessionId = normalizeModelInput(sessionId);
       if (!safeSessionId || snapshots[safeSessionId]) continue;
       snapshots[safeSessionId] = {
-        totalTokens: Number.MAX_SAFE_INTEGER,
+        totalTokens: 0,
         messageCount: 0,
         model: null,
         updatedAt: normalizeModelInput(grokState.updatedAt) || null,
@@ -5996,6 +6001,14 @@ function readGrokJsonFile(filePath) {
   } catch {
     return null;
   }
+}
+
+function grokUpdatesPathForSession(sess) {
+  if (typeof sess?.updatesPath === "string" && sess.updatesPath.trim()) return sess.updatesPath;
+  if (typeof sess?.sessionDir === "string" && sess.sessionDir.trim()) {
+    return path.join(sess.sessionDir, "updates.jsonl");
+  }
+  return null;
 }
 
 function grokSessionIdFor(sess) {
@@ -6025,11 +6038,110 @@ function grokLastActiveFromSignals(signals, summary) {
   );
 }
 
-function estimateGrokTokenDelta(totalTokens, conversationCount) {
+function grokMessageCountFromSignals(signals) {
+  return normalizeNonNegativeNumber(
+    signals?.assistantMessageCount ??
+      signals?.turnCount ??
+      signals?.num_chat_messages ??
+      signals?.messageCount,
+  );
+}
+
+function grokEffectiveTotalFromSignals(signals) {
+  if (!signals || typeof signals !== "object") return 0;
+  const currentContextTotal = Math.max(
+    normalizeNonNegativeNumber(signals.contextTokensUsed),
+    normalizeNonNegativeNumber(signals.totalTokens),
+  );
+  const beforeCompaction = normalizeNonNegativeNumber(signals.totalTokensBeforeCompaction);
+  return beforeCompaction + currentContextTotal;
+}
+
+function grokTimestampToIso(value) {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value) || value <= 0) return null;
+    const millis = value < 10_000_000_000 ? value * 1000 : value;
+    const dt = new Date(millis);
+    return Number.isFinite(dt.getTime()) ? dt.toISOString() : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (/^[0-9]+(?:\.[0-9]+)?$/.test(trimmed)) {
+      return grokTimestampToIso(Number(trimmed));
+    }
+    const dt = new Date(trimmed);
+    return Number.isFinite(dt.getTime()) ? dt.toISOString() : null;
+  }
+  return null;
+}
+
+function grokTimestampFromUpdate(meta, record, fallback) {
+  return (
+    grokTimestampToIso(meta?.agentTimestampMs) ||
+    grokTimestampToIso(meta?.timestampMs) ||
+    grokTimestampToIso(record?.timestamp_ms) ||
+    grokTimestampToIso(record?.timestamp) ||
+    grokTimestampToIso(record?.time) ||
+    fallback ||
+    null
+  );
+}
+
+function grokEventId(value, fallback) {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return fallback;
+}
+
+async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp) {
+  if (!updatesPath) return { events: [], recordsProcessed: 0 };
+  try {
+    const stat = fssync.statSync(updatesPath);
+    if (!stat.isFile()) return { events: [], recordsProcessed: 0 };
+  } catch {
+    return { events: [], recordsProcessed: 0 };
+  }
+
+  const events = [];
+  let lineIndex = 0;
+  const input = fssync.createReadStream(updatesPath, { encoding: "utf8" });
+  const rl = readline.createInterface({ input, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      lineIndex++;
+      if (!line || !line.trim()) continue;
+      let record;
+      try {
+        record = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const meta = record?.params?._meta || record?._meta;
+      if (!meta || typeof meta !== "object") continue;
+      const totalTokens = normalizeNonNegativeNumber(meta.totalTokens);
+      if (totalTokens <= 0) continue;
+      const timestamp = grokTimestampFromUpdate(meta, record, fallbackTimestamp);
+      events.push({
+        totalTokens,
+        timestamp,
+        eventId: grokEventId(meta.eventId ?? record?.eventId ?? record?.id, String(lineIndex)),
+      });
+    }
+  } catch {
+    return { events, recordsProcessed: events.length };
+  }
+
+  return { events, recordsProcessed: events.length };
+}
+
+function estimateGrokTokenDelta(totalTokens, conversationCount, options = {}) {
   const total = Math.trunc(normalizeNonNegativeNumber(totalTokens));
   const inputTokens = Math.round(total * GROK_ESTIMATED_INPUT_RATIO);
   const outputTokens = Math.max(0, total - inputTokens);
-  const conversations = Math.max(1, Math.trunc(normalizeNonNegativeNumber(conversationCount)));
+  const rawConversations = Math.trunc(normalizeNonNegativeNumber(conversationCount));
+  const conversations = options.allowZeroConversationCount ? rawConversations : Math.max(1, rawConversations);
 
   return {
     input_tokens: inputTokens,
@@ -6062,51 +6174,102 @@ async function parseGrokBuildIncremental({
 
   let eventsAggregated = 0;
 
-  for (const sess of sessionList) {
+  for (let index = 0; index < sessionList.length; index++) {
+    const sess = sessionList[index];
     const sessionId = grokSessionIdFor(sess);
-    if (!sessionId) continue;
+    if (!sessionId) {
+      if (onProgress) onProgress({ index: index + 1, total: sessionList.length, bucketsQueued: touchedBuckets.size });
+      continue;
+    }
 
     const signals = sess?.signals && typeof sess.signals === "object"
       ? sess.signals
       : readGrokJsonFile(sess?.signalsPath);
-    if (!signals || typeof signals !== "object") continue;
+    const safeSignals = signals && typeof signals === "object" ? signals : {};
 
     const summary = sess?.summary && typeof sess.summary === "object"
       ? sess.summary
       : readGrokJsonFile(sess?.summaryPath) || {};
-    const totalTokens = normalizeNonNegativeNumber(signals.contextTokensUsed ?? signals.totalTokens);
-    if (totalTokens <= 0) {
-      continue;
-    }
-
     const previous = sessionSnapshots[sessionId] || {};
     const previousTotal = normalizeNonNegativeNumber(previous.totalTokens);
-    const deltaTokens = totalTokens > previousTotal ? totalTokens - previousTotal : 0;
-    if (deltaTokens <= 0) continue;
-
-    const messageCount = normalizeNonNegativeNumber(
-      signals.assistantMessageCount ?? signals.num_chat_messages ?? signals.messageCount,
-    );
     const previousMessageCount = normalizeNonNegativeNumber(previous.messageCount);
-    const deltaMessageCount =
-      messageCount > previousMessageCount ? messageCount - previousMessageCount : 1;
-    const model = grokModelFromSignals(signals);
-    const lastActive = grokLastActiveFromSignals(signals, summary);
-    const hourStartStr = toUtcHalfHourStart(lastActive) || toUtcHalfHourStart(Date.now());
-    if (!hourStartStr) continue;
+    const messageCount = grokMessageCountFromSignals(safeSignals);
+    const model = grokModelFromSignals(safeSignals);
+    const lastActive = grokLastActiveFromSignals(safeSignals, summary);
 
-    const delta = estimateGrokTokenDelta(deltaTokens, deltaMessageCount);
-    const bucket = getHourlyBucket(hourlyState, "grok", model, hourStartStr);
-    addTotals(bucket.totals, delta);
-    touchedBuckets.add(bucketKey("grok", model, hourStartStr));
+    let highWatermark = previousTotal;
+    let observedTotal = previousTotal;
+    let tokenDeltaForSession = 0;
+    let finalTouchedHourStart = null;
+    let source = previous.source || null;
+    let lastEventId = previous.lastEventId || null;
+    let lastEventTimestamp = previous.lastEventTimestamp || null;
+    const pendingTokenDeltas = [];
 
-    eventsAggregated++;
-    sessionSnapshots[sessionId] = {
-      totalTokens: Math.max(previousTotal, totalTokens),
-      messageCount: Math.max(previousMessageCount, messageCount),
-      model,
-      updatedAt: new Date().toISOString(),
+    const recordTokenDelta = (deltaTokens, timestamp, deltaSource) => {
+      const hourStartStr = toUtcHalfHourStart(timestamp) || toUtcHalfHourStart(Date.now());
+      if (!hourStartStr) return false;
+      pendingTokenDeltas.push({ deltaTokens, hourStartStr });
+      tokenDeltaForSession += deltaTokens;
+      finalTouchedHourStart = hourStartStr;
+      source = deltaSource;
+      return true;
     };
+
+    const updates = await readGrokUpdateTokenEvents(grokUpdatesPathForSession(sess), lastActive);
+    for (const event of updates.events) {
+      observedTotal = Math.max(observedTotal, event.totalTokens);
+      lastEventId = event.eventId || lastEventId;
+      lastEventTimestamp = event.timestamp || lastEventTimestamp;
+      if (event.totalTokens <= highWatermark) continue;
+      const deltaTokens = event.totalTokens - highWatermark;
+      highWatermark = event.totalTokens;
+      recordTokenDelta(deltaTokens, event.timestamp || lastActive, "updates");
+    }
+
+    const effectiveSignalTotal = grokEffectiveTotalFromSignals(safeSignals);
+    observedTotal = Math.max(observedTotal, effectiveSignalTotal);
+    if (effectiveSignalTotal > highWatermark) {
+      const deltaTokens = effectiveSignalTotal - highWatermark;
+      highWatermark = effectiveSignalTotal;
+      recordTokenDelta(deltaTokens, lastActive, "signals");
+    }
+
+    const finalTotal = Math.max(previousTotal, highWatermark, observedTotal);
+    const legacyBaselineOnly = previous.legacySeen && previousTotal === 0 && finalTotal > 0;
+    if (!legacyBaselineOnly) {
+      for (const pending of pendingTokenDeltas) {
+        const delta = estimateGrokTokenDelta(pending.deltaTokens, 0, { allowZeroConversationCount: true });
+        const bucket = getHourlyBucket(hourlyState, "grok", model, pending.hourStartStr);
+        addTotals(bucket.totals, delta);
+        touchedBuckets.add(bucketKey("grok", model, pending.hourStartStr));
+        eventsAggregated++;
+      }
+    }
+
+    if (!legacyBaselineOnly && tokenDeltaForSession > 0 && finalTouchedHourStart) {
+      const deltaMessageCount =
+        messageCount > previousMessageCount ? messageCount - previousMessageCount : 1;
+      const bucket = getHourlyBucket(hourlyState, "grok", model, finalTouchedHourStart);
+      addTotals(bucket.totals, { conversation_count: deltaMessageCount });
+      touchedBuckets.add(bucketKey("grok", model, finalTouchedHourStart));
+    }
+
+    if (finalTotal > 0 && (tokenDeltaForSession > 0 || previousTotal > 0 || legacyBaselineOnly)) {
+      sessionSnapshots[sessionId] = {
+        totalTokens: finalTotal,
+        messageCount: Math.max(previousMessageCount, messageCount),
+        model,
+        source: source || previous.source || null,
+        lastEventId,
+        lastEventTimestamp,
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    if (onProgress) {
+      onProgress({ index: index + 1, total: sessionList.length, bucketsQueued: touchedBuckets.size });
+    }
   }
 
   const bucketsQueued = queuePath
@@ -6589,7 +6752,7 @@ module.exports = {
   canonicalizeProjectRef,
   deriveProjectKeyFromRef,
 
-  // Grok Build (xAI) — SessionEnd hook + passive signals.json reader
+  // Grok Build (xAI) — SessionEnd hook + passive updates.jsonl/signals.json reader
   resolveGrokBuildHome,
   resolveGrokBuildSessions,
   parseGrokBuildIncremental,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5967,6 +5967,7 @@ function normalizeGrokSessionSnapshots(grokState) {
         lastEventId: normalizeModelInput(snapshot.lastEventId) || null,
         lastEventTimestamp: normalizeModelInput(snapshot.lastEventTimestamp) || null,
         updatedAt: normalizeModelInput(snapshot.updatedAt) || null,
+        legacySeen: snapshot.legacySeen === true,
       };
     }
   }

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6050,12 +6050,15 @@ function grokMessageCountFromSignals(signals) {
 
 function grokEffectiveTotalFromSignals(signals) {
   if (!signals || typeof signals !== "object") return 0;
-  const currentContextTotal = Math.max(
-    normalizeNonNegativeNumber(signals.contextTokensUsed),
-    normalizeNonNegativeNumber(signals.totalTokens),
-  );
   const beforeCompaction = normalizeNonNegativeNumber(signals.totalTokensBeforeCompaction);
-  return beforeCompaction + currentContextTotal;
+  const totalTokens = normalizeNonNegativeNumber(signals.totalTokens);
+  if (signals.contextTokensUsed == null) {
+    return beforeCompaction + totalTokens;
+  }
+  return Math.max(
+    totalTokens,
+    beforeCompaction + normalizeNonNegativeNumber(signals.contextTokensUsed),
+  );
 }
 
 function grokTimestampToIso(value) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -6214,6 +6214,7 @@ async function parseGrokBuildIncremental({
       tokenDeltaForSession += deltaTokens;
       finalTouchedHourStart = hourStartStr;
       source = deltaSource;
+      lastEventTimestamp = timestamp || lastEventTimestamp;
       return true;
     };
 

--- a/test/grok-hook.test.js
+++ b/test/grok-hook.test.js
@@ -64,6 +64,75 @@ test("generated Grok handler skips malformed numeric signal fields", async () =>
   }
 });
 
+test("generated Grok handler writes session paths and update telemetry", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-handler-updates-"));
+  try {
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const grokHome = path.join(tmp, ".grok");
+    const workspaceRoot = path.join(tmp, "project");
+    const sessionId = "grok-session-updates";
+    const sessionDir = path.join(grokHome, "sessions", encodeURIComponent(workspaceRoot), sessionId);
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const summaryPath = path.join(sessionDir, "summary.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 50,
+        totalTokensBeforeCompaction: 10,
+        assistantMessageCount: 2,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:20:00.000Z",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(summaryPath, JSON.stringify({ updated_at: "2026-04-05T14:10:00.000Z" }), "utf8");
+    await fs.writeFile(
+      updatesPath,
+      JSON.stringify({
+        method: "session/update",
+        params: {
+          _meta: {
+            totalTokens: 120,
+            agentTimestampMs: Date.parse("2026-04-05T14:15:00.000Z"),
+            eventId: "evt-120",
+          },
+        },
+      }) + "\n",
+      "utf8",
+    );
+
+    const handlerPath = path.join(tmp, "grok-session-end-hook.cjs");
+    await fs.writeFile(handlerPath, buildGrokSessionEndHandler({ trackerDir }), "utf8");
+
+    const result = cp.spawnSync(process.execPath, [handlerPath], {
+      env: {
+        ...process.env,
+        GROK_HOME: grokHome,
+        GROK_SESSION_ID: sessionId,
+        GROK_WORKSPACE_ROOT: workspaceRoot,
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const signal = JSON.parse(await fs.readFile(path.join(trackerDir, "grok-last-session.json"), "utf8"));
+    assert.equal(signal.totalTokens, 120);
+    assert.equal(signal.contextTokensUsed, 50);
+    assert.equal(signal.totalTokensBeforeCompaction, 10);
+    assert.equal(signal.messageCount, 2);
+    assert.equal(signal.sessionDir, sessionDir);
+    assert.equal(signal.signalsPath, signalsPath);
+    assert.equal(signal.summaryPath, summaryPath);
+    assert.equal(signal.updatesPath, updatesPath);
+    assert.equal(signal.lastEventId, "evt-120");
+    assert.equal(signal.lastEventTimestamp, "2026-04-05T14:15:00.000Z");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("buildGrokSessionEndHookJson quotes handler paths for shell command", () => {
   const hookJson = buildGrokSessionEndHookJson({
     notifyGrokHandlerPath: "/tmp/Token Tracker's/bin/grok-session-end-hook.cjs",

--- a/test/grok-hook.test.js
+++ b/test/grok-hook.test.js
@@ -133,6 +133,51 @@ test("generated Grok handler writes session paths and update telemetry", async (
   }
 });
 
+test("generated Grok handler preserves zero context after compaction", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-handler-zero-context-"));
+  try {
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const grokHome = path.join(tmp, ".grok");
+    const workspaceRoot = path.join(tmp, "project");
+    const sessionId = "grok-session-zero-context";
+    const sessionDir = path.join(grokHome, "sessions", encodeURIComponent(workspaceRoot), sessionId);
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(
+      path.join(sessionDir, "signals.json"),
+      JSON.stringify({
+        contextTokensUsed: 0,
+        totalTokensBeforeCompaction: 500,
+        totalTokens: 500,
+        assistantMessageCount: 3,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T15:20:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const handlerPath = path.join(tmp, "grok-session-end-hook.cjs");
+    await fs.writeFile(handlerPath, buildGrokSessionEndHandler({ trackerDir }), "utf8");
+
+    const result = cp.spawnSync(process.execPath, [handlerPath], {
+      env: {
+        ...process.env,
+        GROK_HOME: grokHome,
+        GROK_SESSION_ID: sessionId,
+        GROK_WORKSPACE_ROOT: workspaceRoot,
+      },
+      encoding: "utf8",
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const signal = JSON.parse(await fs.readFile(path.join(trackerDir, "grok-last-session.json"), "utf8"));
+    assert.equal(signal.contextTokensUsed, 0);
+    assert.equal(signal.totalTokensBeforeCompaction, 500);
+    assert.equal(signal.totalTokens, 500);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("buildGrokSessionEndHookJson quotes handler paths for shell command", () => {
   const hookJson = buildGrokSessionEndHookJson({
     notifyGrokHandlerPath: "/tmp/Token Tracker's/bin/grok-session-end-hook.cjs",

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -127,6 +127,63 @@ test("notify handler still chains normal original notify commands", async () => 
   }
 });
 
+test("init preserves existing config fields and custom URLs", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-init-config-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+  const prevOpencodeConfigDir = process.env.OPENCODE_CONFIG_DIR;
+  const prevWrite = process.stdout.write;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    process.env.OPENCODE_CONFIG_DIR = path.join(tmp, ".config", "opencode");
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    await fs.mkdir(trackerDir, { recursive: true });
+    await fs.writeFile(
+      path.join(trackerDir, "config.json"),
+      JSON.stringify(
+        {
+          installedAt: "2026-04-01T00:00:00.000Z",
+          baseUrl: "https://self-hosted.example",
+          dashboardUrl: "https://dashboard.example",
+          deviceToken: "device-token",
+          deviceId: "device-id",
+          customFlag: true,
+        },
+        null,
+        2,
+      ) + "\n",
+      "utf8",
+    );
+
+    process.stdout.write = () => true;
+    await cmdInit(["--yes", "--no-auth", "--no-open"]);
+
+    const config = JSON.parse(await fs.readFile(path.join(trackerDir, "config.json"), "utf8"));
+    assert.equal(config.installedAt, "2026-04-01T00:00:00.000Z");
+    assert.equal(config.baseUrl, "https://self-hosted.example");
+    assert.equal(config.dashboardUrl, "https://dashboard.example");
+    assert.equal(config.deviceToken, "device-token");
+    assert.equal(config.deviceId, "device-id");
+    assert.equal(config.customFlag, true);
+  } finally {
+    process.stdout.write = prevWrite;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    if (prevOpencodeConfigDir === undefined) delete process.env.OPENCODE_CONFIG_DIR;
+    else process.env.OPENCODE_CONFIG_DIR = prevOpencodeConfigDir;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("init then uninstall restores original Codex notify (when pre-existing notify exists)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-init-uninstall-"));
   const prevHome = process.env.HOME;

--- a/test/init-uninstall.test.js
+++ b/test/init-uninstall.test.js
@@ -58,7 +58,6 @@ async function runGeneratedNotifyHandler({ trackerDir, notify }) {
     );
     child.stdin?.end();
   });
-  await new Promise((resolve) => setTimeout(resolve, 250));
 }
 
 test("notify handler skips SkyComputerUseClient and stale explicit original notify paths", async () => {
@@ -93,7 +92,7 @@ test("notify handler skips SkyComputerUseClient and stale explicit original noti
       trackerDir: path.join(tmp, "tracker-sky"),
       notify: [skyPath, "turn-ended"],
     });
-    await assert.rejects(fs.stat(markerPath), /ENOENT/);
+    assert.equal(await waitForFile(markerPath, { timeoutMs: 500 }), null);
 
     await runGeneratedNotifyHandler({
       trackerDir: path.join(tmp, "tracker-missing"),
@@ -120,7 +119,8 @@ test("notify handler still chains normal original notify commands", async () => 
       notify: [process.execPath, shimPath],
     });
 
-    const marker = await fs.readFile(markerPath, "utf8");
+    const marker = await waitForFile(markerPath, { timeoutMs: 5000 });
+    assert.ok(marker, "expected chained notify marker to be written");
     assert.ok(marker.includes("turn-ended"), "expected payload args to be forwarded");
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -5958,6 +5958,29 @@ test("parseGrokBuildIncremental preserves legacy baseline marker across zero-tok
     assert.equal(baselineRun.bucketsQueued, 0);
     assert.deepEqual(await readJsonLines(queuePath), []);
     assert.equal(cursors.grok.sessionSnapshots["grok-session-delayed"].totalTokens, 420);
+
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 750,
+        assistantMessageCount: 7,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:40:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const growthRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.ok(growthRun.eventsAggregated > 0);
+    assert.equal(growthRun.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].hour_start, "2026-04-05T14:30:00.000Z");
+    assert.equal(queued[0].total_tokens, 330);
+    assert.equal(queued[0].input_tokens, 264);
+    assert.equal(queued[0].output_tokens, 66);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-delayed"].totalTokens, 750);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -5903,6 +5903,66 @@ test("parseGrokBuildIncremental baselines legacy Grok seenSessions before counti
   }
 });
 
+test("parseGrokBuildIncremental preserves legacy baseline marker across zero-token sync", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-legacy-zero-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = {
+      version: 1,
+      files: {},
+      updatedAt: null,
+      grok: {
+        seenSessions: ["grok-session-delayed"],
+        updatedAt: "2026-04-05T14:00:00.000Z",
+      },
+    };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-delayed");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const session = {
+      sessionDir,
+      signalsPath,
+      summaryPath: path.join(sessionDir, "summary.json"),
+      sessionId: "grok-session-delayed",
+    };
+
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 0,
+        assistantMessageCount: 0,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:10:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const zeroRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(zeroRun.eventsAggregated, 0);
+    assert.equal(zeroRun.bucketsQueued, 0);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-delayed"].legacySeen, true);
+
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 420,
+        assistantMessageCount: 4,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:20:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const baselineRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(baselineRun.eventsAggregated, 0);
+    assert.equal(baselineRun.bucketsQueued, 0);
+    assert.deepEqual(await readJsonLines(queuePath), []);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-delayed"].totalTokens, 420);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("resolveGrokBuildSessions includes sessions with updates only", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-resolve-"));
   try {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -28,6 +28,7 @@ const {
   resolveCraftSessionFiles,
   resolveCraftWorkspaceRoots,
   parseGrokBuildIncremental,
+  resolveGrokBuildSessions,
   parseAntigravityIncremental,
   listAntigravitySessionFiles,
   estimateAntigravityTokens,
@@ -5648,6 +5649,273 @@ test("parseGrokBuildIncremental buckets Grok sessions by UTC half hour", async (
     assert.equal(queued.length, 2);
     assert.equal(queued[0].hour_start, "2026-04-05T14:00:00.000Z");
     assert.equal(queued[1].hour_start, "2026-04-05T14:30:00.000Z");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGrokBuildIncremental reads Grok updates metadata by event timestamp", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-updates-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-updates");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 90,
+        assistantMessageCount: 2,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:50:00.000Z",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      updatesPath,
+      [
+        JSON.stringify({
+          method: "session/update",
+          timestamp: 1775397900,
+          params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:05:00.000Z"), eventId: "evt-1" } },
+        }),
+        JSON.stringify({
+          method: "session/update",
+          params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:06:00.000Z"), eventId: "evt-repeat" } },
+        }),
+        JSON.stringify({
+          method: "session/update",
+          params: { _meta: { totalTokens: 80, agentTimestampMs: Date.parse("2026-04-05T14:07:00.000Z"), eventId: "evt-drop" } },
+        }),
+        JSON.stringify({
+          method: "session/update",
+          params: { _meta: { totalTokens: 250, agentTimestampMs: Date.parse("2026-04-05T14:35:00.000Z"), eventId: "evt-2" } },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const result = await parseGrokBuildIncremental({
+      sessions: [{ sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-updates" }],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 2);
+    assert.equal(result.bucketsQueued, 2);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 2);
+    assert.equal(queued[0].hour_start, "2026-04-05T14:00:00.000Z");
+    assert.equal(queued[0].total_tokens, 100);
+    assert.equal(queued[0].conversation_count, 0);
+    assert.equal(queued[1].hour_start, "2026-04-05T14:30:00.000Z");
+    assert.equal(queued[1].total_tokens, 150);
+    assert.equal(queued[1].input_tokens, 120);
+    assert.equal(queued[1].output_tokens, 30);
+    assert.equal(queued[1].conversation_count, 2);
+    assert.equal(cursors.grok.version, 3);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-updates"].totalTokens, 250);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-updates"].source, "updates");
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-updates"].lastEventId, "evt-2");
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGrokBuildIncremental applies Grok compaction residual once", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-compaction-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-compact");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 50,
+        totalTokensBeforeCompaction: 500,
+        assistantMessageCount: 4,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T15:20:00.000Z",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      updatesPath,
+      JSON.stringify({
+        method: "session/update",
+        params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:05:00.000Z"), eventId: "evt-before-compact" } },
+      }) + "\n",
+      "utf8",
+    );
+
+    const session = { sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-compact" };
+    const firstRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(firstRun.eventsAggregated, 2);
+    assert.equal(firstRun.bucketsQueued, 2);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 2);
+    assert.equal(queued[0].hour_start, "2026-04-05T14:00:00.000Z");
+    assert.equal(queued[0].total_tokens, 100);
+    assert.equal(queued[1].hour_start, "2026-04-05T15:00:00.000Z");
+    assert.equal(queued[1].total_tokens, 450);
+    assert.equal(queued[1].conversation_count, 4);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-compact"].totalTokens, 550);
+
+    const secondRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(secondRun.eventsAggregated, 0);
+    assert.equal(secondRun.bucketsQueued, 0);
+    assert.equal((await readJsonLines(queuePath)).length, 2);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGrokBuildIncremental upgrades v2 Grok cursor without replaying updates", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-v2-cursor-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = {
+      version: 1,
+      files: {},
+      updatedAt: null,
+      grok: {
+        version: 2,
+        sessionSnapshots: {
+          "grok-session-v2": {
+            totalTokens: 250,
+            messageCount: 2,
+            model: "grok-build",
+          },
+        },
+      },
+    };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-v2");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 200,
+        assistantMessageCount: 2,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:50:00.000Z",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      updatesPath,
+      [
+        JSON.stringify({ params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:05:00.000Z") } } }),
+        JSON.stringify({ params: { _meta: { totalTokens: 250, agentTimestampMs: Date.parse("2026-04-05T14:35:00.000Z") } } }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const result = await parseGrokBuildIncremental({
+      sessions: [{ sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-v2" }],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 0);
+    assert.equal(result.bucketsQueued, 0);
+    assert.deepEqual(await readJsonLines(queuePath), []);
+    assert.equal(cursors.grok.version, 3);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-v2"].totalTokens, 250);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGrokBuildIncremental baselines legacy Grok seenSessions before counting new growth", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-legacy-seen-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = {
+      version: 1,
+      files: {},
+      updatedAt: null,
+      grok: {
+        seenSessions: ["grok-session-legacy"],
+        updatedAt: "2026-04-05T14:00:00.000Z",
+      },
+    };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-legacy");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 500,
+        assistantMessageCount: 5,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:10:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const firstRun = await parseGrokBuildIncremental({
+      sessions: [{ sessionDir, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-legacy" }],
+      cursors,
+      queuePath,
+    });
+
+    assert.equal(firstRun.eventsAggregated, 0);
+    assert.equal(firstRun.bucketsQueued, 0);
+    assert.deepEqual(await readJsonLines(queuePath), []);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-legacy"].totalTokens, 500);
+
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 750,
+        assistantMessageCount: 7,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:40:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const secondRun = await parseGrokBuildIncremental({
+      sessions: [{ sessionDir, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-legacy" }],
+      cursors,
+      queuePath,
+    });
+
+    assert.equal(secondRun.eventsAggregated, 1);
+    assert.equal(secondRun.bucketsQueued, 1);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].hour_start, "2026-04-05T14:30:00.000Z");
+    assert.equal(queued[0].total_tokens, 250);
+    assert.equal(queued[0].input_tokens, 200);
+    assert.equal(queued[0].output_tokens, 50);
+    assert.equal(queued[0].conversation_count, 2);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-legacy"].totalTokens, 750);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("resolveGrokBuildSessions includes sessions with updates only", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-resolve-"));
+  try {
+    const grokHome = path.join(tmp, ".grok");
+    const sessionDir = path.join(grokHome, "sessions", "encoded-cwd", "grok-session-updates-only");
+    await fs.mkdir(sessionDir, { recursive: true });
+    await fs.writeFile(path.join(sessionDir, "updates.jsonl"), "\n", "utf8");
+
+    const sessions = resolveGrokBuildSessions({ GROK_HOME: grokHome });
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].sessionId, "grok-session-updates-only");
+    assert.equal(sessions[0].updatesPath, path.join(sessionDir, "updates.jsonl"));
+    assert.equal(sessions[0].signalsPath, path.join(sessionDir, "signals.json"));
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -5776,6 +5776,52 @@ test("parseGrokBuildIncremental applies Grok compaction residual once", async ()
   }
 });
 
+test("parseGrokBuildIncremental preserves zero current context after compaction", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-zero-context-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-zero-context");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        contextTokensUsed: 0,
+        totalTokensBeforeCompaction: 500,
+        totalTokens: 500,
+        assistantMessageCount: 3,
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T15:20:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const result = await parseGrokBuildIncremental({
+      sessions: [
+        {
+          sessionDir,
+          signalsPath,
+          summaryPath: path.join(sessionDir, "summary.json"),
+          sessionId: "grok-session-zero-context",
+        },
+      ],
+      cursors,
+      queuePath,
+    });
+    assert.equal(result.eventsAggregated, 1);
+    assert.equal(result.bucketsQueued, 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].hour_start, "2026-04-05T15:00:00.000Z");
+    assert.equal(queued[0].total_tokens, 500);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-zero-context"].totalTokens, 500);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseGrokBuildIncremental upgrades v2 Grok cursor without replaying updates", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-v2-cursor-"));
   try {

--- a/test/serve-bind-host.test.js
+++ b/test/serve-bind-host.test.js
@@ -1,4 +1,6 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const { test } = require("node:test");
 
 const { LOCAL_BIND_HOST, getLocalServerUrl } = require("../src/commands/serve");
@@ -6,4 +8,10 @@ const { LOCAL_BIND_HOST, getLocalServerUrl } = require("../src/commands/serve");
 test("serve binds to loopback and advertises the loopback URL", () => {
   assert.equal(LOCAL_BIND_HOST, "127.0.0.1");
   assert.equal(getLocalServerUrl(7680), "http://127.0.0.1:7680");
+});
+
+test("serve startup does not persistently rewrite config.json", () => {
+  const source = fs.readFileSync(path.join(__dirname, "..", "src", "commands", "serve.js"), "utf8");
+  assert.doesNotMatch(source, /writeJson\s*\(\s*cfgPath/);
+  assert.doesNotMatch(source, /cfg\.baseUrl\s*=/);
 });

--- a/test/sync-cursor-unknown-migration.test.js
+++ b/test/sync-cursor-unknown-migration.test.js
@@ -6,10 +6,13 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
+  cmdSync,
   migrateCursorUnknownBuckets,
   migrateRolloutCumulativeDeltaBuckets,
+  repairGrokQueueFromSessionSnapshots,
   CURSOR_UNKNOWN_MIGRATION_KEY,
   ROLLOUT_CUMULATIVE_DELTA_MIGRATION_KEY,
+  GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY,
 } = require("../src/commands/sync");
 
 async function makeTempDir() {
@@ -163,5 +166,316 @@ describe("migrateRolloutCumulativeDeltaBuckets", () => {
     );
 
     await fs.rm(dir, { recursive: true, force: true });
+  });
+});
+
+describe("repairGrokQueueFromSessionSnapshots", () => {
+  it("appends Grok corrections from snapshots, preserves history, backs up files, and is idempotent", async () => {
+    const dir = await makeTempDir();
+    const queuePath = path.join(dir, "queue.jsonl");
+    const queueStatePath = path.join(dir, "queue.state.json");
+    const cursors = {
+      hourly: {
+        groupQueued: {
+          "grok|2026-04-05T14:00:00.000Z": "old-grok-group",
+          "codex|2026-04-05T14:00:00.000Z": "keep-codex-group",
+        },
+        buckets: {
+          "grok|grok-build|2026-04-05T14:00:00.000Z": {
+            totals: { total_tokens: 999, conversation_count: 9 },
+            queuedKey: "old-grok-key",
+          },
+          "codex|gpt-5.5|2026-04-05T14:00:00.000Z": {
+            totals: { total_tokens: 123, conversation_count: 1 },
+            queuedKey: "keep-codex-key",
+          },
+        },
+      },
+      grok: {
+        sessionSnapshots: {
+          "grok-a": {
+            totalTokens: 100,
+            messageCount: 2,
+            model: "grok-build",
+            lastEventTimestamp: "2026-04-05T14:05:00.000Z",
+          },
+          "grok-b": {
+            totalTokens: 50,
+            messageCount: 1,
+            model: "grok-build",
+            lastEventTimestamp: "2026-04-05T14:20:00.000Z",
+          },
+          "grok-c": {
+            totalTokens: 70,
+            messageCount: 3,
+            model: "grok-build",
+            lastEventTimestamp: "2026-04-05T14:40:00.000Z",
+          },
+          "grok-d": {
+            totalTokens: 25,
+            messageCount: 4,
+            model: "grok-other",
+            updatedAt: "2026-04-05T15:01:00.000Z",
+          },
+          "grok-zero": {
+            totalTokens: 0,
+            messageCount: 1,
+            model: "grok-build",
+            lastEventTimestamp: "2026-04-05T15:05:00.000Z",
+          },
+        },
+      },
+    };
+
+    await fs.writeFile(
+      queuePath,
+      [
+        JSON.stringify({
+          source: "grok",
+          model: "grok-build",
+          hour_start: "2026-04-05T14:00:00.000Z",
+          total_tokens: 999,
+        }),
+        JSON.stringify({
+          source: "codex",
+          model: "gpt-5.5",
+          hour_start: "2026-04-05T14:00:00.000Z",
+          total_tokens: 123,
+        }),
+        "not-json",
+        JSON.stringify({
+          source: " Grok ",
+          model: "grok-build",
+          hour_start: "2026-04-05T14:30:00.000Z",
+          total_tokens: 777,
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+    await fs.writeFile(
+      queueStatePath,
+      JSON.stringify({ offset: 4096, updatedAt: "2026-04-05T16:00:00.000Z" }),
+      "utf8",
+    );
+
+    const repaired = await repairGrokQueueFromSessionSnapshots({
+      cursors,
+      queuePath,
+      queueStatePath,
+    });
+    assert.equal(repaired, true);
+
+    const queueText = await fs.readFile(queuePath, "utf8");
+    assert.ok(queueText.includes("not-json"));
+    const rows = queueText
+      .trim()
+      .split("\n")
+      .filter((line) => line !== "not-json")
+      .map((line) => JSON.parse(line));
+    assert.equal(rows.length, 6);
+    const grokRows = rows.filter((row) => String(row.source).trim().toLowerCase() === "grok");
+    assert.equal(grokRows.length, 5);
+    assert.deepEqual(
+      rows
+        .map(
+          (row) =>
+            `${String(row.source).trim().toLowerCase()}|${row.model}|${row.hour_start}|${row.total_tokens}`,
+        )
+        .sort(),
+      [
+        "codex|gpt-5.5|2026-04-05T14:00:00.000Z|123",
+        "grok|grok-build|2026-04-05T14:00:00.000Z|150",
+        "grok|grok-build|2026-04-05T14:00:00.000Z|999",
+        "grok|grok-build|2026-04-05T14:30:00.000Z|70",
+        "grok|grok-build|2026-04-05T14:30:00.000Z|777",
+        "grok|grok-other|2026-04-05T15:00:00.000Z|25",
+      ],
+    );
+
+    const aggregatedRow = rows.find(
+      (row) =>
+        row.source === "grok" &&
+        row.hour_start === "2026-04-05T14:00:00.000Z" &&
+        row.total_tokens === 150,
+    );
+    assert.equal(aggregatedRow.input_tokens, 120);
+    assert.equal(aggregatedRow.output_tokens, 30);
+    assert.equal(aggregatedRow.conversation_count, 3);
+
+    const repairedBucket =
+      cursors.hourly.buckets["grok|grok-build|2026-04-05T14:00:00.000Z"];
+    assert.equal(repairedBucket.totals.total_tokens, 150);
+    assert.equal(repairedBucket.totals.input_tokens, 120);
+    assert.equal(repairedBucket.totals.output_tokens, 30);
+    assert.equal(repairedBucket.totals.conversation_count, 3);
+    assert.ok(repairedBucket.queuedKey);
+    assert.equal(cursors.hourly.groupQueued["grok|2026-04-05T14:00:00.000Z"], undefined);
+    assert.equal(cursors.hourly.groupQueued["codex|2026-04-05T14:00:00.000Z"], "keep-codex-group");
+    assert.ok(cursors.hourly.buckets["codex|gpt-5.5|2026-04-05T14:00:00.000Z"]);
+
+    const queueState = JSON.parse(await fs.readFile(queueStatePath, "utf8"));
+    assert.equal(queueState.offset, 0);
+    assert.equal(queueState.note, "reset_after_grok_append_only_repair_2026_05_v4");
+    const migration = cursors.grok.migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY];
+    assert.equal(migration.status, "applied");
+    assert.equal(migration.existingGrokRows, 2);
+    assert.equal(migration.rowsWritten, 3);
+    assert.equal(migration.staleRowsRetracted, 0);
+    assert.match(migration.queueBackupPath, /queue\.jsonl\.bak\./);
+    assert.match(migration.queueStateBackupPath, /queue\.state\.json\.bak\./);
+    await fs.stat(migration.queueBackupPath);
+    await fs.stat(migration.queueStateBackupPath);
+
+    const queueAfterFirstRepair = await fs.readFile(queuePath, "utf8");
+    const secondRepair = await repairGrokQueueFromSessionSnapshots({
+      cursors,
+      queuePath,
+      queueStatePath,
+    });
+    assert.equal(secondRepair, false);
+    assert.equal(await fs.readFile(queuePath, "utf8"), queueAfterFirstRepair);
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("records a no-op marker when there are no Grok rows", async () => {
+    const dir = await makeTempDir();
+    const queuePath = path.join(dir, "queue.jsonl");
+    const cursors = {
+      grok: {
+        sessionSnapshots: {
+          "grok-a": {
+            totalTokens: 100,
+            messageCount: 1,
+            model: "grok-build",
+            lastEventTimestamp: "2026-04-05T14:05:00.000Z",
+          },
+        },
+      },
+    };
+    await fs.writeFile(
+      queuePath,
+      JSON.stringify({
+        source: "codex",
+        model: "gpt-5.5",
+        hour_start: "2026-04-05T14:00:00.000Z",
+        total_tokens: 123,
+      }) + "\n",
+      "utf8",
+    );
+
+    const repaired = await repairGrokQueueFromSessionSnapshots({ cursors, queuePath });
+    assert.equal(repaired, false);
+    assert.equal(cursors.grok.migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY].status, "noop");
+    assert.equal(cursors.grok.migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY].existingGrokRows, 0);
+
+    const rows = (await fs.readFile(queuePath, "utf8"))
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].source, "codex");
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("skips repair without snapshots and leaves queue/state untouched", async () => {
+    const dir = await makeTempDir();
+    const queuePath = path.join(dir, "queue.jsonl");
+    const queueStatePath = path.join(dir, "queue.state.json");
+    const cursors = { grok: { sessionSnapshots: {} } };
+    const queueText =
+      JSON.stringify({
+        source: "grok",
+        model: "grok-build",
+        hour_start: "2026-04-05T14:00:00.000Z",
+        total_tokens: 999,
+      }) + "\n";
+    const stateText = JSON.stringify({ offset: 4096, updatedAt: "2026-04-05T16:00:00.000Z" });
+    await fs.writeFile(queuePath, queueText, "utf8");
+    await fs.writeFile(queueStatePath, stateText, "utf8");
+
+    const repaired = await repairGrokQueueFromSessionSnapshots({
+      cursors,
+      queuePath,
+      queueStatePath,
+    });
+    assert.equal(repaired, false);
+    assert.equal(await fs.readFile(queuePath, "utf8"), queueText);
+    assert.equal(await fs.readFile(queueStatePath, "utf8"), stateText);
+    assert.equal(
+      cursors.grok.migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY].status,
+      "skipped",
+    );
+    assert.equal(
+      cursors.grok.migrations[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY].reason,
+      "missing-session-snapshots",
+    );
+
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it("regular sync does not run Grok history repair unless explicitly requested", async () => {
+    const dir = await makeTempDir();
+    const prevHome = process.env.HOME;
+    const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+    const prevGrokHome = process.env.GROK_HOME;
+    const prevTrackerGrokHome = process.env.TOKENTRACKER_GROK_HOME;
+    try {
+      process.env.HOME = dir;
+      delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+      delete process.env.GROK_HOME;
+      process.env.TOKENTRACKER_GROK_HOME = path.join(dir, ".grok");
+      const trackerDir = path.join(dir, ".tokentracker", "tracker");
+      await fs.mkdir(trackerDir, { recursive: true });
+      const queuePath = path.join(trackerDir, "queue.jsonl");
+      const cursorsPath = path.join(trackerDir, "cursors.json");
+      const queueText =
+        JSON.stringify({
+          source: "grok",
+          model: "grok-build",
+          hour_start: "2026-04-05T14:00:00.000Z",
+          total_tokens: 999,
+        }) + "\n";
+      await fs.writeFile(queuePath, queueText, "utf8");
+      await fs.writeFile(
+        cursorsPath,
+        JSON.stringify({
+          version: 1,
+          files: {},
+          grok: {
+            sessionSnapshots: {
+              "grok-a": {
+                totalTokens: 100,
+                messageCount: 1,
+                model: "grok-build",
+                lastEventTimestamp: "2026-04-05T14:05:00.000Z",
+              },
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      await cmdSync(["--auto"]);
+
+      const queueAfter = await fs.readFile(queuePath, "utf8");
+      assert.equal(queueAfter, queueText);
+      const cursorsAfter = JSON.parse(await fs.readFile(cursorsPath, "utf8"));
+      assert.equal(
+        cursorsAfter.grok.migrations?.[GROK_APPEND_ONLY_REPAIR_MIGRATION_KEY],
+        undefined,
+      );
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+      else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+      if (prevGrokHome === undefined) delete process.env.GROK_HOME;
+      else process.env.GROK_HOME = prevGrokHome;
+      if (prevTrackerGrokHome === undefined) delete process.env.TOKENTRACKER_GROK_HOME;
+      else process.env.TOKENTRACKER_GROK_HOME = prevTrackerGrokHome;
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/sync-openclaw-trigger.test.js
+++ b/test/sync-openclaw-trigger.test.js
@@ -184,6 +184,68 @@ test("sync queues and consumes Grok hook signal after cursor persistence", async
   }
 });
 
+test("sync keeps malformed Grok hook signal without a session id", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-sync-grok-bad-signal-"));
+  const prevHome = process.env.HOME;
+  const prevCodexHome = process.env.CODEX_HOME;
+  const prevCodeHome = process.env.CODE_HOME;
+  const prevGeminiHome = process.env.GEMINI_HOME;
+  const prevOpencodeHome = process.env.OPENCODE_HOME;
+  const prevTokenTrackerGrokHome = process.env.TOKENTRACKER_GROK_HOME;
+  const prevGrokHome = process.env.GROK_HOME;
+  const prevToken = process.env.TOKENTRACKER_DEVICE_TOKEN;
+
+  try {
+    process.env.HOME = tmp;
+    process.env.CODEX_HOME = path.join(tmp, ".codex");
+    process.env.CODE_HOME = path.join(tmp, ".code");
+    process.env.GEMINI_HOME = path.join(tmp, ".gemini");
+    process.env.OPENCODE_HOME = path.join(tmp, ".opencode");
+    delete process.env.TOKENTRACKER_GROK_HOME;
+    process.env.GROK_HOME = path.join(tmp, ".grok");
+    delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+
+    const trackerDir = path.join(tmp, ".tokentracker", "tracker");
+    const signalPath = path.join(trackerDir, "grok-last-session.json");
+    await fs.mkdir(path.dirname(signalPath), { recursive: true });
+    await fs.writeFile(
+      signalPath,
+      JSON.stringify({
+        source: "grok",
+        model: "grok-build",
+        totalTokens: 99,
+        messageCount: 3,
+        lastActive: "2026-04-05T14:45:00.000Z",
+      }) + "\n",
+      "utf8",
+    );
+
+    await cmdSync(["--auto"]);
+
+    const signal = JSON.parse(await fs.readFile(signalPath, "utf8"));
+    assert.equal(signal.totalTokens, 99);
+    assert.deepEqual(await readJsonl(path.join(trackerDir, "queue.jsonl")), []);
+  } finally {
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    if (prevCodeHome === undefined) delete process.env.CODE_HOME;
+    else process.env.CODE_HOME = prevCodeHome;
+    if (prevGeminiHome === undefined) delete process.env.GEMINI_HOME;
+    else process.env.GEMINI_HOME = prevGeminiHome;
+    if (prevOpencodeHome === undefined) delete process.env.OPENCODE_HOME;
+    else process.env.OPENCODE_HOME = prevOpencodeHome;
+    if (prevTokenTrackerGrokHome === undefined) delete process.env.TOKENTRACKER_GROK_HOME;
+    else process.env.TOKENTRACKER_GROK_HOME = prevTokenTrackerGrokHome;
+    if (prevGrokHome === undefined) delete process.env.GROK_HOME;
+    else process.env.GROK_HOME = prevGrokHome;
+    if (prevToken === undefined) delete process.env.TOKENTRACKER_DEVICE_TOKEN;
+    else process.env.TOKENTRACKER_DEVICE_TOKEN = prevToken;
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("sync --from-openclaw falls back to previous session totals when jsonl has zero usage", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "vibeusage-sync-openclaw-fallback-"));
   const prevHome = process.env.HOME;

--- a/test/sync-openclaw-trigger.test.js
+++ b/test/sync-openclaw-trigger.test.js
@@ -164,6 +164,18 @@ test("sync queues and consumes Grok hook signal after cursor persistence", async
 
     const cursors = JSON.parse(await fs.readFile(path.join(trackerDir, "cursors.json"), "utf8"));
     assert.deepEqual(cursors.grok.seenSessions, ["grok-session-hook"]);
+
+    const firstSnapshots = cursors.grok.sessionSnapshots;
+    await cmdSync(["--auto"]);
+
+    const rowsAfterSecondSync = await readJsonl(path.join(trackerDir, "queue.jsonl"));
+    assert.equal(rowsAfterSecondSync.length, rows.length);
+    await assert.rejects(fs.stat(signalPath), /ENOENT/);
+
+    const cursorsAfterSecondSync = JSON.parse(
+      await fs.readFile(path.join(trackerDir, "cursors.json"), "utf8"),
+    );
+    assert.deepEqual(cursorsAfterSecondSync.grok.sessionSnapshots, firstSnapshots);
   } finally {
     if (prevHome === undefined) delete process.env.HOME;
     else process.env.HOME = prevHome;

--- a/test/sync-openclaw-trigger.test.js
+++ b/test/sync-openclaw-trigger.test.js
@@ -145,6 +145,7 @@ test("sync queues and consumes Grok hook signal after cursor persistence", async
         sessionId: "grok-session-hook",
         model: "grok-build",
         totalTokens: 99,
+        contextTokensUsed: 20,
         messageCount: 3,
         lastActive: "2026-04-05T14:45:00.000Z",
       }) + "\n",
@@ -222,7 +223,13 @@ test("sync keeps malformed Grok hook signal without a session id", async () => {
 
     await cmdSync(["--auto"]);
 
-    const signal = JSON.parse(await fs.readFile(signalPath, "utf8"));
+    let signal = JSON.parse(await fs.readFile(signalPath, "utf8"));
+    assert.equal(signal.totalTokens, 99);
+    assert.deepEqual(await readJsonl(path.join(trackerDir, "queue.jsonl")), []);
+
+    await cmdSync(["--auto"]);
+
+    signal = JSON.parse(await fs.readFile(signalPath, "utf8"));
     assert.equal(signal.totalTokens, 99);
     assert.deepEqual(await readJsonl(path.join(trackerDir, "queue.jsonl")), []);
   } finally {


### PR DESCRIPTION
# PR Goal (one sentence)

Prevent legacy Grok cursor migration from replaying old usage while keeping future Grok token deltas accurate.

## Scope

- Baseline legacy `cursors.grok.seenSessions` sessions into `sessionSnapshots.totalTokens` without enqueueing old usage.
- Only enqueue Grok growth after the baseline, preserving the existing v3 cursor semantics.
- Keep `updates.jsonl` as the preferred Grok total source and `signals.json` as fallback.
- Stabilize notify tests by waiting for marker conditions instead of fixed sleeps.

## Codex Context (required when requesting @codex review)

- **Delta since last Codex review:** rebased onto latest `upstream/main`; conflict resolution kept upstream Antigravity changes and this Grok fix.
- **Intended behavior / invariants:** legacy Grok sessions do not replay historical totals; new token growth still queues normally.
- **Edge cases covered:** legacy seen session first sync, second sync growth delta, v2 cursor upgrade, updates timestamp bucketing, compaction residual, zero-token sessions, notify chain allow/deny cases.
- **Tests run (command + result):**
  - `node --test test/init-uninstall.test.js test/grok-hook.test.js test/rollout-parser.test.js test/sync-openclaw-trigger.test.js test/local-api-legacy-codex-schema.test.js` — pass
  - `npm run ci:local` — pass
- **Known gaps / out of scope:** no historical queue repair migration; this only prevents future legacy replay.

## Risk Layer Trigger (if any)

- [ ] Public exposure / share links / unauthenticated access
- [ ] Auth/session/token handling
- [ ] Cross-endpoint invariants or shared logic
- [ ] External gateway / environment constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Grok Build ingestion to use local telemetry (updates.jsonl) for more accurate token totals and richer session metadata; added an explicit append-only repair flow.

* **Bug Fixes / Robustness**
  * More tolerant handling of missing/malformed telemetry and prevention of silent queue rewrites (append-only repairs).

* **Documentation**
  * Updated English and Chinese docs and cost-estimate guidance to reflect telemetry sources and estimation caveats.

* **Tests**
  * Added/expanded tests for telemetry parsing, incremental bucketing, cursor/version upgrades, and session-end handling.

* **Changelog**
  * Noted unreleased fix for Grok Build token inflation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->