### PR TITLE
fix: add node sqlite fallback for provider DB readers

### DIFF
--- a/dashboard/edge-patches/tokentracker-device-token-issue.ts
+++ b/dashboard/edge-patches/tokentracker-device-token-issue.ts
@@ -187,16 +187,12 @@ export default async function (req: Request): Promise<Response> {
   const tokenHash = await sha256Hex(token);
   const createdAt = new Date().toISOString();
 
-  const { error: revokeErr } = await dbClient.database
-    .from("tokentracker_device_tokens")
-    .update({ revoked_at: createdAt })
-    .eq("device_id", deviceId)
-    .is("revoked_at", null);
-
-  if (revokeErr) {
-    return json({ error: "Failed to rotate device token", detail: revokeErr.message }, 500);
-  }
-
+  // NOTE: previous revision revoked all alive tokens on this device before
+  // inserting the new one ("rotate-on-issue"). That coupled with the dashboard
+  // re-minting on every WKWebView reload / module re-eval, killing the CLI's
+  // long-lived token on roughly every dashboard launch and stalling uploads
+  // for ~65% of recently-active users. Explicit rotation belongs in a
+  // separate "sign out devices" endpoint, not in the implicit issue path.
   const { error: tokenErr } = await dbClient.database.from("tokentracker_device_tokens").insert([
     {
       id: tokenId,

--- a/src/lib/cursor-config.js
+++ b/src/lib/cursor-config.js
@@ -1,33 +1,34 @@
 const os = require("node:os");
 const path = require("node:path");
 const fs = require("node:fs");
-const cp = require("node:child_process");
 const https = require("node:https");
 
 const { readJson } = require("./fs");
+const { readSqliteFirstValue } = require("./sqlite-reader");
 
 // ── Path resolution ──
 
 function resolveCursorPaths({ home, platform = process.platform, env = process.env } = {}) {
   const h = home || os.homedir();
+  const pathForPlatform = platform === "win32" ? path.win32 : path.posix;
   let appDir;
   if (platform === "darwin") {
-    appDir = path.join(h, "Library", "Application Support", "Cursor");
+    appDir = pathForPlatform.join(h, "Library", "Application Support", "Cursor");
   } else if (platform === "win32") {
     const appData =
       (typeof env.APPDATA === "string" && env.APPDATA.trim()) ||
-      path.join(h, "AppData", "Roaming");
-    appDir = path.join(appData, "Cursor");
+      pathForPlatform.join(h, "AppData", "Roaming");
+    appDir = pathForPlatform.join(appData, "Cursor");
   } else {
     const xdg =
       (typeof env.XDG_CONFIG_HOME === "string" && env.XDG_CONFIG_HOME.trim()) ||
-      path.join(h, ".config");
-    appDir = path.join(xdg, "Cursor");
+      pathForPlatform.join(h, ".config");
+    appDir = pathForPlatform.join(xdg, "Cursor");
   }
   return {
     appDir,
-    stateDbPath: path.join(appDir, "User", "globalStorage", "state.vscdb"),
-    cliConfigPath: path.join(h, ".cursor", "cli-config.json"),
+    stateDbPath: pathForPlatform.join(appDir, "User", "globalStorage", "state.vscdb"),
+    cliConfigPath: pathForPlatform.join(h, ".cursor", "cli-config.json"),
   };
 }
 
@@ -53,43 +54,15 @@ function cursorDebugLog(message, env = process.env) {
 }
 
 function readCursorAccessTokenFromStateDb(stateDbPath, deps = {}) {
-  const execFileSync = deps.execFileSync || cp.execFileSync;
-  const requireFn = deps.requireFn || require;
-  const env = deps.env || process.env;
-
-  try {
-    return execFileSync("sqlite3", [stateDbPath, CURSOR_ACCESS_TOKEN_SQL], {
-      encoding: "utf8",
-      timeout: 5000,
-      stdio: ["pipe", "pipe", "pipe"],
-    }).trim();
-  } catch (sqliteCliErr) {
-    cursorDebugLog(
-      `sqlite3 CLI token read failed for ${stateDbPath}: ${sqliteCliErr?.message || sqliteCliErr}`,
-      env,
-    );
-  }
-
-  try {
-    const { DatabaseSync } = requireFn("node:sqlite");
-    if (typeof DatabaseSync !== "function") {
-      cursorDebugLog("node:sqlite DatabaseSync is unavailable", env);
-      return null;
-    }
-    const db = new DatabaseSync(stateDbPath, { readOnly: true });
-    try {
-      const row = db.prepare(CURSOR_ACCESS_TOKEN_SQL).get();
-      return typeof row?.value === "string" ? row.value.trim() : null;
-    } finally {
-      db.close();
-    }
-  } catch (nodeSqliteErr) {
-    cursorDebugLog(
-      `node:sqlite token read failed for ${stateDbPath}: ${nodeSqliteErr?.message || nodeSqliteErr}`,
-      env,
-    );
-    return null;
-  }
+  return readSqliteFirstValue(stateDbPath, CURSOR_ACCESS_TOKEN_SQL, "value", {
+    execFileSync: deps.execFileSync,
+    requireFn: deps.requireFn,
+    env: deps.env,
+    stderr: deps.stderr,
+    label: "Cursor",
+    timeout: 5000,
+    maxBuffer: 1024 * 1024,
+  });
 }
 
 /**
@@ -103,8 +76,8 @@ function readCursorAccessTokenFromStateDb(stateDbPath, deps = {}) {
  *   - Google sign-in via WorkOS:    "google-oauth2|<numeric>" → kept verbatim
  *   - other WorkOS subjects:        "github|…", "oidc|…"      → kept verbatim
  */
-function extractCursorSessionToken({ home, deps } = {}) {
-  const { stateDbPath, cliConfigPath } = resolveCursorPaths({ home });
+function extractCursorSessionToken({ home, platform, env, deps } = {}) {
+  const { stateDbPath, cliConfigPath } = resolveCursorPaths({ home, platform, env });
 
   // 1. Extract JWT from SQLite
   if (!fs.existsSync(stateDbPath)) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -2,10 +2,10 @@ const fs = require("node:fs/promises");
 const fssync = require("node:fs");
 const path = require("node:path");
 const readline = require("node:readline");
-const cp = require("node:child_process");
 
 const crypto = require("node:crypto");
 const { ensureDir } = require("./fs");
+const { readSqliteJsonRows } = require("./sqlite-reader");
 
 const DEFAULT_SOURCE = "codex";
 const DEFAULT_MODEL = "unknown";
@@ -2381,27 +2381,15 @@ async function walkOpencodeMessages(dir, out) {
 // OpenCode SQLite DB reader (v1.2+ stores messages in opencode.db)
 // ---------------------------------------------------------------------------
 
-function readOpencodeDbMessages(dbPath) {
+function readOpencodeDbMessages(dbPath, sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   const sql = `SELECT id, session_id, time_updated, data FROM message WHERE json_extract(data, '$.role') = 'assistant' ORDER BY time_created ASC`;
-  let raw;
-  try {
-    raw = cp.execFileSync("sqlite3", ["-json", dbPath, sql], {
-      encoding: "utf8",
-      maxBuffer: 50 * 1024 * 1024,
-      timeout: 30_000,
-    });
-  } catch (_e) {
-    return [];
-  }
-  if (!raw || !raw.trim()) return [];
-  let rows;
-  try {
-    rows = JSON.parse(raw);
-  } catch (_e) {
-    return [];
-  }
-  if (!Array.isArray(rows)) return [];
+  const rows = readSqliteJsonRows(dbPath, sql, {
+    label: "OpenCode",
+    maxBuffer: 50 * 1024 * 1024,
+    timeout: 30_000,
+    ...sqliteOptions,
+  });
   const out = [];
   for (const row of rows) {
     if (!row || typeof row.data !== "string") continue;
@@ -2717,28 +2705,16 @@ function resolveKiroJsonlPath() {
   return path.join(resolveKiroBasePath(), "dev_data", "tokens_generated.jsonl");
 }
 
-function readKiroDbTokens(dbPath, sinceId) {
+function readKiroDbTokens(dbPath, sinceId, sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   const minId = Number.isFinite(sinceId) && sinceId > 0 ? sinceId : 0;
   const sql = `SELECT id, model, provider, tokens_prompt, tokens_generated, timestamp FROM tokens_generated WHERE id > ${minId} ORDER BY id ASC`;
-  let raw;
-  try {
-    raw = cp.execFileSync("sqlite3", ["-json", dbPath, sql], {
-      encoding: "utf8",
-      maxBuffer: 10 * 1024 * 1024,
-      timeout: 15_000,
-    });
-  } catch (_e) {
-    return [];
-  }
-  if (!raw || !raw.trim()) return [];
-  let rows;
-  try {
-    rows = JSON.parse(raw);
-  } catch (_e) {
-    return [];
-  }
-  return Array.isArray(rows) ? rows : [];
+  return readSqliteJsonRows(dbPath, sql, {
+    label: "Kiro",
+    maxBuffer: 10 * 1024 * 1024,
+    timeout: 15_000,
+    ...sqliteOptions,
+  });
 }
 
 // Read Kiro token data from JSONL fallback (tokens_generated.jsonl).
@@ -2880,7 +2856,7 @@ function normalizeKiroModelName(raw) {
   return name || null;
 }
 
-async function parseKiroIncremental({ dbPath, jsonlPath, cursors, queuePath, onProgress }) {
+async function parseKiroIncremental({ dbPath, jsonlPath, cursors, queuePath, onProgress, sqliteOptions } = {}) {
   await ensureDir(path.dirname(queuePath));
   const kiroState = cursors.kiro && typeof cursors.kiro === "object" ? cursors.kiro : {};
   const lastDbId = typeof kiroState.lastDbId === "number"
@@ -2898,7 +2874,7 @@ async function parseKiroIncremental({ dbPath, jsonlPath, cursors, queuePath, onP
   let nextJsonlLine = lastJsonlLine;
   let usingDb = false;
   if (fssync.existsSync(resolvedDbPath)) {
-    rows = readKiroDbTokens(resolvedDbPath, lastDbId);
+    rows = readKiroDbTokens(resolvedDbPath, lastDbId, sqliteOptions);
     usingDb = true;
     // DB and JSONL are siblings for the same usage events. If the DB ever
     // disappears (corrupted / wiped) and we fall back to JSONL in a later
@@ -3088,7 +3064,7 @@ function snapshotSqliteDb(dbPath) {
   };
 }
 
-function readHermesSessions(dbPath, lastCompletedEpoch, unfinishedSessionIds = []) {
+function readHermesSessions(dbPath, lastCompletedEpoch, unfinishedSessionIds = [], sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
   const since = Number.isFinite(lastCompletedEpoch) && lastCompletedEpoch > 0 ? lastCompletedEpoch : 0;
   const forceIds = Array.isArray(unfinishedSessionIds)
@@ -3116,24 +3092,12 @@ function readHermesSessions(dbPath, lastCompletedEpoch, unfinishedSessionIds = [
   }
 
   try {
-    let raw;
-    try {
-      raw = cp.execFileSync("sqlite3", ["-json", effectiveDbPath, sql], {
-        encoding: "utf8",
-        maxBuffer: 10 * 1024 * 1024,
-        timeout: 15_000,
-      });
-    } catch (_e) {
-      return [];
-    }
-    if (!raw || !raw.trim()) return [];
-    let rows;
-    try {
-      rows = JSON.parse(raw);
-    } catch (_e) {
-      return [];
-    }
-    return Array.isArray(rows) ? rows : [];
+    return readSqliteJsonRows(effectiveDbPath, sql, {
+      label: "Hermes",
+      maxBuffer: 10 * 1024 * 1024,
+      timeout: 15_000,
+      ...sqliteOptions,
+    });
   } finally {
     if (snapshot) snapshot.cleanup();
   }
@@ -3147,7 +3111,7 @@ function hasLegacyHermesDefaultState(hermesState) {
   );
 }
 
-async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, onProgress }) {
+async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, onProgress, sqliteOptions } = {}) {
   await ensureDir(path.dirname(queuePath));
   const hermesState = cursors.hermes && typeof cursors.hermes === "object" ? cursors.hermes : {};
 
@@ -3168,7 +3132,12 @@ async function parseHermesIncremental({ hermesPath, dbPath, cursors, queuePath, 
     const trackedUnfinishedSessionIds = Array.isArray(dbState.unfinishedSessionIds)
       ? dbState.unfinishedSessionIds
       : [];
-    const rows = readHermesSessions(dbPath, dbState.lastCompletedStartedAt, trackedUnfinishedSessionIds);
+    const rows = readHermesSessions(
+      dbPath,
+      dbState.lastCompletedStartedAt,
+      trackedUnfinishedSessionIds,
+      sqliteOptions,
+    );
     recordsProcessed += rows.length;
     if (rows.length === 0) {
       dbState.updatedAt = updatedAt;
@@ -3650,44 +3619,22 @@ function canonicalizeKiroCliModelId(raw) {
 // `conversation_id` and the inner JSON `continuation_id` are different
 // UUIDs on observed data; covering both means retraction fires whichever
 // side matches the live session's `session_id`.
-function readKiroCliRequests(dbPath, env = process.env) {
+function readKiroCliRequests(dbPath, env = process.env, sqliteOptions = {}) {
   if (!dbPath || !fssync.existsSync(dbPath)) return [];
-  let raw;
-  try {
-    raw = cp.execFileSync(
-      "sqlite3",
-      [
-        "-json",
-        dbPath,
-        "SELECT conversation_id, " +
-          "json_extract(value, '$.model_info.model_id') AS session_model_id, " +
-          "json_extract(value, '$.user_turn_metadata.continuation_id') AS continuation_id, " +
-          "json_extract(value, '$.user_turn_metadata.requests') AS requests_json " +
-          "FROM conversations_v2 " +
-          "WHERE json_extract(value, '$.user_turn_metadata.requests') IS NOT NULL",
-      ],
-      { encoding: "utf8", maxBuffer: 128 * 1024 * 1024, timeout: 120_000 },
-    );
-  } catch (err) {
-    // TASK-012 / D-8: debug-gated stderr log so a missing sqlite3 binary
-    // is distinguishable from an empty DB. Silent by default. env is
-    // threaded so tests can toggle debug hermetically.
-    const dbg = String((env && env.TOKENTRACKER_DEBUG) || "").toLowerCase();
-    if (dbg === "1" || dbg === "true") {
-      process.stderr.write(
-        `[kiro-cli] sqlite3 read failed: ${err?.message || err}\n`,
-      );
-    }
-    return [];
-  }
-  if (!raw || !raw.trim()) return [];
-  let rows;
-  try {
-    rows = JSON.parse(raw);
-  } catch {
-    return [];
-  }
-  if (!Array.isArray(rows)) return [];
+  const sql =
+    "SELECT conversation_id, " +
+    "json_extract(value, '$.model_info.model_id') AS session_model_id, " +
+    "json_extract(value, '$.user_turn_metadata.continuation_id') AS continuation_id, " +
+    "json_extract(value, '$.user_turn_metadata.requests') AS requests_json " +
+    "FROM conversations_v2 " +
+    "WHERE json_extract(value, '$.user_turn_metadata.requests') IS NOT NULL";
+  const rows = readSqliteJsonRows(dbPath, sql, {
+    label: "Kiro CLI",
+    env,
+    maxBuffer: 128 * 1024 * 1024,
+    timeout: 120_000,
+    ...sqliteOptions,
+  });
   const flat = [];
   for (const row of rows) {
     let requests;
@@ -3715,7 +3662,7 @@ function readKiroCliRequests(dbPath, env = process.env) {
   return flat;
 }
 
-async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onProgress, env } = {}) {
+async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onProgress, env, sqliteOptions } = {}) {
   await ensureDir(path.dirname(queuePath));
   const kiroCliState =
     cursors.kiroCli && typeof cursors.kiroCli === "object" ? cursors.kiroCli : {};
@@ -3750,7 +3697,7 @@ async function parseKiroCliIncremental({ sessionFiles, cursors, queuePath, onPro
   // SQLite conversation_id OR continuation_id to subtract the orphan
   // session-file cursor entry before the new SQLite row is processed.
   const flatDb = fssync.existsSync(dbPath)
-    ? readKiroCliRequests(dbPath, resolvedEnv)
+    ? readKiroCliRequests(dbPath, resolvedEnv, sqliteOptions)
     : [];
   const sessionFilesList = resolveKiroCliSessionFiles(resolvedEnv);
   let flatSessions = [];
@@ -5203,16 +5150,16 @@ function extractZedTotals(thread) {
 // several `threads` schemas; older versions may omit created_at /
 // folder_paths. We dynamically detect via PRAGMA so the query never fails on
 // a missing column.
-function buildZedThreadsQuery(dbPath, cursorUpdatedAt) {
-  const pragma = cp.execFileSync("sqlite3", [dbPath, "PRAGMA table_info(threads)"], {
-    encoding: "utf8",
+function buildZedThreadsQuery(dbPath, cursorUpdatedAt, sqliteOptions = {}) {
+  const pragmaRows = readSqliteJsonRows(dbPath, "PRAGMA table_info(threads)", {
+    label: "Zed",
     maxBuffer: 4 * 1024 * 1024,
     timeout: 10_000,
+    ...sqliteOptions,
   });
   const columns = new Set(
-    pragma
-      .split("\n")
-      .map((line) => line.split("|")[1])
+    pragmaRows
+      .map((row) => row?.name)
       .filter(Boolean),
   );
   const optional = (col) => (columns.has(col) ? col : `NULL AS ${col}`);
@@ -5228,27 +5175,14 @@ function buildZedThreadsQuery(dbPath, cursorUpdatedAt) {
   return `SELECT id, updated_at, ${optional("created_at")}, data_type, hex(data) AS data_hex FROM threads${where}`;
 }
 
-function readZedThreadRowsFromSqlite(dbPath, cursorUpdatedAt) {
-  const query = buildZedThreadsQuery(dbPath, cursorUpdatedAt);
-  let raw;
-  try {
-    raw = cp.execFileSync("sqlite3", ["-json", dbPath, query], {
-      encoding: "utf8",
-      maxBuffer: 256 * 1024 * 1024,
-      timeout: 60_000,
-    });
-  } catch (_e) {
-    return [];
-  }
-  if (!raw || !raw.trim()) return [];
-  let rows;
-  try {
-    rows = JSON.parse(raw);
-  } catch (_e) {
-    return [];
-  }
-  if (!Array.isArray(rows)) return [];
-  return rows;
+function readZedThreadRowsFromSqlite(dbPath, cursorUpdatedAt, sqliteOptions = {}) {
+  const query = buildZedThreadsQuery(dbPath, cursorUpdatedAt, sqliteOptions);
+  return readSqliteJsonRows(dbPath, query, {
+    label: "Zed",
+    maxBuffer: 256 * 1024 * 1024,
+    timeout: 60_000,
+    ...sqliteOptions,
+  });
 }
 
 async function parseZedIncremental({
@@ -5257,6 +5191,7 @@ async function parseZedIncremental({
   queuePath,
   onProgress,
   env,
+  sqliteOptions,
 } = {}) {
   await ensureDir(path.dirname(queuePath));
   const resolvedDb = dbPath || resolveZedDbPath(env || process.env);
@@ -5294,7 +5229,7 @@ async function parseZedIncremental({
   const snap = snapshotSqliteDb(resolvedDb);
   let rows = [];
   try {
-    rows = readZedThreadRowsFromSqlite(snap.path, cursorUpdatedAt);
+    rows = readZedThreadRowsFromSqlite(snap.path, cursorUpdatedAt, sqliteOptions);
   } finally {
     snap.cleanup();
   }
@@ -5528,21 +5463,18 @@ function parseGooseCreatedAt(s) {
   return null;
 }
 
-function readGooseSessionsFromSqlite(dbPath) {
+function readGooseSessionsFromSqlite(dbPath, sqliteOptions = {}) {
   // Probe columns: the `accumulated_*` fields were added in a later Goose
   // version; we keep the query forgiving so older installs still work.
-  let pragma;
-  try {
-    pragma = cp.execFileSync("sqlite3", [dbPath, "PRAGMA table_info(sessions)"], {
-      encoding: "utf8",
-      maxBuffer: 4 * 1024 * 1024,
-      timeout: 10_000,
-    });
-  } catch (_e) { return []; }
+  const pragmaRows = readSqliteJsonRows(dbPath, "PRAGMA table_info(sessions)", {
+    label: "Goose",
+    maxBuffer: 4 * 1024 * 1024,
+    timeout: 10_000,
+    ...sqliteOptions,
+  });
   const columns = new Set(
-    pragma
-      .split("\n")
-      .map((line) => line.split("|")[1])
+    pragmaRows
+      .map((row) => row?.name)
       .filter(Boolean),
   );
   const optional = (col) => (columns.has(col) ? col : `NULL AS ${col}`);
@@ -5562,21 +5494,12 @@ function readGooseSessionsFromSqlite(dbPath) {
     WHERE model_config_json IS NOT NULL
       AND TRIM(model_config_json) != ''
   `.trim();
-  let raw;
-  try {
-    raw = cp.execFileSync("sqlite3", ["-json", dbPath, sql], {
-      encoding: "utf8",
-      maxBuffer: 64 * 1024 * 1024,
-      timeout: 60_000,
-    });
-  } catch (_e) { return []; }
-  if (!raw || !raw.trim()) return [];
-  try {
-    const rows = JSON.parse(raw);
-    return Array.isArray(rows) ? rows : [];
-  } catch (_e) {
-    return [];
-  }
+  return readSqliteJsonRows(dbPath, sql, {
+    label: "Goose",
+    maxBuffer: 64 * 1024 * 1024,
+    timeout: 60_000,
+    ...sqliteOptions,
+  });
 }
 
 async function parseGooseIncremental({
@@ -5585,6 +5508,7 @@ async function parseGooseIncremental({
   queuePath,
   onProgress,
   env,
+  sqliteOptions,
 } = {}) {
   await ensureDir(path.dirname(queuePath));
   const resolvedDb = dbPath || resolveGooseDbPath(env || process.env);
@@ -5618,7 +5542,7 @@ async function parseGooseIncremental({
   const snap = snapshotSqliteDb(resolvedDb);
   let rows = [];
   try {
-    rows = readGooseSessionsFromSqlite(snap.path);
+    rows = readGooseSessionsFromSqlite(snap.path, sqliteOptions);
   } finally {
     snap.cleanup();
   }

--- a/src/lib/sqlite-reader.js
+++ b/src/lib/sqlite-reader.js
@@ -1,0 +1,136 @@
+const cp = require("node:child_process");
+const fssync = require("node:fs");
+
+const warnedSqliteReadFailures = new Set();
+
+function isDebugEnabled(env = process.env) {
+  const value = String((env && env.TOKENTRACKER_DEBUG) || "").toLowerCase();
+  return value === "1" || value === "true";
+}
+
+function formatError(err) {
+  if (!err) return "unknown error";
+  return err && err.message ? err.message : String(err);
+}
+
+function warnSqliteUnavailable({ dbPath, label, cliError, nodeSqliteError, env, stderr }) {
+  const key = `${label || "SQLite"}:${dbPath || ""}`;
+  if (warnedSqliteReadFailures.has(key)) return;
+  warnedSqliteReadFailures.add(key);
+
+  const out = stderr && typeof stderr.write === "function" ? stderr : process.stderr;
+  const displayLabel = label || "local";
+  out.write(
+    `[tokentracker] Cannot read ${displayLabel} SQLite database. Install sqlite3 CLI and add it to PATH, or use Node.js 22+ with node:sqlite support. Path: ${dbPath}\n`,
+  );
+  if (isDebugEnabled(env)) {
+    out.write(`[tokentracker] sqlite3 CLI failed: ${formatError(cliError)}\n`);
+    out.write(`[tokentracker] node:sqlite failed: ${formatError(nodeSqliteError)}\n`);
+  }
+}
+
+function readSqliteRowsWithCli(dbPath, sql, { execFileSync, timeout, maxBuffer }) {
+  const raw = execFileSync("sqlite3", ["-json", dbPath, sql], {
+    encoding: "utf8",
+    maxBuffer,
+    timeout,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  if (!raw || !raw.trim()) return [];
+  const rows = JSON.parse(raw);
+  return Array.isArray(rows) ? rows : [];
+}
+
+function isSqliteCliUnavailable(err) {
+  const message = formatError(err).toLowerCase();
+  return (
+    err?.code === "ENOENT" ||
+    message.includes("spawn sqlite3 enoent") ||
+    message.includes("sqlite3 enoent") ||
+    message.includes("not recognized as an internal or external command")
+  );
+}
+
+function isNodeSqliteUnavailable(err) {
+  const message = formatError(err).toLowerCase();
+  return (
+    message.includes("no such built-in module") ||
+    message.includes("cannot find module 'node:sqlite'") ||
+    message.includes('cannot find module "node:sqlite"') ||
+    message.includes("node:sqlite databasesync is unavailable")
+  );
+}
+
+function readSqliteRowsWithNode(dbPath, sql, { requireFn }) {
+  const { DatabaseSync } = requireFn("node:sqlite");
+  if (typeof DatabaseSync !== "function") {
+    throw new Error("node:sqlite DatabaseSync is unavailable");
+  }
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    const rows = db.prepare(sql).all();
+    return Array.isArray(rows) ? rows : [];
+  } finally {
+    db.close();
+  }
+}
+
+function readSqliteJsonRows(dbPath, sql, options = {}) {
+  if (!dbPath || !sql) return [];
+  try {
+    if (!fssync.existsSync(dbPath)) return [];
+  } catch (_e) {
+    return [];
+  }
+  const execFileSync = options.execFileSync || cp.execFileSync;
+  const requireFn = options.requireFn || require;
+  const env = options.env || process.env;
+  const timeout = Number.isFinite(options.timeout) ? options.timeout : 30_000;
+  const maxBuffer = Number.isFinite(options.maxBuffer) ? options.maxBuffer : 50 * 1024 * 1024;
+  const label = options.label || "local";
+
+  let cliError = null;
+  try {
+    return readSqliteRowsWithCli(dbPath, sql, { execFileSync, timeout, maxBuffer });
+  } catch (err) {
+    cliError = err;
+  }
+
+  let nodeSqliteError = null;
+  try {
+    return readSqliteRowsWithNode(dbPath, sql, { requireFn });
+  } catch (err) {
+    nodeSqliteError = err;
+  }
+
+  if (isSqliteCliUnavailable(cliError) && isNodeSqliteUnavailable(nodeSqliteError)) {
+    warnSqliteUnavailable({
+      dbPath,
+      label,
+      cliError,
+      nodeSqliteError,
+      env,
+      stderr: options.stderr,
+    });
+  }
+  return [];
+}
+
+function readSqliteFirstValue(dbPath, sql, column, options = {}) {
+  const rows = readSqliteJsonRows(dbPath, sql, options);
+  const row = rows[0];
+  if (!row || typeof row !== "object") return null;
+  const key = typeof column === "string" && column.length > 0 ? column : Object.keys(row)[0];
+  const value = row[key];
+  return typeof value === "string" ? value.trim() : value == null ? null : String(value).trim();
+}
+
+function resetSqliteReaderWarningsForTests() {
+  warnedSqliteReadFailures.clear();
+}
+
+module.exports = {
+  readSqliteJsonRows,
+  readSqliteFirstValue,
+  resetSqliteReaderWarningsForTests,
+};

--- a/test/cursor-config.test.js
+++ b/test/cursor-config.test.js
@@ -309,15 +309,18 @@ describe("extractCursorSessionToken", () => {
 
   it("reads the Cursor access token via sqlite3 CLI", () => {
     const jwt = makeCursorJwt();
-    const token = readCursorAccessTokenFromStateDb("/tmp/state.vscdb", {
+    const dbPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-db-")), "state.vscdb");
+    fs.writeFileSync(dbPath, "", "utf8");
+    const token = readCursorAccessTokenFromStateDb(dbPath, {
       execFileSync: (cmd, args, opts) => {
         assert.equal(cmd, "sqlite3");
         assert.deepEqual(args, [
-          "/tmp/state.vscdb",
+          "-json",
+          dbPath,
           "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken';",
         ]);
         assert.equal(opts.encoding, "utf8");
-        return `${jwt}\n`;
+        return JSON.stringify([{ value: jwt }]);
       },
       requireFn: () => {
         throw new Error("node:sqlite should not be used when sqlite3 works");
@@ -330,8 +333,10 @@ describe("extractCursorSessionToken", () => {
 
   it("falls back to node:sqlite when sqlite3 CLI is unavailable", () => {
     const jwt = makeCursorJwt();
+    const dbPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-db-")), "state.vscdb");
+    fs.writeFileSync(dbPath, "", "utf8");
     let closed = false;
-    const token = readCursorAccessTokenFromStateDb("C:\\Users\\alice\\state.vscdb", {
+    const token = readCursorAccessTokenFromStateDb(dbPath, {
       execFileSync: () => {
         throw new Error("spawn sqlite3 ENOENT");
       },
@@ -339,16 +344,16 @@ describe("extractCursorSessionToken", () => {
         assert.equal(name, "node:sqlite");
         return {
           DatabaseSync: class FakeDatabaseSync {
-            constructor(dbPath, options) {
-              assert.equal(dbPath, "C:\\Users\\alice\\state.vscdb");
+            constructor(actualDbPath, options) {
+              assert.equal(actualDbPath, dbPath);
               assert.deepEqual(options, { readOnly: true });
             }
 
             prepare(sql) {
               assert.equal(sql, "SELECT value FROM ItemTable WHERE key = 'cursorAuth/accessToken';");
               return {
-                get() {
-                  return { value: ` ${jwt}\n` };
+                all() {
+                  return [{ value: ` ${jwt}\n` }];
                 },
               };
             }
@@ -367,7 +372,9 @@ describe("extractCursorSessionToken", () => {
   });
 
   it("returns null when neither sqlite reader can read the token", () => {
-    const token = readCursorAccessTokenFromStateDb("/tmp/state.vscdb", {
+    const dbPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-db-")), "state.vscdb");
+    fs.writeFileSync(dbPath, "", "utf8");
+    const token = readCursorAccessTokenFromStateDb(dbPath, {
       execFileSync: () => {
         throw new Error("spawn sqlite3 ENOENT");
       },
@@ -375,6 +382,7 @@ describe("extractCursorSessionToken", () => {
         throw new Error("No such built-in module: node:sqlite");
       },
       env: {},
+      stderr: { write() {} },
     });
 
     assert.equal(token, null);
@@ -383,11 +391,12 @@ describe("extractCursorSessionToken", () => {
   it("builds the Cursor cookie when token reading falls back to node:sqlite", () => {
     const jwt = makeCursorJwt("user_FALLBACK");
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-home-"));
-    const { stateDbPath } = resolveCursorPaths({ home });
+    const { stateDbPath } = resolveCursorPaths({ home, env: {} });
     fs.mkdirSync(path.dirname(stateDbPath), { recursive: true });
     fs.writeFileSync(stateDbPath, "", "utf8");
     const result = extractCursorSessionToken({
       home,
+      env: {},
       deps: {
         execFileSync: () => {
           throw new Error("spawn sqlite3 ENOENT");
@@ -396,8 +405,8 @@ describe("extractCursorSessionToken", () => {
           DatabaseSync: class FakeDatabaseSync {
             prepare() {
               return {
-                get() {
-                  return { value: jwt };
+                all() {
+                  return [{ value: jwt }];
                 },
               };
             }
@@ -422,7 +431,7 @@ describe("extractCursorSessionToken", () => {
     const jwt = `${header}.${payload}.sig`;
 
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-google-"));
-    const { stateDbPath, cliConfigPath } = resolveCursorPaths({ home });
+    const { stateDbPath, cliConfigPath } = resolveCursorPaths({ home, env: {} });
     fs.mkdirSync(path.dirname(stateDbPath), { recursive: true });
     fs.writeFileSync(stateDbPath, "", "utf8");
     fs.mkdirSync(path.dirname(cliConfigPath), { recursive: true });
@@ -430,8 +439,9 @@ describe("extractCursorSessionToken", () => {
 
     const result = extractCursorSessionToken({
       home,
+      env: {},
       deps: {
-        execFileSync: () => `${jwt}\n`,
+        execFileSync: () => JSON.stringify([{ value: jwt }]),
         requireFn: () => {
           throw new Error("sqlite3 CLI used");
         },
@@ -452,14 +462,15 @@ describe("extractCursorSessionToken", () => {
     const jwt = `${header}.${payload}.sig`;
 
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-google-jwt-"));
-    const { stateDbPath } = resolveCursorPaths({ home });
+    const { stateDbPath } = resolveCursorPaths({ home, env: {} });
     fs.mkdirSync(path.dirname(stateDbPath), { recursive: true });
     fs.writeFileSync(stateDbPath, "", "utf8");
 
     const result = extractCursorSessionToken({
       home,
+      env: {},
       deps: {
-        execFileSync: () => `${jwt}\n`,
+        execFileSync: () => JSON.stringify([{ value: jwt }]),
         requireFn: () => {
           throw new Error("sqlite3 CLI used");
         },
@@ -480,14 +491,15 @@ describe("extractCursorSessionToken", () => {
     const jwt = `${header}.${payload}.sig`;
 
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-gh-"));
-    const { stateDbPath } = resolveCursorPaths({ home });
+    const { stateDbPath } = resolveCursorPaths({ home, env: {} });
     fs.mkdirSync(path.dirname(stateDbPath), { recursive: true });
     fs.writeFileSync(stateDbPath, "", "utf8");
 
     const result = extractCursorSessionToken({
       home,
+      env: {},
       deps: {
-        execFileSync: () => `${jwt}\n`,
+        execFileSync: () => JSON.stringify([{ value: jwt }]),
         requireFn: () => {
           throw new Error("sqlite3 CLI used");
         },
@@ -504,14 +516,15 @@ describe("extractCursorSessionToken", () => {
     const jwt = `${header}.${payload}.sig`;
 
     const home = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-cursor-unknown-"));
-    const { stateDbPath } = resolveCursorPaths({ home });
+    const { stateDbPath } = resolveCursorPaths({ home, env: {} });
     fs.mkdirSync(path.dirname(stateDbPath), { recursive: true });
     fs.writeFileSync(stateDbPath, "", "utf8");
 
     const result = extractCursorSessionToken({
       home,
+      env: {},
       deps: {
-        execFileSync: () => `${jwt}\n`,
+        execFileSync: () => JSON.stringify([{ value: jwt }]),
         requireFn: () => {
           throw new Error("sqlite3 CLI used");
         },

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -10,6 +10,7 @@ const {
   parseClaudeIncremental,
   parseGeminiIncremental,
   parseOpencodeIncremental,
+  readOpencodeDbMessages,
   parseKiroIncremental,
   parseHermesIncremental,
   resolveHermesPath,
@@ -1018,6 +1019,63 @@ test("parseOpencodeIncremental aggregates message tokens and model", async () =>
       queuePath,
     });
     assert.equal(resAgain.bucketsQueued, 0);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("readOpencodeDbMessages falls back to node:sqlite when sqlite3 CLI is unavailable", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tokentracker-opencode-db-"));
+  try {
+    const dbPath = path.join(tmp, "opencode.db");
+    await fs.writeFile(dbPath, "", "utf8");
+    const message = buildOpencodeMessage({
+      modelID: "deepseek-v4-flash-free",
+      created: "2025-12-29T10:14:00.000Z",
+      completed: "2025-12-29T10:15:00.000Z",
+      tokens: { input: 34, output: 10, reasoning: 2, cached: 0, cacheWrite: 0 },
+    });
+    const rows = readOpencodeDbMessages(dbPath, {
+      execFileSync() {
+        throw new Error("spawn sqlite3 ENOENT");
+      },
+      requireFn(name) {
+        assert.equal(name, "node:sqlite");
+        return {
+          DatabaseSync: class FakeDatabaseSync {
+            constructor(actualDbPath, options) {
+              assert.equal(actualDbPath, dbPath);
+              assert.deepEqual(options, { readOnly: true });
+            }
+
+            prepare(sql) {
+              assert.match(sql, /FROM message/);
+              return {
+                all() {
+                  return [
+                    {
+                      id: "msg_db_1",
+                      session_id: "ses_db_1",
+                      time_updated: Date.parse("2025-12-29T10:15:00.000Z"),
+                      data: JSON.stringify(message),
+                    },
+                  ];
+                },
+              };
+            }
+
+            close() {}
+          },
+        };
+      },
+      stderr: { write() {} },
+    });
+
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].id, "msg_db_1");
+    assert.equal(rows[0].sessionID, "ses_db_1");
+    assert.equal(rows[0].data.modelID, "deepseek-v4-flash-free");
+    assert.equal(rows[0].data.tokens.input, 34);
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }
@@ -2939,9 +2997,11 @@ test("parseHermesIncremental snapshots the DB locally for UNC paths", async () =
     createHermesDb(realDbPath, [
       { id: "unc_session", model: "gpt-5.4-mini", started_at: epoch, ended_at: epoch + 60, input_tokens: 700, output_tokens: 100, message_count: 2 },
     ]);
-    // Prefix with an extra `/` so isUncPath() returns true; node's path layer
-    // still resolves it to the same inode on POSIX.
-    const uncStyle = "/" + realDbPath;
+    // Prefix so isUncPath() returns true while node's path layer still
+    // resolves it to the same inode.
+    const uncStyle = process.platform === "win32"
+      ? "\\\\?\\" + realDbPath
+      : "/" + realDbPath;
     const result = await parseHermesIncremental({ dbPath: uncStyle, cursors, queuePath });
     assert.equal(result.recordsProcessed, 1);
     assert.equal(result.eventsAggregated, 1);

--- a/test/sqlite-reader.test.js
+++ b/test/sqlite-reader.test.js
@@ -1,0 +1,168 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const {
+  readSqliteFirstValue,
+  readSqliteJsonRows,
+  resetSqliteReaderWarningsForTests,
+} = require("../src/lib/sqlite-reader");
+
+function tempDbPath() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-sqlite-reader-"));
+  const dbPath = path.join(dir, "state.db");
+  fs.writeFileSync(dbPath, "", "utf8");
+  return dbPath;
+}
+
+test("readSqliteJsonRows uses sqlite3 CLI first", () => {
+  const dbPath = tempDbPath();
+  const rows = readSqliteJsonRows(dbPath, "SELECT 1 AS n", {
+    execFileSync(cmd, args) {
+      assert.equal(cmd, "sqlite3");
+      assert.deepEqual(args, ["-json", dbPath, "SELECT 1 AS n"]);
+      return JSON.stringify([{ n: 1 }]);
+    },
+    requireFn() {
+      throw new Error("node:sqlite should not be used");
+    },
+  });
+
+  assert.deepEqual(rows, [{ n: 1 }]);
+});
+
+test("readSqliteJsonRows falls back to node:sqlite when sqlite3 CLI fails", () => {
+  const dbPath = tempDbPath();
+  let closed = false;
+  const rows = readSqliteJsonRows(dbPath, "SELECT 2 AS n", {
+    execFileSync() {
+      throw new Error("spawn sqlite3 ENOENT");
+    },
+    requireFn(name) {
+      assert.equal(name, "node:sqlite");
+      return {
+        DatabaseSync: class FakeDatabaseSync {
+          constructor(actualDbPath, options) {
+            assert.equal(actualDbPath, dbPath);
+            assert.deepEqual(options, { readOnly: true });
+          }
+
+          prepare(sql) {
+            assert.equal(sql, "SELECT 2 AS n");
+            return {
+              all() {
+                return [{ n: 2 }];
+              },
+            };
+          }
+
+          close() {
+            closed = true;
+          }
+        },
+      };
+    },
+  });
+
+  assert.deepEqual(rows, [{ n: 2 }]);
+  assert.equal(closed, true);
+});
+
+test("readSqliteJsonRows warns once when no sqlite reader works", () => {
+  resetSqliteReaderWarningsForTests();
+  const dbPath = tempDbPath();
+  let stderr = "";
+  const options = {
+    label: "OpenCode",
+    env: {},
+    stderr: { write(chunk) { stderr += chunk; } },
+    execFileSync() {
+      throw new Error("spawn sqlite3 ENOENT");
+    },
+    requireFn() {
+      throw new Error("No such built-in module: node:sqlite");
+    },
+  };
+
+  assert.deepEqual(readSqliteJsonRows(dbPath, "SELECT 1", options), []);
+  assert.deepEqual(readSqliteJsonRows(dbPath, "SELECT 1", options), []);
+
+  const matches = stderr.match(/Cannot read OpenCode SQLite database/g) || [];
+  assert.equal(matches.length, 1);
+  assert.match(stderr, /Install sqlite3 CLI/);
+  assert.match(stderr, /Node\.js 22\+/);
+});
+
+test("readSqliteJsonRows includes low-level errors in debug mode", () => {
+  resetSqliteReaderWarningsForTests();
+  const dbPath = tempDbPath();
+  let stderr = "";
+
+  readSqliteJsonRows(dbPath, "SELECT 1", {
+    label: "Kiro CLI",
+    env: { TOKENTRACKER_DEBUG: "1" },
+    stderr: { write(chunk) { stderr += chunk; } },
+    execFileSync() {
+      throw new Error("spawn sqlite3 ENOENT");
+    },
+    requireFn() {
+      throw new Error("No such built-in module: node:sqlite");
+    },
+  });
+
+  assert.match(stderr, /sqlite3 CLI failed: spawn sqlite3 ENOENT/);
+  assert.match(stderr, /node:sqlite failed: No such built-in module: node:sqlite/);
+});
+
+test("readSqliteJsonRows stays quiet for query/schema failures", () => {
+  resetSqliteReaderWarningsForTests();
+  const dbPath = tempDbPath();
+  let stderr = "";
+
+  const rows = readSqliteJsonRows(dbPath, "SELECT value FROM MissingTable", {
+    label: "Cursor",
+    env: { TOKENTRACKER_DEBUG: "1" },
+    stderr: { write(chunk) { stderr += chunk; } },
+    execFileSync() {
+      throw new Error("Parse error: no such table: MissingTable");
+    },
+    requireFn() {
+      throw new Error("no such table: MissingTable");
+    },
+  });
+
+  assert.deepEqual(rows, []);
+  assert.equal(stderr, "");
+});
+
+test("readSqliteFirstValue trims string values and closes node:sqlite DB", () => {
+  const dbPath = tempDbPath();
+  let closed = false;
+  const value = readSqliteFirstValue(dbPath, "SELECT value FROM ItemTable", "value", {
+    execFileSync() {
+      throw new Error("spawn sqlite3 ENOENT");
+    },
+    requireFn() {
+      return {
+        DatabaseSync: class FakeDatabaseSync {
+          prepare() {
+            return {
+              all() {
+                return [{ value: " token\n" }];
+              },
+            };
+          }
+
+          close() {
+            closed = true;
+          }
+        },
+      };
+    },
+  });
+
+  assert.equal(value, "token");
+  assert.equal(closed, true);
+});


### PR DESCRIPTION
OpenCode and several other provider parsers still depended on the external sqlite3 binary, so usage sync could silently return no records on machines that only had Node available. This centralizes SQLite reads in a shared helper that tries sqlite3 -json first and falls back to node:sqlite when the CLI is missing.

Reuse the helper for Cursor token extraction plus OpenCode, Kiro, Hermes, Kiro CLI, Zed, and Goose database reads. Keep provider-specific timeouts and buffers, preserve snapshot handling for active DBs, and emit a deduplicated actionable warning only when both SQLite readers are unavailable.

Add focused tests for the helper, Cursor token extraction, OpenCode node:sqlite fallback, and Windows-safe path/snapshot behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database access reliability with built-in fallback mechanisms for session and token retrieval.

* **Changes**
  * Device token management no longer automatically revokes existing tokens when new ones are issued; explicit rotation must be handled separately.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->