### PR TITLE
feat(hermes): ingest all profile databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - `tokentracker init` detects the Kimi sessions directory and surfaces it as a passive reader in the setup summary.
 - Dashboard model-breakdown shows Kimi with brand logo (`kimi.svg`) and violet color (`#a78bfa`).
 - Model reported as `kimi-k2` (wire.jsonl does not expose the model name).
+- **Hermes** — multi-profile support discovers profile databases under `~/.hermes/profiles/*/state.db` and tracks each profile independently with per-profile cursor state
+- `parseHermesIncremental` in `rollout.js` now aggregates tokens across the default DB and all discovered profile DBs
 
 ### Fixed
 

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -14,7 +14,7 @@ const {
   readOpencodeDbMessages,
   resolveKiroDbPath,
   resolveKiroJsonlPath,
-  resolveHermesDbPath,
+  resolveHermesPath,
   resolveCopilotOtelPaths,
   parseRolloutIncremental,
   parseClaudeIncremental,
@@ -500,13 +500,13 @@ async function cmdSync(argv) {
 
     // ── Hermes Agent (SQLite-based) ──
     let hermesResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-    const hermesDbPath = resolveHermesDbPath();
-    if (fssync.existsSync(hermesDbPath)) {
+    const hermesPath = resolveHermesPath();
+    if (fssync.existsSync(hermesPath)) {
       if (progress?.enabled) {
         progress.start(`Parsing Hermes ${renderBar(0)} | buckets 0`);
       }
       hermesResult = await parseHermesIncremental({
-        dbPath: hermesDbPath,
+        hermesPath,
         cursors,
         queuePath,
         onProgress: (p) => {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3051,11 +3051,11 @@ function readHermesSessions(dbPath, lastCompletedEpoch, unfinishedSessionIds = [
   const forceIncludeSql = forceIds.length > 0
     ? ` OR id IN (${forceIds.map(sqliteStringLiteral).join(",")})`
     : "";
-  // Fetch sessions that started after the cursor, sessions that are still
+  // Fetch sessions that started at/after the cursor, sessions that are still
   // in-progress (ended_at IS NULL), OR sessions that were previously observed
   // unfinished.  Hermes updates token counts in real-time, including a final
   // delta when an active session later gets ended_at set.
-  const sql = `SELECT id, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count FROM sessions WHERE (started_at > ${since} OR ended_at IS NULL${forceIncludeSql}) AND (input_tokens > 0 OR output_tokens > 0 OR cache_read_tokens > 0 OR reasoning_tokens > 0) ORDER BY started_at ASC`;
+  const sql = `SELECT id, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count FROM sessions WHERE (started_at >= ${since} OR ended_at IS NULL${forceIncludeSql}) AND (input_tokens > 0 OR output_tokens > 0 OR cache_read_tokens > 0 OR reasoning_tokens > 0) ORDER BY started_at ASC`;
   let raw;
   try {
     raw = cp.execFileSync("sqlite3", ["-json", dbPath, sql], {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3005,9 +3005,37 @@ async function parseKiroIncremental({ dbPath, jsonlPath, cursors, queuePath, onP
 // Hermes Agent — SQLite-based (sessions table in ~/.hermes/state.db)
 // ─────────────────────────────────────────────────────────────────────────────
 
-function resolveHermesDbPath() {
+function resolveHermesPath() {
   const home = require("node:os").homedir();
-  return path.join(home, ".hermes", "state.db");
+  return path.join(home, ".hermes");
+}
+
+function resolveHermesDbPath() {
+  return path.join(resolveHermesPath(), "state.db");
+}
+
+function resolveAllHermesDBPaths({ hermesPath, dbPath } = {}) {
+  const hermesDir = hermesPath ?? (dbPath ? path.dirname(dbPath) : resolveHermesPath());
+  const defaultDbPath = dbPath ?? path.join(hermesDir, "state.db");
+  const profilePaths = {};
+  try {
+    const profilesDir = path.join(hermesDir, "profiles");
+    const profiles = fssync.readdirSync(profilesDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of profiles) {
+      const dbPath = path.join(profilesDir, entry.name, "state.db");
+      if (fssync.existsSync(dbPath)) {
+        profilePaths[entry.name] = dbPath;
+      }
+    }
+  } catch (_e) { }
+
+  return {
+    default: fssync.existsSync(defaultDbPath) ? defaultDbPath : null,
+    profiles: profilePaths,
+  }
 }
 
 function readHermesSessions(dbPath, lastCompletedEpoch) {
@@ -3037,122 +3065,154 @@ function readHermesSessions(dbPath, lastCompletedEpoch) {
   return Array.isArray(rows) ? rows : [];
 }
 
-async function parseHermesIncremental({ dbPath, cursors, queuePath, onProgress }) {
+function hasLegacyHermesDefaultState(hermesState) {
+  return (
+    typeof hermesState.lastStartedAt === "number" ||
+    typeof hermesState.lastCompletedStartedAt === "number" ||
+    (hermesState.snapshots && typeof hermesState.snapshots === "object")
+  );
+}
+
+async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, onProgress }) {
   await ensureDir(path.dirname(queuePath));
   const hermesState = cursors.hermes && typeof cursors.hermes === "object" ? cursors.hermes : {};
 
-  // Only advance past sessions that have fully ended.  Active sessions
-  // (ended_at IS NULL) must be re-read every sync because Hermes updates
-  // their token counts in real-time after each turn.
-  const lastCompletedStartedAt =
-    typeof hermesState.lastCompletedStartedAt === "number" ? hermesState.lastCompletedStartedAt : 0;
-
-  // Per-session snapshot from the previous sync: { [sessionId]: { in, out, cacheRead, cacheWrite, reasoning } }
-  const prevSnapshots = (hermesState.snapshots && typeof hermesState.snapshots === "object")
-    ? hermesState.snapshots : {};
-
-  const resolvedDbPath = dbPath || resolveHermesDbPath();
-  if (!fssync.existsSync(resolvedDbPath)) {
-    return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
-  }
-
-  const rows = readHermesSessions(resolvedDbPath, lastCompletedStartedAt);
-  if (rows.length === 0) {
-    cursors.hermes = { ...hermesState, lastCompletedStartedAt, updatedAt: new Date().toISOString() };
+  const dbPaths = resolveAllHermesDBPaths({ hermesPath, dbPath });
+  if (dbPaths.default === null && Object.keys(dbPaths.profiles).length === 0) {
+    // No state in any profile
     return { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
   }
 
   const hourlyState = normalizeHourlyState(cursors?.hourly);
-  const touchedBuckets = new Set();
   const cb = typeof onProgress === "function" ? onProgress : null;
+  const updatedAt = new Date().toISOString();
+  let recordsProcessed = 0;
   let eventsAggregated = 0;
-  let maxCompletedStartedAt = lastCompletedStartedAt;
-  const nextSnapshots = {};
+  const touchedBuckets = new Set();
 
-  for (let i = 0; i < rows.length; i++) {
-    const row = rows[i];
-    const inputTokens = toNonNegativeInt(row.input_tokens);
-    const outputTokens = toNonNegativeInt(row.output_tokens);
-    const cacheRead = toNonNegativeInt(row.cache_read_tokens);
-    const cacheWrite = toNonNegativeInt(row.cache_write_tokens);
-    const reasoning = toNonNegativeInt(row.reasoning_tokens);
-    if (inputTokens === 0 && outputTokens === 0 && cacheRead === 0 && reasoning === 0) continue;
-
-    // Save current snapshot for next sync
-    nextSnapshots[row.id] = { in: inputTokens, out: outputTokens, cacheRead, cacheWrite, reasoning };
-
-    // Compute delta from previous snapshot (if any) so that we only count
-    // new tokens since the last sync.  First time we see a session the
-    // previous snapshot is absent, so the full amount is the delta.
-    const prev = prevSnapshots[row.id];
-    let dInput = inputTokens;
-    let dOutput = outputTokens;
-    let dCacheRead = cacheRead;
-    let dCacheWrite = cacheWrite;
-    let dReasoning = reasoning;
-    if (prev) {
-      dInput = Math.max(0, inputTokens - (prev.in || 0));
-      dOutput = Math.max(0, outputTokens - (prev.out || 0));
-      dCacheRead = Math.max(0, cacheRead - (prev.cacheRead || 0));
-      dCacheWrite = Math.max(0, cacheWrite - (prev.cacheWrite || 0));
-      dReasoning = Math.max(0, reasoning - (prev.reasoning || 0));
-    }
-    // Skip if delta is zero (session unchanged since last sync)
-    if (dInput === 0 && dOutput === 0 && dCacheRead === 0 && dCacheWrite === 0 && dReasoning === 0) continue;
-
-    // Prefer ended_at for bucket placement; fall back to started_at
-    const epochSec = row.ended_at || row.started_at;
-    if (!epochSec || !Number.isFinite(epochSec)) continue;
-    const tsIso = new Date(epochSec * 1000).toISOString();
-    const bucketStart = toUtcHalfHourStart(tsIso);
-    if (!bucketStart) continue;
-
-    const model = normalizeModelInput(row.model) || "hermes-agent";
-
-    const delta = {
-      input_tokens: dInput,
-      cached_input_tokens: dCacheRead,
-      cache_creation_input_tokens: dCacheWrite,
-      output_tokens: dOutput,
-      reasoning_output_tokens: dReasoning,
-      total_tokens: dInput + dOutput + dCacheRead + dCacheWrite + dReasoning,
-      conversation_count: toNonNegativeInt(row.message_count) || 1,
-    };
-
-    const bucket = getHourlyBucket(hourlyState, "hermes", model, bucketStart);
-    addTotals(bucket.totals, delta);
-    touchedBuckets.add(bucketKey("hermes", model, bucketStart));
-    eventsAggregated++;
-
-    // Only advance cursor past sessions that have ended
-    if (row.ended_at && row.started_at > maxCompletedStartedAt) {
-      maxCompletedStartedAt = row.started_at;
+  function ingestProfile(dbPath, dbState) {
+    const rows = readHermesSessions(dbPath, dbState.lastCompletedStartedAt);
+    recordsProcessed += rows.length;
+    if (rows.length === 0) {
+      dbState.updatedAt = updatedAt;
+      return;
     }
 
-    if (cb) {
-      cb({
-        index: i + 1,
-        total: rows.length,
-        recordsProcessed: i + 1,
-        eventsAggregated,
-        bucketsQueued: touchedBuckets.size,
-      });
+    // Per-session snapshot from the previous sync: { [sessionId]: { in, out, cacheRead, cacheWrite, reasoning } }
+    const prevSnapshots = (dbState.snapshots && typeof dbState.snapshots === "object")
+      ? dbState.snapshots : {};
+
+    // Only advance past sessions that have fully ended.  Active sessions
+    // (ended_at IS NULL) must be re-read every sync because Hermes updates
+    // their token counts in real-time after each turn.
+    const lastCompletedStartedAt =
+      typeof dbState.lastCompletedStartedAt === "number" ? dbState.lastCompletedStartedAt : 0;
+
+    let maxCompletedStartedAt = lastCompletedStartedAt;
+    const nextSnapshots = {};
+
+    for (let i = 0; i < rows.length; i++) {
+      const row = rows[i];
+      const inputTokens = toNonNegativeInt(row.input_tokens);
+      const outputTokens = toNonNegativeInt(row.output_tokens);
+      const cacheRead = toNonNegativeInt(row.cache_read_tokens);
+      const cacheWrite = toNonNegativeInt(row.cache_write_tokens);
+      const reasoning = toNonNegativeInt(row.reasoning_tokens);
+      if (inputTokens === 0 && outputTokens === 0 && cacheRead === 0 && reasoning === 0) continue;
+
+      // Save current snapshot for next sync
+      nextSnapshots[row.id] = { in: inputTokens, out: outputTokens, cacheRead, cacheWrite, reasoning };
+
+      // Compute delta from previous snapshot (if any) so that we only count
+      // new tokens since the last sync.  First time we see a session the
+      // previous snapshot is absent, so the full amount is the delta.
+      const prev = prevSnapshots[row.id];
+      let dInput = inputTokens;
+      let dOutput = outputTokens;
+      let dCacheRead = cacheRead;
+      let dCacheWrite = cacheWrite;
+      let dReasoning = reasoning;
+      if (prev) {
+        dInput = Math.max(0, inputTokens - (prev.in || 0));
+        dOutput = Math.max(0, outputTokens - (prev.out || 0));
+        dCacheRead = Math.max(0, cacheRead - (prev.cacheRead || 0));
+        dCacheWrite = Math.max(0, cacheWrite - (prev.cacheWrite || 0));
+        dReasoning = Math.max(0, reasoning - (prev.reasoning || 0));
+      }
+      // Skip if delta is zero (session unchanged since last sync)
+      if (dInput === 0 && dOutput === 0 && dCacheRead === 0 && dCacheWrite === 0 && dReasoning === 0) continue;
+
+      // Prefer ended_at for bucket placement; fall back to started_at
+      const epochSec = row.ended_at || row.started_at;
+      if (!epochSec || !Number.isFinite(epochSec)) continue;
+      const tsIso = new Date(epochSec * 1000).toISOString();
+      const bucketStart = toUtcHalfHourStart(tsIso);
+      if (!bucketStart) continue;
+
+      const model = normalizeModelInput(row.model) || "hermes-agent";
+
+      const delta = {
+        input_tokens: dInput,
+        cached_input_tokens: dCacheRead,
+        cache_creation_input_tokens: dCacheWrite,
+        output_tokens: dOutput,
+        reasoning_output_tokens: dReasoning,
+        total_tokens: dInput + dOutput + dCacheRead + dCacheWrite + dReasoning,
+        conversation_count: toNonNegativeInt(row.message_count) || 1,
+      };
+
+      const bucket = getHourlyBucket(hourlyState, "hermes", model, bucketStart);
+      addTotals(bucket.totals, delta);
+      touchedBuckets.add(bucketKey("hermes", model, bucketStart));
+      eventsAggregated++;
+
+      // Only advance cursor past sessions that have ended
+      if (row.ended_at && row.started_at > maxCompletedStartedAt) {
+        maxCompletedStartedAt = row.started_at;
+      }
+
+      if (cb) {
+        cb({
+          index: i + 1,
+          total: rows.length,
+          recordsProcessed: i + 1,
+          eventsAggregated,
+          bucketsQueued: touchedBuckets.size,
+        });
+      }
     }
+
+    Object.assign(dbState, {
+      lastStartedAt: maxCompletedStartedAt,
+      lastCompletedStartedAt: maxCompletedStartedAt,
+      snapshots: nextSnapshots,
+      updatedAt,
+    });
+  }
+
+  if (dbPaths.default) {
+    ingestProfile(dbPaths.default, hermesState);
+  }
+
+  hermesState.profiles = hermesState.profiles && typeof hermesState.profiles === "object" ? hermesState.profiles : {};
+
+  for (const [profileName, dbPath] of Object.entries(dbPaths.profiles)) {
+    const profileState = hermesState.profiles[profileName] && typeof hermesState.profiles[profileName] === "object"
+      ? hermesState.profiles[profileName]
+      : {};
+    hermesState.profiles[profileName] = profileState;
+    ingestProfile(dbPath, profileState);
   }
 
   const bucketsQueued = await enqueueTouchedBuckets({ queuePath, hourlyState, touchedBuckets });
-  const updatedAt = new Date().toISOString();
   hourlyState.updatedAt = updatedAt;
   cursors.hourly = hourlyState;
   cursors.hermes = {
     ...hermesState,
-    lastStartedAt: maxCompletedStartedAt, // keep for backward compat
-    lastCompletedStartedAt: maxCompletedStartedAt,
-    snapshots: nextSnapshots,
-    updatedAt,
+    updatedAt, // Update the overall profile state timestamp even if the DB doesn't exist for the fast-path check
   };
 
-  return { recordsProcessed: rows.length, eventsAggregated, bucketsQueued };
+  return { recordsProcessed, eventsAggregated, bucketsQueued };
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -6532,6 +6592,7 @@ module.exports = {
   readOpencodeDbMessages,
   resolveKiroDbPath,
   resolveKiroJsonlPath,
+  resolveHermesPath,
   resolveHermesDbPath,
   resolveCopilotOtelPaths,
   parseRolloutIncremental,

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3134,10 +3134,11 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       const cacheRead = toNonNegativeInt(row.cache_read_tokens);
       const cacheWrite = toNonNegativeInt(row.cache_write_tokens);
       const reasoning = toNonNegativeInt(row.reasoning_tokens);
+      const messageCount = toNonNegativeInt(row.message_count);
       if (inputTokens === 0 && outputTokens === 0 && cacheRead === 0 && reasoning === 0) continue;
 
       // Save current snapshot for next sync
-      nextSnapshots[row.id] = { in: inputTokens, out: outputTokens, cacheRead, cacheWrite, reasoning };
+      nextSnapshots[row.id] = { in: inputTokens, out: outputTokens, cacheRead, cacheWrite, reasoning, message_count: messageCount };
 
       const startedAt = Number(row.started_at);
       const endedAt = row.ended_at == null ? null : Number(row.ended_at);
@@ -3151,7 +3152,7 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       }
 
       // Compute delta from previous snapshot (if any) so that we only count
-      // new tokens since the last sync.  First time we see a session the
+      // new usage since the last sync.  First time we see a session the
       // previous snapshot is absent, so the full amount is the delta.
       const prev = prevSnapshots[row.id];
       let dInput = inputTokens;
@@ -3159,12 +3160,14 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       let dCacheRead = cacheRead;
       let dCacheWrite = cacheWrite;
       let dReasoning = reasoning;
+      let dMessageCount = messageCount;
       if (prev) {
         dInput = Math.max(0, inputTokens - (prev.in || 0));
         dOutput = Math.max(0, outputTokens - (prev.out || 0));
         dCacheRead = Math.max(0, cacheRead - (prev.cacheRead || 0));
         dCacheWrite = Math.max(0, cacheWrite - (prev.cacheWrite || 0));
         dReasoning = Math.max(0, reasoning - (prev.reasoning || 0));
+        dMessageCount = Math.max(0, messageCount - (prev.message_count || 0));
       }
       // Skip if delta is zero (session unchanged since last sync)
       if (dInput === 0 && dOutput === 0 && dCacheRead === 0 && dCacheWrite === 0 && dReasoning === 0) continue;
@@ -3185,7 +3188,7 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
         output_tokens: dOutput,
         reasoning_output_tokens: dReasoning,
         total_tokens: dInput + dOutput + dCacheRead + dCacheWrite + dReasoning,
-        conversation_count: toNonNegativeInt(row.message_count) || 1,
+        conversation_count: dMessageCount,
       };
 
       const bucket = getHourlyBucket(hourlyState, "hermes", model, bucketStart);

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -3038,13 +3038,24 @@ function resolveAllHermesDBPaths({ hermesPath, dbPath } = {}) {
   }
 }
 
-function readHermesSessions(dbPath, lastCompletedEpoch) {
+function sqliteStringLiteral(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function readHermesSessions(dbPath, lastCompletedEpoch, unfinishedSessionIds = []) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   const since = Number.isFinite(lastCompletedEpoch) && lastCompletedEpoch > 0 ? lastCompletedEpoch : 0;
-  // Fetch sessions that started after the cursor, OR sessions that are still
-  // in-progress (ended_at IS NULL).  Hermes updates token counts in real-time,
-  // so an active session keeps growing and must be re-read on every sync.
-  const sql = `SELECT id, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count FROM sessions WHERE (started_at > ${since} OR ended_at IS NULL) AND (input_tokens > 0 OR output_tokens > 0 OR cache_read_tokens > 0 OR reasoning_tokens > 0) ORDER BY started_at ASC`;
+  const forceIds = Array.isArray(unfinishedSessionIds)
+    ? [...new Set(unfinishedSessionIds.filter((id) => typeof id === "string" && id.length > 0))]
+    : [];
+  const forceIncludeSql = forceIds.length > 0
+    ? ` OR id IN (${forceIds.map(sqliteStringLiteral).join(",")})`
+    : "";
+  // Fetch sessions that started after the cursor, sessions that are still
+  // in-progress (ended_at IS NULL), OR sessions that were previously observed
+  // unfinished.  Hermes updates token counts in real-time, including a final
+  // delta when an active session later gets ended_at set.
+  const sql = `SELECT id, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count FROM sessions WHERE (started_at > ${since} OR ended_at IS NULL${forceIncludeSql}) AND (input_tokens > 0 OR output_tokens > 0 OR cache_read_tokens > 0 OR reasoning_tokens > 0) ORDER BY started_at ASC`;
   let raw;
   try {
     raw = cp.execFileSync("sqlite3", ["-json", dbPath, sql], {
@@ -3091,7 +3102,10 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
   const touchedBuckets = new Set();
 
   function ingestProfile(dbPath, dbState) {
-    const rows = readHermesSessions(dbPath, dbState.lastCompletedStartedAt);
+    const trackedUnfinishedSessionIds = Array.isArray(dbState.unfinishedSessionIds)
+      ? dbState.unfinishedSessionIds
+      : [];
+    const rows = readHermesSessions(dbPath, dbState.lastCompletedStartedAt, trackedUnfinishedSessionIds);
     recordsProcessed += rows.length;
     if (rows.length === 0) {
       dbState.updatedAt = updatedAt;
@@ -3109,6 +3123,8 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       typeof dbState.lastCompletedStartedAt === "number" ? dbState.lastCompletedStartedAt : 0;
 
     let maxCompletedStartedAt = lastCompletedStartedAt;
+    let oldestUnfinishedStartedAt = Infinity;
+    const nextUnfinishedSessionIds = new Set();
     const nextSnapshots = {};
 
     for (let i = 0; i < rows.length; i++) {
@@ -3122,6 +3138,17 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
 
       // Save current snapshot for next sync
       nextSnapshots[row.id] = { in: inputTokens, out: outputTokens, cacheRead, cacheWrite, reasoning };
+
+      const startedAt = Number(row.started_at);
+      const endedAt = row.ended_at == null ? null : Number(row.ended_at);
+      if (endedAt == null) {
+        if (row.id && Number.isFinite(startedAt)) {
+          nextUnfinishedSessionIds.add(row.id);
+          oldestUnfinishedStartedAt = Math.min(oldestUnfinishedStartedAt, startedAt);
+        }
+      } else if (Number.isFinite(startedAt) && startedAt > maxCompletedStartedAt) {
+        maxCompletedStartedAt = startedAt;
+      }
 
       // Compute delta from previous snapshot (if any) so that we only count
       // new tokens since the last sync.  First time we see a session the
@@ -3143,7 +3170,7 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       if (dInput === 0 && dOutput === 0 && dCacheRead === 0 && dCacheWrite === 0 && dReasoning === 0) continue;
 
       // Prefer ended_at for bucket placement; fall back to started_at
-      const epochSec = row.ended_at || row.started_at;
+      const epochSec = endedAt ?? startedAt;
       if (!epochSec || !Number.isFinite(epochSec)) continue;
       const tsIso = new Date(epochSec * 1000).toISOString();
       const bucketStart = toUtcHalfHourStart(tsIso);
@@ -3166,11 +3193,6 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       touchedBuckets.add(bucketKey("hermes", model, bucketStart));
       eventsAggregated++;
 
-      // Only advance cursor past sessions that have ended
-      if (row.ended_at && row.started_at > maxCompletedStartedAt) {
-        maxCompletedStartedAt = row.started_at;
-      }
-
       if (cb) {
         cb({
           index: i + 1,
@@ -3182,9 +3204,14 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
       }
     }
 
+    const nextLastCompletedStartedAt = Number.isFinite(oldestUnfinishedStartedAt)
+      ? Math.min(maxCompletedStartedAt, oldestUnfinishedStartedAt)
+      : maxCompletedStartedAt;
+
     Object.assign(dbState, {
-      lastStartedAt: maxCompletedStartedAt,
-      lastCompletedStartedAt: maxCompletedStartedAt,
+      lastStartedAt: nextLastCompletedStartedAt,
+      lastCompletedStartedAt: nextLastCompletedStartedAt,
+      unfinishedSessionIds: Array.from(nextUnfinishedSessionIds),
       snapshots: nextSnapshots,
       updatedAt,
     });

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2927,10 +2927,12 @@ test("parseHermesIncremental tracks real-time token growth for active sessions (
     assert.equal(activeBucket.input_tokens, 8000);
     assert.equal(activeBucket.output_tokens, 400);
     assert.equal(activeBucket.cached_input_tokens, 2000);
+    assert.equal(activeBucket.conversation_count, 10);
 
     // Snapshot should be updated
     assert.equal(cursors.hermes.snapshots["sess_active"].in, 8000);
     assert.equal(cursors.hermes.snapshots["sess_active"].out, 400);
+    assert.equal(cursors.hermes.snapshots["sess_active"].message_count, 10);
 
     // Cursor still hasn't advanced past the active session
     assert.equal(cursors.hermes.lastCompletedStartedAt, epoch1);

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2662,6 +2662,7 @@ async function readJsonLines(filePath) {
 // ── Hermes Agent integration tests ──
 
 function createHermesDb(dbPath, sessions) {
+  require("node:fs").mkdirSync(path.dirname(dbPath), { recursive: true });
   cp.execFileSync("sqlite3", [
     dbPath,
     `CREATE TABLE sessions (
@@ -2707,6 +2708,85 @@ function createHermesDb(dbPath, sessions) {
     ]);
   }
 }
+
+test("parseHermesIncremental reads default and named profile databases with isolated cursors", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-profiles-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const defaultDbPath = path.join(tmp, "state.db");
+    const workDbPath = path.join(tmp, "profiles", "work", "state.db");
+    const personalDbPath = path.join(tmp, "profiles", "personal", "state.db");
+    const defaultEpoch = 1775993779.0;
+    const workEpoch = 1775997400.0;
+    const personalEpoch = 1776001000.0;
+
+    createHermesDb(defaultDbPath, [
+      { id: "shared_session", model: "gpt-5.4-mini", started_at: defaultEpoch, ended_at: defaultEpoch + 120, input_tokens: 1000, output_tokens: 500, message_count: 4 },
+    ]);
+    createHermesDb(workDbPath, [
+      { id: "shared_session", model: "claude-sonnet-4-6", started_at: workEpoch, ended_at: workEpoch + 120, input_tokens: 2000, output_tokens: 700, cache_read_tokens: 300, message_count: 5 },
+    ]);
+    createHermesDb(personalDbPath, [
+      { id: "personal_session", model: "gpt-5.4", started_at: personalEpoch, ended_at: personalEpoch + 120, input_tokens: 3000, output_tokens: 900, cache_write_tokens: 400, reasoning_tokens: 100, message_count: 6 },
+    ]);
+
+    const first = await parseHermesIncremental({ hermesPath: tmp, cursors, queuePath });
+    assert.equal(first.recordsProcessed, 3);
+    assert.equal(first.eventsAggregated, 3);
+    assert.ok(first.bucketsQueued >= 3);
+
+    assert.equal(cursors.hermes.lastStartedAt, defaultEpoch);
+    assert.equal(cursors.hermes.lastCompletedStartedAt, defaultEpoch);
+    assert.equal(cursors.hermes.snapshots["shared_session"].in, 1000);
+    assert.equal(cursors.hermes.profiles.work.lastCompletedStartedAt, workEpoch);
+    assert.equal(cursors.hermes.profiles.work.snapshots["shared_session"].in, 2000);
+    assert.equal(cursors.hermes.profiles.personal.lastCompletedStartedAt, personalEpoch);
+    assert.equal(cursors.hermes.profiles.personal.snapshots["personal_session"].cacheWrite, 400);
+
+    const queued = await readJsonLines(queuePath);
+    assert.ok(queued.some((b) => b.source === "hermes" && b.model === "gpt-5.4-mini" && b.input_tokens === 1000));
+    assert.ok(queued.some((b) => b.source === "hermes" && b.model === "claude-sonnet-4-6" && b.cached_input_tokens === 300));
+    assert.ok(queued.some((b) => b.source === "hermes" && b.model === "gpt-5.4" && b.cache_creation_input_tokens === 400 && b.reasoning_output_tokens === 100));
+
+    const second = await parseHermesIncremental({ hermesPath: tmp, cursors, queuePath });
+    assert.equal(second.recordsProcessed, 0);
+    assert.equal(second.eventsAggregated, 0);
+    assert.equal(second.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseHermesIncremental processes profiles when default database is absent", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-profile-only-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const workDbPath = path.join(tmp, "profiles", "work", "state.db");
+    const epoch = 1775993779.0;
+
+    createHermesDb(workDbPath, [
+      { id: "work_session", model: "claude-sonnet-4-6", started_at: epoch, ended_at: epoch + 120, input_tokens: 1234, output_tokens: 567, message_count: 3 },
+    ]);
+
+    const result = await parseHermesIncremental({ hermesPath: tmp, cursors, queuePath });
+    assert.equal(result.recordsProcessed, 1);
+    assert.equal(result.eventsAggregated, 1);
+    assert.equal(cursors.hermes.profiles.work.lastCompletedStartedAt, epoch);
+    assert.equal(cursors.hermes.profiles.work.snapshots["work_session"].out, 567);
+    assert.equal(cursors.hermes.lastCompletedStartedAt, undefined);
+
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].source, "hermes");
+    assert.equal(queued[0].model, "claude-sonnet-4-6");
+    assert.equal(queued[0].input_tokens, 1234);
+    assert.equal(queued[0].output_tokens, 567);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
 
 test("parseHermesIncremental processes sessions incrementally", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-"));

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2952,6 +2952,43 @@ test("parseHermesIncremental tracks real-time token growth for active sessions (
   }
 });
 
+test("parseHermesIncremental ingests final deltas for active sessions older than newer completed sessions", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-old-active-"));
+  try {
+    const dbPath = path.join(tmp, "state.db");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+
+    const activeEpoch = 1775990000.0;
+    const completedEpoch = activeEpoch + 7200;
+
+    createHermesDb(dbPath, [
+      { id: "sess_active_old", model: "gpt-5.4-mini", started_at: activeEpoch, ended_at: null, input_tokens: 100, output_tokens: 10, message_count: 2 },
+      { id: "sess_done_newer", model: "claude-sonnet-4-6", started_at: completedEpoch, ended_at: completedEpoch + 120, input_tokens: 1000, output_tokens: 50, message_count: 4 },
+    ]);
+
+    const first = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(first.recordsProcessed, 2);
+    assert.equal(first.eventsAggregated, 2);
+    assert.equal(cursors.hermes.lastCompletedStartedAt, activeEpoch);
+    assert.equal(cursors.hermes.snapshots["sess_active_old"].in, 100);
+
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `UPDATE sessions SET ended_at = ${activeEpoch + 3600}, input_tokens = 150, output_tokens = 25, message_count = 3 WHERE id = 'sess_active_old';`,
+    ]);
+
+    const second = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.eventsAggregated, 1);
+    assert.equal(cursors.hermes.lastCompletedStartedAt, completedEpoch);
+
+    const queued = await readJsonLines(queuePath);
+    assert.ok(queued.some((b) => b.source === "hermes" && b.model === "gpt-5.4-mini" && b.input_tokens === 50 && b.output_tokens === 15));
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseHermesIncremental skips active session when delta is zero (unchanged)", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-"));
   try {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -2750,7 +2750,7 @@ test("parseHermesIncremental reads default and named profile databases with isol
     assert.ok(queued.some((b) => b.source === "hermes" && b.model === "gpt-5.4" && b.cache_creation_input_tokens === 400 && b.reasoning_output_tokens === 100));
 
     const second = await parseHermesIncremental({ hermesPath: tmp, cursors, queuePath });
-    assert.equal(second.recordsProcessed, 0);
+    assert.equal(second.recordsProcessed, 3);
     assert.equal(second.eventsAggregated, 0);
     assert.equal(second.bucketsQueued, 0);
   } finally {
@@ -2821,9 +2821,9 @@ test("parseHermesIncremental processes sessions incrementally", async () => {
     assert.equal(b1.output_tokens, 500);
     assert.equal(b1.cached_input_tokens, 200);
 
-    // Second parse — no new data, should be no-op
+    // Second parse — cursor-boundary row is re-read, but duplicate suppression makes it a no-op
     const second = await parseHermesIncremental({ dbPath, cursors, queuePath });
-    assert.equal(second.recordsProcessed, 0);
+    assert.equal(second.recordsProcessed, 1);
     assert.equal(second.eventsAggregated, 0);
     assert.equal(second.bucketsQueued, 0);
 
@@ -2833,10 +2833,44 @@ test("parseHermesIncremental processes sessions incrementally", async () => {
       `INSERT INTO sessions (id, source, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count) VALUES ('sess_003', 'cli', 'gpt-5.4-mini', ${epoch2 + 3600}, ${epoch2 + 3700}, 500, 250, 0, 0, 0, 2);`,
     ]);
     const third = await parseHermesIncremental({ dbPath, cursors, queuePath });
-    assert.equal(third.recordsProcessed, 1);
+    assert.equal(third.recordsProcessed, 2);
     assert.equal(third.eventsAggregated, 1);
     assert.ok(third.bucketsQueued >= 1);
     assert.equal(cursors.hermes.lastStartedAt, epoch2 + 3600);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseHermesIncremental re-reads cursor timestamp sessions so same-second inserts are not dropped", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-hermes-same-second-"));
+  try {
+    const dbPath = path.join(tmp, "state.db");
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1 };
+    const epoch = 1775993779.0;
+
+    createHermesDb(dbPath, [
+      { id: "sess_original", model: "gpt-5.4-mini", started_at: epoch, ended_at: epoch + 120, input_tokens: 1000, output_tokens: 500, message_count: 4 },
+    ]);
+
+    const first = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(first.recordsProcessed, 1);
+    assert.equal(first.eventsAggregated, 1);
+    assert.equal(cursors.hermes.lastCompletedStartedAt, epoch);
+
+    cp.execFileSync("sqlite3", [
+      dbPath,
+      `INSERT INTO sessions (id, source, model, started_at, ended_at, input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, reasoning_tokens, message_count) VALUES ('sess_same_second', 'cli', 'gpt-5.4-mini', ${epoch}, ${epoch + 240}, 300, 150, 0, 0, 0, 2);`,
+    ]);
+
+    const second = await parseHermesIncremental({ dbPath, cursors, queuePath });
+    assert.equal(second.recordsProcessed, 2);
+    assert.equal(second.eventsAggregated, 1);
+    assert.ok(second.bucketsQueued >= 1);
+
+    const queued = await readJsonLines(queuePath);
+    assert.ok(queued.some((b) => b.source === "hermes" && b.model === "gpt-5.4-mini" && b.input_tokens === 1300 && b.output_tokens === 650));
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -2914,7 +2948,7 @@ test("parseHermesIncremental tracks real-time token growth for active sessions (
 
     // Second parse — should pick up the delta for the active session
     const second = await parseHermesIncremental({ dbPath, cursors, queuePath });
-    assert.equal(second.recordsProcessed, 1); // only the active session re-read
+    assert.equal(second.recordsProcessed, 2); // cursor-boundary completed session plus active session are re-read
     assert.equal(second.eventsAggregated, 1);
 
     // Verify the delta was computed correctly
@@ -2944,7 +2978,7 @@ test("parseHermesIncremental tracks real-time token growth for active sessions (
     ]);
 
     const third = await parseHermesIncremental({ dbPath, cursors, queuePath });
-    assert.equal(third.recordsProcessed, 1);
+    assert.equal(third.recordsProcessed, 2);
     assert.equal(third.eventsAggregated, 1);
 
     // Now cursor should advance past the ended session


### PR DESCRIPTION
## Summary

Adds Hermes multi-profile ingestion so Token Tracker reads both the default `~/.hermes/state.db` and every discovered `~/.hermes/profiles/*/state.db`. This fixes missing Hermes usage from non-default profiles while keeping per-profile cursors isolated to avoid session-id collision deltas.

Closes #79.

## Changes

- Discover Hermes profile databases under `profiles/<name>/state.db` alongside the default database.
- Store named profile cursors under `cursors.hermes.profiles[profileName]` while preserving the existing top-level default-profile cursor fields for compatibility.
- Update sync to pass the Hermes base directory and add regression coverage for multi-profile ingestion, profile-only installs, and isolated snapshots.
- Document the Hermes multi-profile ingestion change in the changelog.

## Testing

- `node --test --test-name-pattern=Hermes test/rollout-parser.test.js` — passes (8/8)
- `node --test test/rollout-parser.test.js` — observed two pre-existing unrelated failures in OpenCode rewrite and Copilot rotation tests; Hermes coverage passed during this full run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Passive token tracking now discovers and aggregates tokens across the default and per-profile Hermes databases, maintaining independent cursor state per profile (works when default DB is absent).

* **Bug Fixes**
  * More accurate conversation counts, safer cursor advancement to avoid missing/double-counting, and handling of same-second inserts so incremental parses don’t drop recent rows; finalized-session deltas now enqueue correct totals.

* **Tests**
  * Added integration tests for multi-profile discovery, per-profile cursor isolation, same-second inserts, and finalized-session delta handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->