### PR TITLE
Show provider icons in leaderboard columns

### DIFF
--- a/dashboard/src/components/LeaderboardProviderColumnHeader.jsx
+++ b/dashboard/src/components/LeaderboardProviderColumnHeader.jsx
@@ -6,6 +6,7 @@ import React from "react";
  */
 const INVERT_IN_DARK = new Set([
   "/brand-logos/cursor.svg",
+  "/brand-logos/kimi.svg",
   "/brand-logos/kiro.svg",
   "/brand-logos/copilot.svg",
 ]);

--- a/dashboard/src/components/LeaderboardProviderColumnHeader.test.jsx
+++ b/dashboard/src/components/LeaderboardProviderColumnHeader.test.jsx
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { LeaderboardProviderColumnHeader } from "./LeaderboardProviderColumnHeader.jsx";
+
+describe("LeaderboardProviderColumnHeader", () => {
+  it("inverts the monochrome Kimi logo in dark mode", () => {
+    const { container } = render(
+      <LeaderboardProviderColumnHeader iconSrc="/brand-logos/kimi.svg" label="Kimi" />,
+    );
+
+    const img = container.querySelector('img[src="/brand-logos/kimi.svg"]');
+    expect(img).toHaveClass("dark:invert");
+  });
+});

--- a/dashboard/src/lib/__tests__/leaderboard-columns.test.js
+++ b/dashboard/src/lib/__tests__/leaderboard-columns.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { LEADERBOARD_TOKEN_COLUMNS } from "../leaderboard-columns.js";
+
+describe("LEADERBOARD_TOKEN_COLUMNS", () => {
+  it("uses the bundled Hermes brand logo for the Hermes leaderboard column", () => {
+    const hermesColumn = LEADERBOARD_TOKEN_COLUMNS.find((col) => col.key === "hermes_tokens");
+
+    expect(hermesColumn?.icon).toBe("/brand-logos/hermes.svg");
+  });
+});

--- a/dashboard/src/lib/leaderboard-columns.js
+++ b/dashboard/src/lib/leaderboard-columns.js
@@ -14,7 +14,7 @@ export const LEADERBOARD_TOKEN_COLUMNS = [
   { key: "kimi_tokens", copyKey: "leaderboard.column.kimi", icon: "/brand-logos/kimi.svg" },
   { key: "opencode_tokens", copyKey: "leaderboard.column.opencode", icon: "/brand-logos/opencode.svg" },
   { key: "openclaw_tokens", copyKey: "leaderboard.column.openclaw", icon: "/brand-logos/openclaw.svg" },
-  { key: "hermes_tokens", copyKey: "leaderboard.column.hermes", icon: null },
+  { key: "hermes_tokens", copyKey: "leaderboard.column.hermes", icon: "/brand-logos/hermes.svg" },
   { key: "other_tokens", copyKey: "leaderboard.column.supplemental", icon: null },
 ];
 


### PR DESCRIPTION
## Summary
- Add the bundled Hermes SVG to the Hermes leaderboard token column so the column renders the provider logo instead of text-only output.
- Invert the monochrome Kimi SVG in dark mode so it stays visible on dark leaderboard headers.
- Add targeted Vitest coverage for the Hermes column icon mapping and the Kimi dark-mode inversion class.

## Root Cause
- The Hermes leaderboard column had `icon: null` even though the bundled Hermes logo exists.
- The Kimi SVG uses `currentColor`, so it needs the same dark-mode inversion treatment as the other monochrome provider marks.

## Readiness
- Base: `mm7894215/TokenTracker:main`.
- Head: `fflake33:codex/leaderboard-provider-icons`.
- Commit: `e683e6243fa20121865d5d1a13627597cb801894`.
- Plan Completion Audit: no plan file detected.
- Coverage Audit: targeted coverage exists for both changed code paths. Remaining gap: no browser screenshot-level visual confirmation was run.
- Fresh Verification: current commit with a clean working tree.

## Verification
- `git diff --check HEAD~1..HEAD` - passed, exit 0.
- `npm --prefix dashboard test -- LeaderboardProviderColumnHeader.test.jsx leaderboard-columns.test.js` - passed, 2 test files / 2 tests.
- `npm --prefix dashboard run build` - passed, exit 0. Vite emitted the existing large chunk-size warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hermes token icon now displays in leaderboard columns.

* **Bug Fixes**
  * Kimi logo now displays correctly in dark mode.

* **Tests**
  * Added unit tests to verify icon display and dark mode styling behavior in leaderboard components.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->