### PR TITLE
feat: add Antigravity as Skills Manager sync target

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ That's it. First run installs hooks, syncs your data, and opens the dashboard at
 - 📊 A local dashboard at `localhost:7680` with usage trends, model breakdown, cost analysis
 - 🔌 Auto-detected hooks for every supported AI tool you have installed
 - 🏠 100% local — no account, no API keys, no network calls (except optional leaderboard)
-- 🧩 *Optional:* a Skills tab that browses 250+ public skills and syncs them across Claude · Codex · Grok · Gemini · OpenCode · Hermes
+- 🧩 *Optional:* a Skills tab that browses 250+ public skills and syncs them across Claude · Codex · Grok · Antigravity · Gemini · OpenCode · Hermes
 
 > **Want a native macOS menu bar app?** [Download `TokenTrackerBar.dmg`](https://github.com/mm7894215/TokenTracker/releases/latest) → drag to Applications. Includes desktop widgets, menu bar status icon, and the same dashboard in a WKWebView.
 
@@ -91,7 +91,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 - 📈 **Real-time rate limit tracking** — Claude / Codex / Cursor / Gemini / Kiro / Copilot / Antigravity quota windows with reset countdowns
 - 💰 **Cost engine** — 2,200+ models priced via [LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) (auto-refreshed daily) + curated overrides for niche tools (Kiro, Cursor Composer, Kimi, CodeBuddy hy3); 24h disk cache + bundled offline snapshot mean accurate USD without an internet connection. Models without published vendor pricing (e.g. Tencent hy3-preview) are tracked by tokens but show $0 cost until the vendor publishes a rate.
 - 🌐 **Optional leaderboard** — Compare with developers worldwide; drag-to-reorder columns to focus on the providers you care about (opt-in, sign in to participate)
-- 🧩 **Optional Skills tab** — browse 250+ public skills from `anthropics/skills`, `ComposioHQ/awesome-claude-skills`, `skills.sh` and any GitHub repo you add; sync them across Claude / Codex / Grok / Gemini / OpenCode / Hermes with named targets and one-click Undo
+- 🧩 **Optional Skills tab** — browse 250+ public skills from `anthropics/skills`, `ComposioHQ/awesome-claude-skills`, `skills.sh` and any GitHub repo you add; sync them across Claude / Codex / Grok / Antigravity / Gemini / OpenCode / Hermes with named targets and one-click Undo
 - 🔒 **Privacy-first** — Only token counts and timestamps. Never prompts, responses, or file contents.
 
 ---
@@ -134,7 +134,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 <tr>
 <td colspan="2">
 
-**Skills Manager** — browse 250+ public skills from GitHub & `skills.sh`, install once, sync to Claude / Codex / Grok / Gemini / OpenCode / Hermes. Per-target toggles, one-click Undo, no manual file copying.
+**Skills Manager** — browse 250+ public skills from GitHub & `skills.sh`, install once, sync to Claude / Codex / Grok / Antigravity / Gemini / OpenCode / Hermes. Per-target toggles, one-click Undo, no manual file copying.
 
 <img src="https://raw.githubusercontent.com/mm7894215/tokentracker/main/docs/screenshots/skills.png" alt="Skills Manager" />
 
@@ -241,6 +241,7 @@ Most users never need this — defaults are sensible. For advanced setups:
 | `GEMINI_HOME` | Override Gemini CLI directory | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | Override Grok Build directory for the Grok integration and Skills Manager | `~/.grok` |
 | `GROK_HOME` | Legacy Grok Build directory override, used when `TOKENTRACKER_GROK_HOME` is unset | `~/.grok` |
+| `TOKENTRACKER_ANTIGRAVITY_HOME` | Force a single Antigravity Skills directory (auto-detects `~/.gemini/antigravity` + `~/.gemini/antigravity-ide` otherwise) | auto |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,7 +46,7 @@ npx tokentracker-cli
 - 📊 本地 Dashboard（`localhost:7680`）—— 用量趋势、模型明细、成本分析
 - 🔌 自动识别并挂接你电脑上所有已安装的 AI 工具
 - 🏠 100% 本地运行 —— 无账号、无 API Key、无网络请求（排行榜是可选的）
-- 🧩 *可选：* Skills 面板——浏览 250+ 公开 skill，并在 Claude · Codex · Grok · Gemini · OpenCode · Hermes 之间同步
+- 🧩 *可选：* Skills 面板——浏览 250+ 公开 skill，并在 Claude · Codex · Grok · Antigravity · Gemini · OpenCode · Hermes 之间同步
 
 > **想要原生 macOS 菜单栏 App？** [下载 `TokenTrackerBar.dmg`](https://github.com/mm7894215/TokenTracker/releases/latest) → 拖入「应用程序」即可。包含桌面小组件、菜单栏状态图标，以及同一套 Dashboard（跑在 WKWebView 里）。
 
@@ -91,7 +91,7 @@ brew install mm7894215/tokentracker/tokentracker
 - 📈 **实时限额追踪** —— Claude / Codex / Cursor / Gemini / Kiro / Copilot / Antigravity 的配额窗口与重置倒计时
 - 💰 **成本引擎** —— 内置 70+ 模型定价表，精确到 USD
 - 🌐 **可选排行榜** —— 与全球开发者对比；列可拖拽排序，聚焦你关心的 provider（需登录参与）
-- 🧩 **可选 Skills 面板** —— 浏览 250+ 公开 skill（来自 `anthropics/skills`、`ComposioHQ/awesome-claude-skills`、`skills.sh` 以及你自己添加的任何 GitHub 仓库），在 Claude / Codex / Grok / Gemini / OpenCode / Hermes 之间同步，目标 Agent 文字可见、可单独管理、一键撤销
+- 🧩 **可选 Skills 面板** —— 浏览 250+ 公开 skill（来自 `anthropics/skills`、`ComposioHQ/awesome-claude-skills`、`skills.sh` 以及你自己添加的任何 GitHub 仓库），在 Claude / Codex / Grok / Antigravity / Gemini / OpenCode / Hermes 之间同步，目标 Agent 文字可见、可单独管理、一键撤销
 - 🔒 **隐私优先** —— 只记录 token 数量与时间戳。**绝不**收集 prompt、回复、文件内容
 
 ---
@@ -134,7 +134,7 @@ brew install mm7894215/tokentracker/tokentracker
 <tr>
 <td colspan="2">
 
-**Skills 管理器** —— 浏览 250+ 公开 skill（GitHub 仓库 & `skills.sh`），一次安装，同步到 Claude / Codex / Grok / Gemini / OpenCode / Hermes。每个 Agent 单独开关，一键撤销，再也不用手动复制文件夹。
+**Skills 管理器** —— 浏览 250+ 公开 skill（GitHub 仓库 & `skills.sh`），一次安装，同步到 Claude / Codex / Grok / Antigravity / Gemini / OpenCode / Hermes。每个 Agent 单独开关，一键撤销，再也不用手动复制文件夹。
 
 <img src="https://raw.githubusercontent.com/mm7894215/tokentracker/main/docs/screenshots/skills.png" alt="Skills Manager" />
 
@@ -241,6 +241,7 @@ flowchart LR
 | `GEMINI_HOME` | 覆盖 Gemini CLI 目录 | `~/.gemini` |
 | `TOKENTRACKER_GROK_HOME` | 覆盖 Grok Build 目录，供 Grok 集成和 Skills Manager 使用 | `~/.grok` |
 | `GROK_HOME` | 旧版 Grok Build 目录覆盖变量；未设置 `TOKENTRACKER_GROK_HOME` 时使用 | `~/.grok` |
+| `TOKENTRACKER_ANTIGRAVITY_HOME` | 强制指定 Antigravity Skills 目录（不设时自动检测 `~/.gemini/antigravity` 和 `~/.gemini/antigravity-ide`，同步会同时写入两者） | 自动 |
 
 ---
 

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -29,7 +29,7 @@ targets:
         PRODUCT_NAME: TokenTrackerBar
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.22.3"
+        MARKETING_VERSION: "0.23.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -81,7 +81,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.22.3"
+        MARKETING_VERSION: "0.23.0"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/dashboard/src/pages/SkillsPage.jsx
+++ b/dashboard/src/pages/SkillsPage.jsx
@@ -39,6 +39,7 @@ const TARGET_CHIP_ICON_CLASSES = {
   claude: "text-orange-500 dark:text-orange-300",
   codex: "text-emerald-600 dark:text-emerald-300",
   grok: "text-zinc-700 dark:text-zinc-200",
+  antigravity: "text-violet-600 dark:text-violet-300",
   gemini: "text-sky-600 dark:text-sky-300",
   opencode: "text-amber-600 dark:text-amber-300",
   hermes: "text-indigo-500 dark:text-indigo-300",

--- a/dashboard/src/pages/SkillsPage.test.jsx
+++ b/dashboard/src/pages/SkillsPage.test.jsx
@@ -37,6 +37,7 @@ beforeEach(() => {
     targets: [
       { id: "claude", label: "Claude" },
       { id: "grok", label: "Grok" },
+      { id: "antigravity", label: "Antigravity" },
     ],
     skills: [
       {
@@ -44,7 +45,7 @@ beforeEach(() => {
         name: "Sample Skill",
         directory: "sample-skill",
         description: "Keeps the installed list visible.",
-        targets: ["claude", "grok"],
+        targets: ["claude", "grok", "antigravity"],
         managed: true,
       },
     ],
@@ -69,6 +70,7 @@ describe("SkillsPage", () => {
     expect(await screen.findByText("Sample Skill")).toBeInTheDocument();
     expect(screen.getByText("Keeps the installed list visible.")).toBeInTheDocument();
     expect(screen.getByText("Grok")).toBeInTheDocument();
+    expect(screen.getByText("Antigravity")).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.queryByText(copy("skills.empty.my"))).not.toBeInTheDocument();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.22.3",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tokentracker-cli",
-      "version": "0.22.3",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@mongodb-js/zstd": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.22.3",
+  "version": "0.23.0",
   "description": "Token usage tracker for AI agent CLIs (Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, OpenClaw, Every Code, Hermes, GitHub Copilot, Kimi Code, CodeBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose)",
   "main": "src/cli.js",
   "bin": {

--- a/src/lib/antigravity-paths.js
+++ b/src/lib/antigravity-paths.js
@@ -1,0 +1,48 @@
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const MAIN_APP_SUBDIR = "antigravity";
+const IDE_SUBDIR = "antigravity-ide";
+
+function geminiHome(env) {
+  return path.join(env.HOME || env.USERPROFILE || os.homedir(), ".gemini");
+}
+
+function trimmed(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function existsDir(dirPath) {
+  try {
+    return fs.statSync(dirPath).isDirectory();
+  } catch (_e) {
+    return false;
+  }
+}
+
+function resolveAntigravitySkillDirs(env = process.env) {
+  const override = trimmed(env.TOKENTRACKER_ANTIGRAVITY_HOME);
+  if (override) return [path.join(override, "skills")];
+
+  const home = geminiHome(env);
+  const mainSkills = path.join(home, MAIN_APP_SUBDIR, "skills");
+  const ideSkills = path.join(home, IDE_SUBDIR, "skills");
+  const mainParent = path.join(home, MAIN_APP_SUBDIR);
+  const ideParent = path.join(home, IDE_SUBDIR);
+
+  const dirs = [];
+  if (existsDir(mainParent)) dirs.push(mainSkills);
+  if (existsDir(ideParent)) dirs.push(ideSkills);
+
+  // Neither Antigravity install present: fall back to the main-app path so
+  // targetList still surfaces a stable path string and the user can install
+  // skills now and run Antigravity later. The empty parent will be created on
+  // demand by ensureDir; cleanup happens naturally via uninstallSkill.
+  if (dirs.length > 0) return dirs;
+  return [mainSkills];
+}
+
+module.exports = {
+  resolveAntigravitySkillDirs,
+};

--- a/src/lib/skills-manager.js
+++ b/src/lib/skills-manager.js
@@ -2,6 +2,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 const { resolveGrokHome } = require("./grok-hook");
+const { resolveAntigravitySkillDirs } = require("./antigravity-paths");
 
 const DEFAULT_REPOS = [
   { owner: "anthropics", name: "skills", branch: "main", enabled: true },
@@ -14,11 +15,27 @@ const TARGETS = {
   claude: { id: "claude", label: "Claude", dir: () => path.join(os.homedir(), ".claude", "skills") },
   codex: { id: "codex", label: "Codex", dir: () => path.join(os.homedir(), ".codex", "skills") },
   grok: { id: "grok", label: "Grok", dir: () => path.join(resolveGrokHome(process.env), "skills") },
+  antigravity: { id: "antigravity", label: "Antigravity", dirs: () => resolveAntigravitySkillDirs(process.env) },
   gemini: { id: "gemini", label: "Gemini", dir: () => path.join(os.homedir(), ".gemini", "skills") },
   opencode: { id: "opencode", label: "OpenCode", dir: () => path.join(os.homedir(), ".config", "opencode", "skills") },
   hermes: { id: "hermes", label: "Hermes", dir: () => path.join(os.homedir(), ".hermes", "skills") },
   agents: { id: "agents", label: "Agents", visible: false, dir: () => path.join(os.homedir(), ".agents", "skills") },
 };
+
+// Dual contract: a target exposes either dir() → string (single path) or
+// dirs() → string[] (parallel-write to multiple paths, e.g. Antigravity which
+// has separate user-skills dirs for the main app and the IDE). Consumers must
+// route through these helpers so the single-path targets stay zero-overhead.
+function targetDirs(target) {
+  if (typeof target.dirs === "function") return target.dirs();
+  return [target.dir()];
+}
+
+// Used for surfacing one path in UI/local-api responses. For multi-dir targets
+// this is the canonical "first" entry by convention (main app before IDE).
+function targetPrimaryDir(target) {
+  return targetDirs(target)[0];
+}
 
 const FETCH_TIMEOUT_MS = 20_000;
 const DISCOVER_CONCURRENCY = 4;
@@ -130,7 +147,7 @@ function targetList() {
     .map((target) => ({
       id: target.id,
       label: target.label,
-      path: target.dir(),
+      path: targetPrimaryDir(target),
     }));
 }
 
@@ -342,27 +359,35 @@ function syncSkillToTarget(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) throw new Error(`Unsupported target: ${targetId}`);
   const source = path.join(ssotDir(), directory);
-  const dest = path.join(target.dir(), directory);
   if (!fs.existsSync(source)) throw new Error(`Managed skill not found: ${directory}`);
-  ensureDir(path.dirname(dest));
-  removePath(dest);
-  try {
-    fs.symlinkSync(source, dest, "dir");
-  } catch (_e) {
-    copyDir(source, dest);
+  for (const baseDir of targetDirs(target)) {
+    const dest = path.join(baseDir, directory);
+    ensureDir(path.dirname(dest));
+    removePath(dest);
+    try {
+      fs.symlinkSync(source, dest, "dir");
+    } catch (_e) {
+      copyDir(source, dest);
+    }
   }
 }
 
 function removeSkillFromTarget(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) return;
-  removePath(path.join(target.dir(), directory));
+  for (const baseDir of targetDirs(target)) {
+    removePath(path.join(baseDir, directory));
+  }
 }
 
 function scanTargetSkill(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) return false;
-  return fs.existsSync(path.join(target.dir(), directory)) || isSymlink(path.join(target.dir(), directory));
+  for (const baseDir of targetDirs(target)) {
+    const candidate = path.join(baseDir, directory);
+    if (fs.existsSync(candidate) || isSymlink(candidate)) return true;
+  }
+  return false;
 }
 
 function listInstalledSkills() {
@@ -378,41 +403,42 @@ function listInstalledSkills() {
   const managedDirs = new Set(managed.map((skill) => skill.directory.toLowerCase()));
   const unmanaged = new Map();
   for (const target of Object.values(TARGETS)) {
-    const dir = target.dir();
-    let entries = [];
-    try {
-      entries = fs.readdirSync(dir, { withFileTypes: true });
-    } catch (_e) {
-      continue;
-    }
-    for (const entry of entries) {
-      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-      const directory = entry.name;
-      if (!directory || directory.startsWith(".") || managedDirs.has(directory.toLowerCase())) continue;
-      const skillPath = path.join(dir, directory, "SKILL.md");
-      if (!fs.existsSync(skillPath)) continue;
-      const metadata = readSkillMetadata(fs.readFileSync(skillPath, "utf8"), directory);
-      const key = directory.toLowerCase();
-      if (!unmanaged.has(key)) {
-        unmanaged.set(key, {
-          id: `local:${directory}`,
-          key: `local:${directory}`,
-          name: metadata.name,
-          description: metadata.description,
-          directory,
-          readmeUrl: null,
-          repoOwner: null,
-          repoName: null,
-          repoBranch: null,
-          installedAt: null,
-          managed: false,
-          targets: [],
-          targetPaths: {},
-        });
+    for (const dir of targetDirs(target)) {
+      let entries = [];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch (_e) {
+        continue;
       }
-      const skill = unmanaged.get(key);
-      skill.targets.push(target.id);
-      skill.targetPaths[target.id] = path.join(dir, directory);
+      for (const entry of entries) {
+        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+        const directory = entry.name;
+        if (!directory || directory.startsWith(".") || managedDirs.has(directory.toLowerCase())) continue;
+        const skillPath = path.join(dir, directory, "SKILL.md");
+        if (!fs.existsSync(skillPath)) continue;
+        const metadata = readSkillMetadata(fs.readFileSync(skillPath, "utf8"), directory);
+        const key = directory.toLowerCase();
+        if (!unmanaged.has(key)) {
+          unmanaged.set(key, {
+            id: `local:${directory}`,
+            key: `local:${directory}`,
+            name: metadata.name,
+            description: metadata.description,
+            directory,
+            readmeUrl: null,
+            repoOwner: null,
+            repoName: null,
+            repoBranch: null,
+            installedAt: null,
+            managed: false,
+            targets: [],
+            targetPaths: {},
+          });
+        }
+        const skill = unmanaged.get(key);
+        if (!skill.targets.includes(target.id)) skill.targets.push(target.id);
+        if (!skill.targetPaths[target.id]) skill.targetPaths[target.id] = path.join(dir, directory);
+      }
     }
   }
 
@@ -596,10 +622,12 @@ function findLocalSkillSource(directory) {
   const installName = sanitizePathSegment(directory);
   if (!installName) return null;
   for (const target of Object.values(TARGETS)) {
-    const skillPath = path.join(target.dir(), installName);
-    const docPath = path.join(skillPath, "SKILL.md");
-    if (fs.existsSync(docPath)) {
-      return { path: skillPath, targetId: target.id };
+    for (const baseDir of targetDirs(target)) {
+      const skillPath = path.join(baseDir, installName);
+      const docPath = path.join(skillPath, "SKILL.md");
+      if (fs.existsSync(docPath)) {
+        return { path: skillPath, targetId: target.id };
+      }
     }
   }
   return null;

--- a/test/antigravity-paths.test.js
+++ b/test/antigravity-paths.test.js
@@ -1,0 +1,82 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { afterEach, beforeEach, describe, it } = require("node:test");
+
+const { resolveAntigravitySkillDirs } = require("../src/lib/antigravity-paths");
+
+function makeSandbox() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "tt-antigravity-paths-"));
+}
+
+function clean(dir) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch (_e) {}
+}
+
+describe("resolveAntigravitySkillDirs", () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = makeSandbox();
+  });
+
+  afterEach(() => {
+    clean(sandbox);
+  });
+
+  it("returns override-only path when TOKENTRACKER_ANTIGRAVITY_HOME is set", () => {
+    const override = path.join(sandbox, "custom-home");
+    const dirs = resolveAntigravitySkillDirs({
+      HOME: sandbox,
+      TOKENTRACKER_ANTIGRAVITY_HOME: override,
+    });
+    assert.deepEqual(dirs, [path.join(override, "skills")]);
+  });
+
+  it("ignores override when value is empty/whitespace", () => {
+    fs.mkdirSync(path.join(sandbox, ".gemini", "antigravity"), { recursive: true });
+    const dirs = resolveAntigravitySkillDirs({
+      HOME: sandbox,
+      TOKENTRACKER_ANTIGRAVITY_HOME: "   ",
+    });
+    assert.deepEqual(dirs, [path.join(sandbox, ".gemini", "antigravity", "skills")]);
+  });
+
+  it("returns only main app dir when only ~/.gemini/antigravity exists", () => {
+    fs.mkdirSync(path.join(sandbox, ".gemini", "antigravity"), { recursive: true });
+    const dirs = resolveAntigravitySkillDirs({ HOME: sandbox });
+    assert.deepEqual(dirs, [path.join(sandbox, ".gemini", "antigravity", "skills")]);
+  });
+
+  it("returns only IDE dir when only ~/.gemini/antigravity-ide exists", () => {
+    fs.mkdirSync(path.join(sandbox, ".gemini", "antigravity-ide"), { recursive: true });
+    const dirs = resolveAntigravitySkillDirs({ HOME: sandbox });
+    assert.deepEqual(dirs, [path.join(sandbox, ".gemini", "antigravity-ide", "skills")]);
+  });
+
+  it("returns both dirs when both main app and IDE are present", () => {
+    fs.mkdirSync(path.join(sandbox, ".gemini", "antigravity"), { recursive: true });
+    fs.mkdirSync(path.join(sandbox, ".gemini", "antigravity-ide"), { recursive: true });
+    const dirs = resolveAntigravitySkillDirs({ HOME: sandbox });
+    assert.deepEqual(dirs, [
+      path.join(sandbox, ".gemini", "antigravity", "skills"),
+      path.join(sandbox, ".gemini", "antigravity-ide", "skills"),
+    ]);
+  });
+
+  it("falls back to main app dir when neither parent exists", () => {
+    const dirs = resolveAntigravitySkillDirs({ HOME: sandbox });
+    assert.deepEqual(dirs, [path.join(sandbox, ".gemini", "antigravity", "skills")]);
+  });
+
+  it("uses USERPROFILE when HOME is missing (Windows-style env)", () => {
+    fs.mkdirSync(path.join(sandbox, ".gemini", "antigravity"), { recursive: true });
+    const dirs = resolveAntigravitySkillDirs({ USERPROFILE: sandbox });
+    assert.deepEqual(dirs, [path.join(sandbox, ".gemini", "antigravity", "skills")]);
+  });
+});

--- a/test/local-api-skills.test.js
+++ b/test/local-api-skills.test.js
@@ -10,6 +10,7 @@ process.env.HOME = sandboxHome;
 process.env.USERPROFILE = sandboxHome;
 process.env.TOKENTRACKER_GROK_HOME = path.join(sandboxHome, ".grok");
 delete process.env.GROK_HOME;
+delete process.env.TOKENTRACKER_ANTIGRAVITY_HOME;
 
 const { createLocalApiHandler } = require("../src/lib/local-api");
 
@@ -130,6 +131,10 @@ describe("/functions/tokentracker-skills auth + input", () => {
     assert.ok(Array.isArray(body.targets));
     assert.ok(Array.isArray(body.skills));
     assert.ok(body.targets.some((target) => target.id === "grok" && target.label === "Grok"));
+    assert.ok(
+      body.targets.some((target) => target.id === "antigravity" && target.label === "Antigravity"),
+      "Antigravity must appear in installed-skills targets",
+    );
   });
 
   it("surfaces addRepo validation error via 500 with message", async () => {

--- a/test/skills-manager.test.js
+++ b/test/skills-manager.test.js
@@ -12,6 +12,7 @@ process.env.HOME = sandboxHome;
 process.env.USERPROFILE = sandboxHome;
 process.env.TOKENTRACKER_GROK_HOME = path.join(sandboxHome, ".grok");
 delete process.env.GROK_HOME;
+delete process.env.TOKENTRACKER_ANTIGRAVITY_HOME;
 
 const skills = require("../src/lib/skills-manager");
 
@@ -112,5 +113,75 @@ describe("skills-manager importLocalSkill re-sync", () => {
 
     // cleanup: uninstall managed skill
     skills.uninstallSkill(third.id);
+  });
+});
+
+describe("skills-manager antigravity target", () => {
+  const mainSkillsDir = path.join(sandboxHome, ".gemini", "antigravity", "skills");
+  const ideSkillsDir = path.join(sandboxHome, ".gemini", "antigravity-ide", "skills");
+  const skillName = "ag-skill";
+
+  before(() => {
+    // Create both Antigravity main-app and IDE parent dirs so dirs() returns both
+    fs.mkdirSync(path.join(sandboxHome, ".gemini", "antigravity"), { recursive: true });
+    fs.mkdirSync(path.join(sandboxHome, ".gemini", "antigravity-ide"), { recursive: true });
+    // Seed source skill under the main-app dir so findLocalSkillSource picks it up
+    writeLocalSkill(".gemini/antigravity/skills", skillName);
+  });
+
+  it("targetList includes antigravity with the main-app dir as primary path", () => {
+    const target = skills.targetList().find((t) => t.id === "antigravity");
+    assert.ok(target);
+    assert.equal(target.label, "Antigravity");
+    assert.equal(target.path, mainSkillsDir);
+  });
+
+  it("writes to both main-app and IDE dirs in parallel on install + removes both on uninstall", () => {
+    const installed = skills.importLocalSkill(skillName, ["antigravity"]);
+    assert.equal(installed.managed, true);
+    assert.deepEqual(installed.targets, ["antigravity"]);
+    // Both directories should be populated (re-sync writes through dirs() array)
+    assert.ok(fs.existsSync(path.join(mainSkillsDir, skillName, "SKILL.md")));
+    assert.ok(fs.existsSync(path.join(ideSkillsDir, skillName, "SKILL.md")));
+
+    // Drop antigravity from target set — both dirs should be cleaned
+    const cleared = skills.setSkillTargets(installed.id, []);
+    assert.deepEqual(cleared.targets, []);
+    assert.ok(!fs.existsSync(path.join(mainSkillsDir, skillName)));
+    assert.ok(!fs.existsSync(path.join(ideSkillsDir, skillName)));
+
+    skills.uninstallSkill(installed.id);
+  });
+
+  it("TOKENTRACKER_ANTIGRAVITY_HOME forces a single override path", () => {
+    const overrideHome = path.join(sandboxHome, "custom-ag");
+    const overrideSkill = "ag-skill-override";
+    const prev = process.env.TOKENTRACKER_ANTIGRAVITY_HOME;
+    process.env.TOKENTRACKER_ANTIGRAVITY_HOME = overrideHome;
+    try {
+      // targetList sees the override
+      const target = skills.targetList().find((t) => t.id === "antigravity");
+      assert.equal(target.path, path.join(overrideHome, "skills"));
+
+      // Seed source under the override path so findLocalSkillSource locates it
+      const seedDir = path.join(overrideHome, "skills", overrideSkill);
+      fs.mkdirSync(seedDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(seedDir, "SKILL.md"),
+        "---\nname: Override Skill\ndescription: forced override\n---\n",
+      );
+
+      const installed = skills.importLocalSkill(overrideSkill, ["antigravity"]);
+      assert.deepEqual(installed.targets, ["antigravity"]);
+      // override path written
+      assert.ok(fs.existsSync(path.join(overrideHome, "skills", overrideSkill, "SKILL.md")));
+      // default-discovery paths must NOT receive a copy when override is set
+      assert.ok(!fs.existsSync(path.join(mainSkillsDir, overrideSkill)));
+      assert.ok(!fs.existsSync(path.join(ideSkillsDir, overrideSkill)));
+      skills.uninstallSkill(installed.id);
+    } finally {
+      if (prev === undefined) delete process.env.TOKENTRACKER_ANTIGRAVITY_HOME;
+      else process.env.TOKENTRACKER_ANTIGRAVITY_HOME = prev;
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds Google **Antigravity** as a Skills Manager sync target, alongside the existing six (Claude / Codex / Grok / Gemini / OpenCode / Hermes). Antigravity ships as two distinct products that read separate skill dirs, so this PR introduces a parallel-write contract that mirrors SKILL.md into both:

- **Antigravity main app** (Electron, `com.google.antigravity` v2.0.1) → `~/.gemini/antigravity/skills/`
- **Antigravity IDE** (VSCode fork v1.107.0) → `~/.gemini/antigravity-ide/skills/`

Verified end-to-end on a real install by hitting Antigravity's own `/exa.language_server_pb.LanguageServerService/GetAllSkills` API — both products report the synced skill after install and drop it after uninstall.

## Implementation

- **Dual-contract TARGETS**: existing six targets keep their `dir() → string` contract; Antigravity uses `dirs() → string[]`. New `targetDirs()` / `targetPrimaryDir()` helpers route consumers transparently — single-dir targets stay zero-overhead.
- **`src/lib/antigravity-paths.js`** (new): `resolveAntigravitySkillDirs(env)` auto-detects which Antigravity install is present (only writes to dirs whose parent exists) and exposes `TOKENTRACKER_ANTIGRAVITY_HOME` as a force-single-path escape hatch for non-standard setups.
- **5 consumer functions** refactored to iterate every `baseDir`: `syncSkillToTarget`, `removeSkillFromTarget`, `scanTargetSkill`, `listInstalledSkills`, `findLocalSkillSource`.
- **Dashboard**: SkillsPage `TARGET_CHIP_ICON_CLASSES` adds antigravity entry; `ProviderIcon` already supported `ANTIGRAVITY` (multi-color brand SVG).

## Test coverage

| Suite | Cases |
|---|---|
| `test/antigravity-paths.test.js` (new) | 7 — env override, IDE-only / main-only / both-installed / neither-installed / USERPROFILE fallback |
| `test/skills-manager.test.js` | +3 — targetList primary path, parallel write to both dirs + uninstall, env override forces single |
| `test/local-api-skills.test.js` | +1 — antigravity appears in installed-skills targets |
| `dashboard/src/pages/SkillsPage.test.jsx` | +1 — Antigravity chip renders |

Backend `npm test` 30/30 ✓, dashboard test 1/1 ✓, `validate:guardrails` clean.

## Visual verification (light + dark modes)

End-to-end verified in a real browser (agent-browser via CDP):
- DOM chip counts match filesystem state: Claude 46 / Codex 18 / Grok 7 / **Antigravity 8** / Gemini 3 / OpenCode 2 / Hermes 3
- Light mode: best-of-n shows mono Grok chip; agent-browser shows Claude + Codex + Antigravity row
- Dark mode: same rows render with correct contrast (zinc-200 fallback for mono icons, brand color preserved for multi-color SVGs)

## Behaviour summary

- **Both installs detected**: install/uninstall mirrors to both `~/.gemini/antigravity/skills/` and `~/.gemini/antigravity-ide/skills/` (verified live via GetAllSkills API)
- **Only main app or only IDE installed**: writes only to the present one
- **Neither installed**: falls back to the main-app path so the UI surfaces a stable path and skills can pre-stage before the user installs Antigravity; ensureDir creates the parent lazily and uninstall cleans up
- **`TOKENTRACKER_ANTIGRAVITY_HOME=/path`**: forces a single override path, no auto-detection

## Test plan

- [ ] `npm test` (full backend suite)
- [ ] `npm --prefix dashboard run test`
- [ ] `npm run validate:guardrails`
- [ ] Manual: open Skills page, confirm Antigravity chip appears, sync a skill to Antigravity, check it's loaded in real Antigravity install
- [ ] Manual: unset `TOKENTRACKER_ANTIGRAVITY_HOME`, confirm both dirs get the skill; set it, confirm only override path gets the skill

## Version bump

`0.22.3 → 0.23.0` (MINOR, per project convention for feature additions). `package.json`, `package-lock.json`, and both `MARKETING_VERSION` entries in `TokenTrackerBar/project.yml` are synchronized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Antigravity as a supported target in the Skills Manager for skill synchronization across multiple providers.
  * Introduced `TOKENTRACKER_ANTIGRAVITY_HOME` environment variable for custom Antigravity skills directory configuration.

* **Documentation**
  * Updated README documentation to describe Antigravity support and configuration options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/97?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->