### PR TITLE
Add local usage JSON export command

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -7,6 +7,7 @@ const { cmdUninstall } = require("./commands/uninstall");
 const { cmdServe } = require("./commands/serve");
 const { cmdDeviceLogin } = require("./commands/device-login");
 const { cmdWrapped } = require("./commands/wrapped");
+const { cmdUsage } = require("./commands/usage");
 
 async function run(argv) {
   const [command, ...rest] = argv;
@@ -50,6 +51,9 @@ async function run(argv) {
     case "wrapped":
       await cmdWrapped(rest);
       return;
+    case "usage":
+      await cmdUsage(rest);
+      return;
     default:
       throw new Error(`Unknown command: ${command}`);
   }
@@ -72,6 +76,7 @@ function printHelp() {
       "  npx tokentracker [--debug] uninstall [--purge]",
       "  npx tokentracker [--debug] device-login [--json] [--base-url <url>]",
       "  npx tokentracker [--debug] wrapped [--year 2026] [--json]",
+      "  npx tokentracker [--debug] usage [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--json] [--local-only]",
       "",
       "Notes:",
       "  - init: consent first, local setup next, browser sign-in last.",
@@ -86,6 +91,7 @@ function printHelp() {
       "  - --from-openclaw marks sync runs triggered by OpenClaw hooks.",
       "  - --debug shows original backend errors.",
       "  - device-login pairs a headless CLI / SSH session with a browser sign-in (15-min code).",
+      "  - usage reads local queue.jsonl only; --local-only is accepted for explicit offline scripts.",
       "",
     ].join("\n"),
   );

--- a/src/commands/usage.js
+++ b/src/commands/usage.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const path = require("node:path");
+const os = require("node:os");
+
+const { resolveTrackerPaths } = require("../lib/tracker-paths");
+const { ensurePricingLoaded } = require("../lib/pricing");
+const { readQueueData } = require("../lib/local-api");
+const {
+  assertDayFlag,
+  buildUsageSummary,
+  renderUsageSummary,
+} = require("../lib/usage-summary");
+
+function parseArgs(argv = []) {
+  const out = { from: null, to: null, json: false, localOnly: false };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") {
+      out.json = true;
+    } else if (arg === "--local-only") {
+      out.localOnly = true;
+    } else if (arg === "--from") {
+      const value = argv[++i];
+      assertDayFlag(value, "--from");
+      out.from = value;
+    } else if (arg === "--to") {
+      const value = argv[++i];
+      assertDayFlag(value, "--to");
+      out.to = value;
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  if (out.from && out.to && out.from > out.to) {
+    throw new Error(`--from must be earlier than or equal to --to`);
+  }
+
+  return out;
+}
+
+async function cmdUsage(argv = []) {
+  const opts = parseArgs(argv);
+  const home = os.homedir();
+  const { trackerDir, cacheDir } = await resolveTrackerPaths({ home });
+  const queuePath = path.join(trackerDir, "queue.jsonl");
+
+  await ensurePricingLoaded({ cachePath: path.join(cacheDir, "pricing.json") }).catch(() => null);
+
+  const rows = readQueueData(queuePath);
+  const summary = buildUsageSummary(rows, { from: opts.from, to: opts.to });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(summary, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(renderUsageSummary(summary));
+}
+
+module.exports = { cmdUsage, parseArgs };

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1786,6 +1786,8 @@ module.exports = {
   createLocalApiHandler,
   resolveAllowedInsforgeBaseUrl,
   resolveQueuePath,
+  readQueueData,
+  aggregateByDay,
   // Exported for cross-consumer tests (pricing + native contract lock).
   MODEL_PRICING,
   getModelPricing,

--- a/src/lib/usage-summary.js
+++ b/src/lib/usage-summary.js
@@ -1,0 +1,168 @@
+"use strict";
+
+const { aggregateByDay } = require("./local-api");
+const { computeRowCost } = require("./pricing");
+const { formatCompact } = require("./wrapped-aggregator");
+
+const TOKEN_FIELDS = [
+  "total_tokens",
+  "billable_total_tokens",
+  "input_tokens",
+  "output_tokens",
+  "cached_input_tokens",
+  "cache_creation_input_tokens",
+  "reasoning_output_tokens",
+  "conversation_count",
+];
+
+function isDay(value) {
+  return typeof value === "string" && /^\d{4}-\d{2}-\d{2}$/.test(value);
+}
+
+function rowDay(row) {
+  return typeof row?.hour_start === "string" ? row.hour_start.slice(0, 10) : null;
+}
+
+function createTotals() {
+  return {
+    total_tokens: 0,
+    billable_total_tokens: 0,
+    input_tokens: 0,
+    output_tokens: 0,
+    cached_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    reasoning_output_tokens: 0,
+    conversation_count: 0,
+    total_cost_usd: 0,
+  };
+}
+
+function addRowTotals(target, row) {
+  for (const field of TOKEN_FIELDS) {
+    if (field === "billable_total_tokens") {
+      target[field] += Number(row.billable_total_tokens ?? row.total_tokens ?? 0) || 0;
+    } else {
+      target[field] += Number(row[field] || 0) || 0;
+    }
+  }
+  target.total_cost_usd += computeRowCost(row);
+}
+
+function addDailyTotals(target, row) {
+  for (const field of TOKEN_FIELDS) {
+    target[field] += Number(row[field] || 0) || 0;
+  }
+  target.total_cost_usd += Number(row.total_cost_usd || 0) || 0;
+}
+
+function finalizeTotals(totals) {
+  return {
+    ...totals,
+    total_cost_usd: totals.total_cost_usd.toFixed(6),
+  };
+}
+
+function topBreakdown(rows, keyName) {
+  const groups = new Map();
+
+  for (const row of rows) {
+    const key = row?.[keyName] || "unknown";
+    if (!groups.has(key)) {
+      groups.set(key, { name: key, totals: createTotals() });
+    }
+    addRowTotals(groups.get(key).totals, row);
+  }
+
+  return Array.from(groups.values())
+    .map((entry) => ({ ...entry, totals: finalizeTotals(entry.totals) }))
+    .sort((a, b) => b.totals.billable_total_tokens - a.totals.billable_total_tokens)
+    .slice(0, 10);
+}
+
+function normalizeDailyCost(daily) {
+  return daily.map((day) => ({
+    ...day,
+    total_cost_usd: Number(day.total_cost_usd || 0).toFixed(6),
+  }));
+}
+
+function buildUsageSummary(rows, opts = {}) {
+  const dailyAll = aggregateByDay(Array.isArray(rows) ? rows : []);
+  const firstDay = dailyAll[0]?.day || null;
+  const lastDay = dailyAll[dailyAll.length - 1]?.day || null;
+  const from = opts.from || firstDay;
+  const to = opts.to || lastDay;
+
+  const daily = dailyAll.filter((day) => {
+    if (from && day.day < from) return false;
+    if (to && day.day > to) return false;
+    return true;
+  });
+
+  const rowsInRange = (Array.isArray(rows) ? rows : []).filter((row) => {
+    const day = rowDay(row);
+    if (!day) return false;
+    if (from && day < from) return false;
+    if (to && day > to) return false;
+    return true;
+  });
+
+  const totals = createTotals();
+  for (const day of daily) addDailyTotals(totals, day);
+
+  return {
+    generated_at: new Date().toISOString(),
+    local_only: true,
+    source: "queue.jsonl",
+    range: { from, to },
+    rows: rowsInRange.length,
+    days: daily.length,
+    totals: finalizeTotals(totals),
+    top_sources: topBreakdown(rowsInRange, "source"),
+    top_models: topBreakdown(rowsInRange, "model"),
+    daily: normalizeDailyCost(daily),
+  };
+}
+
+function renderUsageSummary(summary) {
+  const lines = [
+    "TokenTracker usage (local)",
+    "",
+    `Range: ${summary.range.from || "n/a"} to ${summary.range.to || "n/a"}`,
+    `Rows: ${summary.rows.toLocaleString("en-US")}`,
+    `Days: ${summary.days.toLocaleString("en-US")}`,
+    `Total tokens: ${formatCompact(summary.totals.total_tokens)}`,
+    `Billable tokens: ${formatCompact(summary.totals.billable_total_tokens)}`,
+    `Estimated cost: $${summary.totals.total_cost_usd}`,
+  ];
+
+  if (summary.top_sources.length > 0) {
+    lines.push("", "Top tools:");
+    for (const source of summary.top_sources.slice(0, 5)) {
+      lines.push(
+        `  ${source.name}: ${formatCompact(source.totals.billable_total_tokens)} · $${source.totals.total_cost_usd}`,
+      );
+    }
+  }
+
+  if (summary.top_models.length > 0) {
+    lines.push("", "Top models:");
+    for (const model of summary.top_models.slice(0, 5)) {
+      lines.push(
+        `  ${model.name}: ${formatCompact(model.totals.billable_total_tokens)} · $${model.totals.total_cost_usd}`,
+      );
+    }
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+function assertDayFlag(value, flag) {
+  if (!isDay(value)) throw new Error(`${flag} expects YYYY-MM-DD, got: ${value}`);
+}
+
+module.exports = {
+  buildUsageSummary,
+  renderUsageSummary,
+  assertDayFlag,
+};

--- a/test/cli-help.test.js
+++ b/test/cli-help.test.js
@@ -21,4 +21,5 @@ test("help output uses TokenTracker identifiers", async () => {
   assert.match(out, /tokentracker/);
   assert.ok(!out.includes("vibe"));
   assert.match(out, /doctor/);
+  assert.match(out, /usage/);
 });

--- a/test/usage-summary.test.js
+++ b/test/usage-summary.test.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  buildUsageSummary,
+  renderUsageSummary,
+} = require("../src/lib/usage-summary");
+const { parseArgs } = require("../src/commands/usage");
+
+test("usage summary exports local totals, daily data, and top breakdowns", () => {
+  const rows = [
+    {
+      source: "claude",
+      model: "claude-sonnet-4-5",
+      hour_start: "2026-05-01T10:00:00.000Z",
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+      billable_total_tokens: 150,
+      conversation_count: 1,
+    },
+    {
+      source: "codex",
+      model: "gpt-5",
+      hour_start: "2026-05-02T10:00:00.000Z",
+      input_tokens: 200,
+      output_tokens: 100,
+      total_tokens: 300,
+      billable_total_tokens: 300,
+      conversation_count: 2,
+    },
+  ];
+
+  const summary = buildUsageSummary(rows, { from: "2026-05-01", to: "2026-05-01" });
+
+  assert.equal(summary.local_only, true);
+  assert.deepEqual(summary.range, { from: "2026-05-01", to: "2026-05-01" });
+  assert.equal(summary.rows, 1);
+  assert.equal(summary.days, 1);
+  assert.equal(summary.totals.total_tokens, 150);
+  assert.equal(summary.totals.billable_total_tokens, 150);
+  assert.equal(summary.totals.conversation_count, 1);
+  assert.equal(typeof summary.totals.total_cost_usd, "string");
+  assert.equal(summary.daily.length, 1);
+  assert.equal(summary.top_sources[0].name, "claude");
+  assert.equal(summary.top_models[0].name, "claude-sonnet-4-5");
+});
+
+test("usage summary text includes cost and local scope", () => {
+  const summary = buildUsageSummary([
+    {
+      source: "codex",
+      model: "gpt-5",
+      hour_start: "2026-05-01T10:00:00.000Z",
+      total_tokens: 1000,
+      billable_total_tokens: 1000,
+    },
+  ]);
+
+  const text = renderUsageSummary(summary);
+  assert.match(text, /TokenTracker usage \(local\)/);
+  assert.match(text, /Estimated cost: \$/);
+  assert.match(text, /Top tools:/);
+});
+
+test("usage args accept explicit local-only scripts and reject invalid dates", () => {
+  assert.deepEqual(parseArgs(["--json", "--local-only", "--from", "2026-05-01"]), {
+    from: "2026-05-01",
+    to: null,
+    json: true,
+    localOnly: true,
+  });
+
+  assert.throws(() => parseArgs(["--from", "2026/05/01"]), /YYYY-MM-DD/);
+  assert.throws(() => parseArgs(["--from", "2026-05-02", "--to", "2026-05-01"]), /--from/);
+});


### PR DESCRIPTION
First off, thank you for building TokenTracker. The local progress and token/cost tracking are genuinely useful, and this project has been a great base for personal usage dashboards.

This PR adds a small local-only export surface for scripts and private dashboards:

- new `tokentracker usage` command
- `--json` output with totals, estimated USD cost, daily rows, top sources, and top models
- `--from` / `--to` date filters
- `--local-only` accepted as an explicit no-cloud/offline scripting flag
- reuses the existing local queue reader, deduping, aggregation, and pricing logic

This does not change cloud sync or leaderboard behavior; it just makes the local usage data easier to consume from other tools.

Checks run:

- `node --test test/usage-summary.test.js test/cli-help.test.js`
- `node bin/tracker.js usage --json --local-only --from 2099-01-01 --to 2099-01-02`

Refs #112.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `usage` CLI command to view token usage and cost summaries.
  * Supports date filtering with `--from` and `--to` options for time-based analysis.
  * Offers JSON output format via the `--json` flag.
  * Includes `--local-only` flag for displaying local usage only.
  * Reports estimated costs and displays top sources and models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mm7894215/TokenTracker/pull/113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->