### PR TITLE
Preload dashboard limits and leaderboard pages

### DIFF
--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -16,6 +16,7 @@ import { AppLayout } from "./ui/components/Sidebar.jsx";
 import { CommandPalette } from "./ui/dashboard/components/CommandPalette.jsx";
 import { ToastProvider } from "./ui/components/Toast.jsx";
 import {
+  getLeaderboardPreloadContextKey,
   markDashboardMainContentVisible,
   preloadDashboardPageResources,
   preloadLeaderboardDefaultState,
@@ -73,7 +74,7 @@ export default function App() {
   useCloudUsageSync();
   const dashboardMainContentVisibleRef = useRef(false);
   const dashboardResourcePreloadStartedRef = useRef(false);
-  const leaderboardStatePreloadStartedRef = useRef(false);
+  const leaderboardStatePreloadContextKeysRef = useRef(new Set());
   const mockEnabled = isMockEnabled();
   const screenshotMode = useMemo(() => {
     if (typeof window === "undefined") return false;
@@ -119,18 +120,20 @@ export default function App() {
 
   const tryPreloadLeaderboardDefaultState = useCallback(() => {
     if (!dashboardMainContentVisibleRef.current) return;
-    if (leaderboardStatePreloadStartedRef.current) return;
     if (!mockEnabled && insforge.loading) return;
     if (!mockEnabled && !signedIn) return;
-    leaderboardStatePreloadStartedRef.current = true;
-    void preloadLeaderboardDefaultState({
+    const preloadOptions = {
       accessMode: leaderboardAccessMode,
       baseUrl: getLeaderboardBaseUrl(),
       mockEnabled,
       signedIn,
       authLoading: Boolean(insforge.loading),
       userId: cloudAuthSignedIn ? insforge.user?.id || null : null,
-    });
+    };
+    const contextKey = getLeaderboardPreloadContextKey(preloadOptions);
+    if (leaderboardStatePreloadContextKeysRef.current.has(contextKey)) return;
+    leaderboardStatePreloadContextKeysRef.current.add(contextKey);
+    void preloadLeaderboardDefaultState(preloadOptions);
   }, [
     cloudAuthSignedIn,
     insforge.loading,

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, Suspense, useMemo } from "react";
+import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef } from "react";
 import { useLocation } from "react-router-dom";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
@@ -8,13 +8,18 @@ import { ThemeProvider } from "./ui/foundation/ThemeProvider.jsx";
 import { useInsforgeAuth } from "./contexts/InsforgeAuthContext.jsx";
 import { LoginModalProvider } from "./contexts/LoginModalContext.jsx";
 import { LoginModal } from "./components/LoginModal.jsx";
-import { getBackendBaseUrl } from "./lib/config";
+import { getBackendBaseUrl, getLeaderboardBaseUrl } from "./lib/config";
 import { isMockEnabled } from "./lib/mock-data";
 import { isScreenshotModeEnabled } from "./lib/screenshot-mode";
 import { useCloudUsageSync } from "./hooks/use-cloud-usage-sync";
 import { AppLayout } from "./ui/components/Sidebar.jsx";
 import { CommandPalette } from "./ui/dashboard/components/CommandPalette.jsx";
 import { ToastProvider } from "./ui/components/Toast.jsx";
+import {
+  markDashboardMainContentVisible,
+  preloadDashboardPageResources,
+  preloadLeaderboardDefaultState,
+} from "./lib/dashboard-preload.js";
 // NativeAuthCallbackPage must be eager-imported: its module-level code
 // captures the OAuth `insforge_code` query param synchronously at app
 // boot, BEFORE the InsForge SDK's detectAuthCallback() strips it. Lazy
@@ -66,6 +71,9 @@ export default function App() {
   const location = useLocation();
   const insforge = useInsforgeAuth();
   useCloudUsageSync();
+  const dashboardMainContentVisibleRef = useRef(false);
+  const dashboardResourcePreloadStartedRef = useRef(false);
+  const leaderboardStatePreloadStartedRef = useRef(false);
   const mockEnabled = isMockEnabled();
   const screenshotMode = useMemo(() => {
     if (typeof window === "undefined") return false;
@@ -88,6 +96,7 @@ export default function App() {
     (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
 
   const normalizedPath = pathname.replace(/\/+$/, "") || "/";
+  const isDashboardDefaultPath = normalizedPath === "/" || normalizedPath === "/dashboard";
   const isLeaderboardPath = normalizedPath === "/leaderboard";
   // Standalone shareable profile page: /u/:userId (public, anonymous-visible).
   const profileMatch = normalizedPath.match(/^\/u\/([^/]+)$/i);
@@ -98,6 +107,58 @@ export default function App() {
   const sessionSoftExpired = false;
   const baseUrl = getBackendBaseUrl();
   const isAuthGateTriggered = !signedIn && !mockEnabled && !isLocalMode;
+  const leaderboardAccessMode = mockEnabled
+    ? "mock"
+    : insforge.loading
+      ? "unavailable"
+      : cloudAuthSignedIn
+        ? "cloud"
+        : signedIn
+          ? "local"
+          : "unavailable";
+
+  const tryPreloadLeaderboardDefaultState = useCallback(() => {
+    if (!dashboardMainContentVisibleRef.current) return;
+    if (leaderboardStatePreloadStartedRef.current) return;
+    if (!mockEnabled && insforge.loading) return;
+    if (!mockEnabled && !signedIn) return;
+    leaderboardStatePreloadStartedRef.current = true;
+    void preloadLeaderboardDefaultState({
+      accessMode: leaderboardAccessMode,
+      baseUrl: getLeaderboardBaseUrl(),
+      mockEnabled,
+      signedIn,
+      authLoading: Boolean(insforge.loading),
+      userId: cloudAuthSignedIn ? insforge.user?.id || null : null,
+    });
+  }, [
+    cloudAuthSignedIn,
+    insforge.loading,
+    insforge.user?.id,
+    leaderboardAccessMode,
+    mockEnabled,
+    signedIn,
+  ]);
+
+  const handleDashboardMainContentVisible = useCallback(() => {
+    if (!isDashboardDefaultPath) return;
+    if (!dashboardMainContentVisibleRef.current) {
+      dashboardMainContentVisibleRef.current = true;
+      markDashboardMainContentVisible();
+    }
+    if (!dashboardResourcePreloadStartedRef.current) {
+      dashboardResourcePreloadStartedRef.current = true;
+      void preloadDashboardPageResources();
+    }
+    tryPreloadLeaderboardDefaultState();
+  }, [
+    isDashboardDefaultPath,
+    tryPreloadLeaderboardDefaultState,
+  ]);
+
+  useEffect(() => {
+    tryPreloadLeaderboardDefaultState();
+  }, [tryPreloadLeaderboardDefaultState]);
 
   const authObject = useMemo(() => {
     if (!insforge.enabled || !cloudAuthSignedIn) return null;
@@ -180,6 +241,7 @@ export default function App() {
         userId={profileUserId}
         signInUrl="/login"
         signUpUrl="/login"
+        onMainContentVisible={handleDashboardMainContentVisible}
       />
     );
     if (showSidebar) {

--- a/dashboard/src/App.navigation-preload.test.jsx
+++ b/dashboard/src/App.navigation-preload.test.jsx
@@ -41,6 +41,16 @@ const insforgeMock = vi.hoisted(() => ({
 const pending = vi.hoisted(() => new Promise(() => {}));
 
 vi.mock("./lib/dashboard-preload.js", () => ({
+  getLeaderboardPreloadContextKey: vi.fn((options = {}) =>
+    [
+      options.accessMode || "",
+      options.baseUrl || "",
+      String(Boolean(options.mockEnabled)),
+      String(Boolean(options.signedIn)),
+      String(Boolean(options.authLoading)),
+      options.userId || "null",
+    ].join("|"),
+  ),
   markDashboardMainContentVisible: vi.fn(),
   preloadDashboardPageResources: vi.fn(() => pending),
   preloadLeaderboardDefaultState: vi.fn(() => pending),

--- a/dashboard/src/App.navigation-preload.test.jsx
+++ b/dashboard/src/App.navigation-preload.test.jsx
@@ -1,0 +1,196 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App.jsx";
+import {
+  preloadDashboardPageResources,
+  preloadLeaderboardDefaultState,
+} from "./lib/dashboard-preload.js";
+
+const TEXT = {
+  dashboard: "Dashboard page",
+  device: "Device page",
+  ipCheck: "IP check",
+  landing: "Landing page",
+  leaderboard: "Leaderboard page",
+  leaderboardNav: "Leaderboard nav",
+  limits: "Limits page",
+  limitsNav: "Limits nav",
+  login: "Login page",
+  nativeCallback: "Native callback",
+  profile: "Profile page",
+  reveal: "reveal main content",
+  settings: "Settings page",
+  skills: "Skills page",
+  widgets: "Widgets page",
+  wrapped: "Wrapped page",
+};
+
+const insforgeMock = vi.hoisted(() => ({
+  enabled: true,
+  signedIn: true,
+  loading: false,
+  user: { id: "user-1" },
+  displayName: "Ada",
+  getAccessToken: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+const pending = vi.hoisted(() => new Promise(() => {}));
+
+vi.mock("./lib/dashboard-preload.js", () => ({
+  markDashboardMainContentVisible: vi.fn(),
+  preloadDashboardPageResources: vi.fn(() => pending),
+  preloadLeaderboardDefaultState: vi.fn(() => pending),
+}));
+
+vi.mock("./hooks/useLocale.js", () => ({
+  useLocale: () => ({ resolvedLocale: "en" }),
+}));
+
+vi.mock("./contexts/InsforgeAuthContext.jsx", () => ({
+  useInsforgeAuth: () => insforgeMock,
+}));
+
+vi.mock("./hooks/use-cloud-usage-sync", () => ({
+  useCloudUsageSync: vi.fn(),
+}));
+
+vi.mock("./lib/mock-data", () => ({
+  isMockEnabled: () => false,
+}));
+
+vi.mock("./lib/config", () => ({
+  getBackendBaseUrl: () => "",
+  getLeaderboardBaseUrl: () => "https://edge.example",
+}));
+
+vi.mock("./lib/screenshot-mode", () => ({
+  isScreenshotModeEnabled: () => false,
+}));
+
+vi.mock("./components/ErrorBoundary.jsx", () => ({
+  ErrorBoundary: ({ children }) => <>{children}</>,
+}));
+
+vi.mock("./ui/foundation/ThemeProvider.jsx", () => ({
+  ThemeProvider: ({ children }) => <>{children}</>,
+}));
+
+vi.mock("./contexts/LoginModalContext.jsx", () => ({
+  LoginModalProvider: ({ children }) => <>{children}</>,
+}));
+
+vi.mock("./components/LoginModal.jsx", () => ({
+  LoginModal: () => null,
+}));
+
+vi.mock("@vercel/analytics/react", () => ({
+  Analytics: () => null,
+}));
+
+vi.mock("@vercel/speed-insights/react", () => ({
+  SpeedInsights: () => null,
+}));
+
+vi.mock("./ui/components/Sidebar.jsx", async () => {
+  const { Link } = await vi.importActual("react-router-dom");
+  return {
+    AppLayout: ({ children }) => (
+      <div>
+        <nav>
+          <Link to="/limits">{TEXT.limitsNav}</Link>
+          <Link to="/leaderboard">{TEXT.leaderboardNav}</Link>
+        </nav>
+        {children}
+      </div>
+    ),
+  };
+});
+
+vi.mock("./ui/dashboard/components/CommandPalette.jsx", () => ({
+  CommandPalette: () => null,
+}));
+
+vi.mock("./pages/DashboardPage.jsx", () => ({
+  DashboardPage: ({ onMainContentVisible }) => (
+    <main>
+      <h1>{TEXT.dashboard}</h1>
+      <button type="button" onClick={onMainContentVisible}>
+        {TEXT.reveal}
+      </button>
+    </main>
+  ),
+}));
+
+vi.mock("./pages/LimitsPage.jsx", () => ({
+  LimitsPage: () => <main>{TEXT.limits}</main>,
+}));
+
+vi.mock("./pages/LeaderboardPage.jsx", () => ({
+  LeaderboardPage: () => <main>{TEXT.leaderboard}</main>,
+}));
+
+vi.mock("./pages/NativeAuthCallbackPage.jsx", () => ({
+  NativeAuthCallbackPage: () => <main>{TEXT.nativeCallback}</main>,
+}));
+
+vi.mock("./pages/IpCheckPage.jsx", () => ({ default: () => <main>{TEXT.ipCheck}</main> }));
+vi.mock("./pages/LandingPage.jsx", () => ({ LandingPage: () => <main>{TEXT.landing}</main> }));
+vi.mock("./pages/LeaderboardProfilePage.jsx", () => ({ LeaderboardProfilePage: () => <main>{TEXT.profile}</main> }));
+vi.mock("./pages/LoginPage.jsx", () => ({ LoginPage: () => <main>{TEXT.login}</main> }));
+vi.mock("./pages/DevicePage.jsx", () => ({ default: () => <main>{TEXT.device}</main> }));
+vi.mock("./pages/WrappedPage.jsx", () => ({ default: () => <main>{TEXT.wrapped}</main> }));
+vi.mock("./pages/SettingsPage.jsx", () => ({ SettingsPage: () => <main>{TEXT.settings}</main> }));
+vi.mock("./pages/SkillsPage.jsx", () => ({ SkillsPage: () => <main>{TEXT.skills}</main> }));
+vi.mock("./pages/WidgetsPage.jsx", () => ({ WidgetsPage: () => <main>{TEXT.widgets}</main> }));
+
+function renderApp(initialPath = "/dashboard") {
+  window.history.pushState({}, "", initialPath);
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+async function startPendingPreload(user) {
+  renderApp("/dashboard");
+  expect(await screen.findByText(TEXT.dashboard)).toBeInTheDocument();
+  await user.click(screen.getByRole("button", { name: TEXT.reveal }));
+  await waitFor(() => {
+    expect(preloadDashboardPageResources).toHaveBeenCalledTimes(1);
+    expect(preloadLeaderboardDefaultState).toHaveBeenCalledTimes(1);
+  });
+}
+
+describe("App navigation while preload is pending", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.pushState({}, "", "/");
+  });
+
+  it("switches to /limits without waiting for pending preload promises", async () => {
+    const user = userEvent.setup();
+    await startPendingPreload(user);
+
+    await act(async () => {
+      await user.click(screen.getByRole("link", { name: TEXT.limitsNav }));
+    });
+
+    expect(await screen.findByText(TEXT.limits)).toBeInTheDocument();
+  });
+
+  it("switches to /leaderboard without waiting for pending preload promises", async () => {
+    const user = userEvent.setup();
+    await startPendingPreload(user);
+
+    await act(async () => {
+      await user.click(screen.getByRole("link", { name: TEXT.leaderboardNav }));
+    });
+
+    expect(await screen.findByText(TEXT.leaderboard)).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/App.preload.test.jsx
+++ b/dashboard/src/App.preload.test.jsx
@@ -1,0 +1,272 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import App from "./App.jsx";
+import {
+  markDashboardMainContentVisible,
+  preloadDashboardPageResources,
+  preloadLeaderboardDefaultState,
+} from "./lib/dashboard-preload.js";
+
+const TEXT = {
+  dashboard: "Dashboard page",
+  device: "Device page",
+  ipCheck: "IP check",
+  landing: "Landing page",
+  leaderboard: "Leaderboard page",
+  limits: "Limits page",
+  limitsNav: "Limits nav",
+  login: "Login page",
+  nativeCallback: "Native callback",
+  profile: "Profile page",
+  reveal: "reveal main content",
+  settings: "Settings page",
+  skills: "Skills page",
+  widgets: "Widgets page",
+  wrapped: "Wrapped page",
+};
+
+const insforgeMock = vi.hoisted(() => ({
+  enabled: true,
+  signedIn: true,
+  loading: false,
+  user: { id: "user-1" },
+  displayName: "Ada",
+  getAccessToken: vi.fn(),
+  signOut: vi.fn(),
+}));
+
+vi.mock("./lib/dashboard-preload.js", () => ({
+  markDashboardMainContentVisible: vi.fn(),
+  preloadDashboardPageResources: vi.fn(() => Promise.resolve([])),
+  preloadLeaderboardDefaultState: vi.fn(() => Promise.resolve(null)),
+}));
+
+vi.mock("./hooks/useLocale.js", () => ({
+  useLocale: () => ({ resolvedLocale: "en" }),
+}));
+
+vi.mock("./contexts/InsforgeAuthContext.jsx", () => ({
+  useInsforgeAuth: () => insforgeMock,
+}));
+
+vi.mock("./hooks/use-cloud-usage-sync", () => ({
+  useCloudUsageSync: vi.fn(),
+}));
+
+vi.mock("./lib/mock-data", () => ({
+  isMockEnabled: () => false,
+}));
+
+vi.mock("./lib/config", () => ({
+  getBackendBaseUrl: () => "",
+  getLeaderboardBaseUrl: () => "https://edge.example",
+}));
+
+vi.mock("./lib/screenshot-mode", () => ({
+  isScreenshotModeEnabled: () => false,
+}));
+
+vi.mock("./components/ErrorBoundary.jsx", () => ({
+  ErrorBoundary: ({ children }) => <>{children}</>,
+}));
+
+vi.mock("./ui/foundation/ThemeProvider.jsx", () => ({
+  ThemeProvider: ({ children }) => <>{children}</>,
+}));
+
+vi.mock("./contexts/LoginModalContext.jsx", () => ({
+  LoginModalProvider: ({ children }) => <>{children}</>,
+}));
+
+vi.mock("./components/LoginModal.jsx", () => ({
+  LoginModal: () => null,
+}));
+
+vi.mock("@vercel/analytics/react", () => ({
+  Analytics: () => null,
+}));
+
+vi.mock("@vercel/speed-insights/react", () => ({
+  SpeedInsights: () => null,
+}));
+
+vi.mock("./ui/components/Sidebar.jsx", () => ({
+  AppLayout: ({ children }) => (
+    <div>
+      <a href="/limits" onClick={(event) => event.preventDefault()}>
+        {TEXT.limitsNav}
+      </a>
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("./ui/dashboard/components/CommandPalette.jsx", () => ({
+  CommandPalette: () => null,
+}));
+
+vi.mock("./pages/DashboardPage.jsx", () => ({
+  DashboardPage: ({ onMainContentVisible }) => (
+    <main>
+      <h1>{TEXT.dashboard}</h1>
+      <button type="button" onClick={onMainContentVisible}>
+        {TEXT.reveal}
+      </button>
+    </main>
+  ),
+}));
+
+vi.mock("./pages/LimitsPage.jsx", () => ({
+  LimitsPage: ({ onMainContentVisible }) => {
+    React.useEffect(() => {
+      onMainContentVisible?.();
+    }, [onMainContentVisible]);
+    return <main>{TEXT.limits}</main>;
+  },
+}));
+
+vi.mock("./pages/LeaderboardPage.jsx", () => ({
+  LeaderboardPage: ({ onMainContentVisible }) => {
+    React.useEffect(() => {
+      onMainContentVisible?.();
+    }, [onMainContentVisible]);
+    return <main>{TEXT.leaderboard}</main>;
+  },
+}));
+
+vi.mock("./pages/NativeAuthCallbackPage.jsx", () => ({
+  NativeAuthCallbackPage: () => <main>{TEXT.nativeCallback}</main>,
+}));
+
+vi.mock("./pages/IpCheckPage.jsx", () => ({ default: () => <main>{TEXT.ipCheck}</main> }));
+vi.mock("./pages/LandingPage.jsx", () => ({ LandingPage: () => <main>{TEXT.landing}</main> }));
+vi.mock("./pages/LeaderboardProfilePage.jsx", () => ({ LeaderboardProfilePage: () => <main>{TEXT.profile}</main> }));
+vi.mock("./pages/LoginPage.jsx", () => ({ LoginPage: () => <main>{TEXT.login}</main> }));
+vi.mock("./pages/DevicePage.jsx", () => ({ default: () => <main>{TEXT.device}</main> }));
+vi.mock("./pages/WrappedPage.jsx", () => ({ default: () => <main>{TEXT.wrapped}</main> }));
+vi.mock("./pages/SettingsPage.jsx", () => ({ SettingsPage: () => <main>{TEXT.settings}</main> }));
+vi.mock("./pages/SkillsPage.jsx", () => ({ SkillsPage: () => <main>{TEXT.skills}</main> }));
+vi.mock("./pages/WidgetsPage.jsx", () => ({ WidgetsPage: () => <main>{TEXT.widgets}</main> }));
+
+function renderApp(initialPath = "/dashboard") {
+  window.history.pushState({}, "", initialPath);
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <App />
+    </MemoryRouter>,
+  );
+}
+
+describe("App deferred dashboard preload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insforgeMock.enabled = true;
+    insforgeMock.signedIn = true;
+    insforgeMock.loading = false;
+    insforgeMock.user = { id: "user-1" };
+    insforgeMock.displayName = "Ada";
+    window.history.pushState({}, "", "/");
+  });
+
+  it("does not start target preload before the dashboard main content is visible", async () => {
+    const user = userEvent.setup();
+    renderApp("/dashboard");
+
+    expect(await screen.findByText(TEXT.dashboard)).toBeInTheDocument();
+    expect(preloadDashboardPageResources).not.toHaveBeenCalled();
+    expect(preloadLeaderboardDefaultState).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: TEXT.reveal }));
+
+    await waitFor(() => {
+      expect(markDashboardMainContentVisible).toHaveBeenCalledTimes(1);
+      expect(preloadDashboardPageResources).toHaveBeenCalledTimes(1);
+      expect(preloadLeaderboardDefaultState).toHaveBeenCalledWith({
+        accessMode: "cloud",
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: "user-1",
+      });
+    });
+  });
+
+  it.each([
+    ["/limits", TEXT.limits],
+    ["/leaderboard", TEXT.leaderboard],
+  ])("does not start dashboard preload for deep-linked %s", async (path, pageText) => {
+    renderApp(path);
+
+    expect(await screen.findByText(pageText)).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(markDashboardMainContentVisible).not.toHaveBeenCalled();
+      expect(preloadDashboardPageResources).not.toHaveBeenCalled();
+      expect(preloadLeaderboardDefaultState).not.toHaveBeenCalled();
+    });
+  });
+
+  it("uses local dashboard access for leaderboard state preload eligibility", async () => {
+    const user = userEvent.setup();
+    insforgeMock.signedIn = false;
+    insforgeMock.user = null;
+
+    renderApp("/dashboard");
+
+    expect(await screen.findByText(TEXT.dashboard)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: TEXT.reveal }));
+
+    await waitFor(() => {
+      expect(preloadDashboardPageResources).toHaveBeenCalledTimes(1);
+      expect(preloadLeaderboardDefaultState).toHaveBeenCalledWith({
+        accessMode: "local",
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: null,
+      });
+    });
+  });
+
+  it("waits for cloud auth to settle before preloading leaderboard default state", async () => {
+    const user = userEvent.setup();
+    insforgeMock.loading = true;
+    insforgeMock.signedIn = false;
+    insforgeMock.user = null;
+    const view = renderApp("/dashboard");
+
+    expect(await screen.findByText(TEXT.dashboard)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: TEXT.reveal }));
+
+    await waitFor(() => {
+      expect(preloadDashboardPageResources).toHaveBeenCalledTimes(1);
+      expect(preloadLeaderboardDefaultState).not.toHaveBeenCalled();
+    });
+
+    insforgeMock.loading = false;
+    insforgeMock.signedIn = true;
+    insforgeMock.user = { id: "user-late" };
+    view.rerender(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(preloadLeaderboardDefaultState).toHaveBeenCalledTimes(1);
+      expect(preloadLeaderboardDefaultState).toHaveBeenCalledWith({
+        accessMode: "cloud",
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: "user-late",
+      });
+    });
+  });
+});

--- a/dashboard/src/App.preload.test.jsx
+++ b/dashboard/src/App.preload.test.jsx
@@ -39,6 +39,16 @@ const insforgeMock = vi.hoisted(() => ({
 }));
 
 vi.mock("./lib/dashboard-preload.js", () => ({
+  getLeaderboardPreloadContextKey: vi.fn((options = {}) =>
+    [
+      options.accessMode || "",
+      options.baseUrl || "",
+      String(Boolean(options.mockEnabled)),
+      String(Boolean(options.signedIn)),
+      String(Boolean(options.authLoading)),
+      options.userId || "null",
+    ].join("|"),
+  ),
   markDashboardMainContentVisible: vi.fn(),
   preloadDashboardPageResources: vi.fn(() => Promise.resolve([])),
   preloadLeaderboardDefaultState: vi.fn(() => Promise.resolve(null)),
@@ -229,6 +239,48 @@ describe("App deferred dashboard preload", () => {
         signedIn: true,
         authLoading: false,
         userId: null,
+      });
+    });
+  });
+
+  it("preloads again when the leaderboard auth context changes", async () => {
+    const user = userEvent.setup();
+    insforgeMock.signedIn = false;
+    insforgeMock.user = null;
+    const view = renderApp("/dashboard");
+
+    expect(await screen.findByText(TEXT.dashboard)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: TEXT.reveal }));
+
+    await waitFor(() => {
+      expect(preloadLeaderboardDefaultState).toHaveBeenCalledTimes(1);
+      expect(preloadLeaderboardDefaultState).toHaveBeenLastCalledWith({
+        accessMode: "local",
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: null,
+      });
+    });
+
+    insforgeMock.signedIn = true;
+    insforgeMock.user = { id: "user-cloud" };
+    view.rerender(
+      <MemoryRouter initialEntries={["/dashboard"]}>
+        <App />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(preloadLeaderboardDefaultState).toHaveBeenCalledTimes(2);
+      expect(preloadLeaderboardDefaultState).toHaveBeenLastCalledWith({
+        accessMode: "cloud",
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: "user-cloud",
       });
     });
   });

--- a/dashboard/src/hooks/use-usage-limits.test.tsx
+++ b/dashboard/src/hooks/use-usage-limits.test.tsx
@@ -1,0 +1,127 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getUsageLimits } from "../lib/api";
+import { publishUsageLimitsPreloadState } from "../lib/dashboard-preload.js";
+import { useUsageLimits } from "./use-usage-limits";
+
+vi.mock("../lib/api", () => ({
+  getUsageLimits: vi.fn(),
+}));
+
+vi.mock("../lib/dashboard-preload.js", () => ({
+  publishUsageLimitsPreloadState: vi.fn(),
+}));
+
+const existingLimits = {
+  fetched_at: "2026-05-30T10:00:00.000Z",
+  claude: { configured: false },
+  codex: { configured: false },
+  cursor: { configured: false },
+  gemini: { configured: false },
+  kimi: {
+    configured: true,
+    primary_window: { used_percent: 42, reset_at: "2026-05-30T12:00:00.000Z" },
+  },
+  kiro: { configured: false },
+  antigravity: { configured: false },
+};
+
+const freshLimits = {
+  ...existingLimits,
+  fetched_at: "2026-05-30T10:05:00.000Z",
+  kimi: {
+    configured: true,
+    primary_window: { used_percent: 18, reset_at: "2026-05-30T12:30:00.000Z" },
+  },
+};
+
+describe("useUsageLimits", () => {
+  beforeEach(() => {
+    vi.mocked(getUsageLimits).mockReset();
+    vi.mocked(publishUsageLimitsPreloadState).mockReset();
+  });
+
+  it("uses reusable initial data immediately and writes the background refresh back to cache", async () => {
+    vi.mocked(getUsageLimits).mockResolvedValue(freshLimits);
+
+    const { result } = renderHook(() =>
+      useUsageLimits({
+        initialRefresh: true,
+        initialState: { data: existingLimits },
+        publishToPreloadCache: true,
+      }),
+    );
+
+    expect(result.current.data).toBe(existingLimits);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+
+    await waitFor(() => expect(result.current.data).toEqual(freshLimits));
+
+    expect(getUsageLimits).toHaveBeenCalledWith({ refresh: true });
+    expect(publishUsageLimitsPreloadState).toHaveBeenCalledWith(freshLimits, {
+      source: "page-load",
+    });
+  });
+
+  it("keeps the initialRefresh fallback when no reusable initial data exists", async () => {
+    vi.mocked(getUsageLimits).mockResolvedValue(freshLimits);
+
+    const { result } = renderHook(() => useUsageLimits({ initialRefresh: true }));
+
+    expect(result.current.data).toBeNull();
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getUsageLimits).toHaveBeenCalledWith({ refresh: true });
+    expect(result.current.data).toEqual(freshLimits);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("keeps initial cached data visible when the background refresh fails", async () => {
+    vi.mocked(getUsageLimits).mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() =>
+      useUsageLimits({
+        initialRefresh: true,
+        initialState: { data: existingLimits },
+        publishToPreloadCache: true,
+      }),
+    );
+
+    expect(result.current.data).toBe(existingLimits);
+    expect(result.current.isLoading).toBe(false);
+
+    await waitFor(() => expect(result.current.error).toBe("network down"));
+
+    expect(result.current.data).toBe(existingLimits);
+    expect(publishUsageLimitsPreloadState).not.toHaveBeenCalled();
+  });
+
+  it("forces refresh manually and writes cache with the manual-refresh source", async () => {
+    vi.mocked(getUsageLimits).mockResolvedValue(freshLimits);
+
+    const { result } = renderHook(() =>
+      useUsageLimits({
+        initialRefresh: false,
+        initialState: { data: existingLimits },
+        publishToPreloadCache: true,
+      }),
+    );
+
+    await Promise.resolve();
+    expect(getUsageLimits).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    expect(getUsageLimits).toHaveBeenCalledTimes(1);
+    expect(getUsageLimits).toHaveBeenCalledWith({ refresh: true });
+    expect(result.current.data).toEqual(freshLimits);
+    expect(publishUsageLimitsPreloadState).toHaveBeenCalledWith(freshLimits, {
+      source: "manual-refresh",
+    });
+  });
+});

--- a/dashboard/src/hooks/use-usage-limits.ts
+++ b/dashboard/src/hooks/use-usage-limits.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { getUsageLimits } from "../lib/api";
+import { publishUsageLimitsPreloadState } from "../lib/dashboard-preload.js";
 
 interface UsageLimitsData {
   fetched_at: string;
@@ -12,30 +13,61 @@ interface UsageLimitsData {
   antigravity: { configured: boolean; error?: string | null; account_email?: string | null; account_plan?: string | null; primary_window?: { used_percent: number; reset_at?: string | null } | null; secondary_window?: { used_percent: number; reset_at?: string | null } | null; tertiary_window?: { used_percent: number; reset_at?: string | null } | null };
 }
 
-export function useUsageLimits(options?: { initialRefresh?: boolean }) {
-  const [data, setData] = useState<UsageLimitsData | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+interface UsageLimitsInitialState {
+  data?: UsageLimitsData | null;
+  error?: string | null;
+  status?: string;
+}
+
+interface UseUsageLimitsOptions {
+  initialRefresh?: boolean;
+  initialState?: UsageLimitsInitialState | null;
+  publishToPreloadCache?: boolean;
+}
+
+export function useUsageLimits(options?: UseUsageLimitsOptions) {
+  const hasInitialState = Boolean(options?.initialState);
+  const [data, setData] = useState<UsageLimitsData | null>(() => (
+    hasInitialState ? options?.initialState?.data ?? null : null
+  ));
+  const [error, setError] = useState<string | null>(() => (
+    hasInitialState ? options?.initialState?.error ?? null : null
+  ));
+  const [isLoading, setIsLoading] = useState(!hasInitialState);
   const initialRefresh = Boolean(options?.initialRefresh);
+  const publishToPreloadCache = Boolean(options?.publishToPreloadCache);
+
+  const publishSuccessfulState = useCallback(
+    (value: UsageLimitsData | null, source: "page-load" | "manual-refresh") => {
+      if (!publishToPreloadCache || !value || typeof value !== "object") return;
+      publishUsageLimitsPreloadState(value, { source });
+    },
+    [publishToPreloadCache],
+  );
 
   const refresh = useCallback(async () => {
     try {
       const res = await getUsageLimits({ refresh: true });
-      setData(res && typeof res === "object" ? res as UsageLimitsData : null);
+      const nextData = res && typeof res === "object" ? res as UsageLimitsData : null;
+      setData(nextData);
       setError(null);
+      publishSuccessfulState(nextData, "manual-refresh");
     } catch (err) {
       setError((err as Error)?.message || String(err));
     }
-  }, []);
+  }, [publishSuccessfulState]);
 
   useEffect(() => {
+    if (hasInitialState && !initialRefresh) return;
     let cancelled = false;
     (async () => {
       try {
         const res = await getUsageLimits(initialRefresh ? { refresh: true } : {});
         if (cancelled) return;
-        setData(res && typeof res === "object" ? res as UsageLimitsData : null);
+        const nextData = res && typeof res === "object" ? res as UsageLimitsData : null;
+        setData(nextData);
         setError(null);
+        publishSuccessfulState(nextData, "page-load");
       } catch (err) {
         if (cancelled) return;
         setError((err as Error)?.message || String(err));
@@ -46,7 +78,7 @@ export function useUsageLimits(options?: { initialRefresh?: boolean }) {
     return () => {
       cancelled = true;
     };
-  }, [initialRefresh]);
+  }, [hasInitialState, initialRefresh, publishSuccessfulState]);
 
   return { data, error, isLoading, refresh };
 }

--- a/dashboard/src/lib/dashboard-preload.d.ts
+++ b/dashboard/src/lib/dashboard-preload.d.ts
@@ -78,7 +78,6 @@ export interface LeaderboardPreloadOptions extends DashboardPreloadContext {
 
 export const DASHBOARD_PRELOAD_TARGETS: readonly DashboardPreloadTarget[];
 export const DASHBOARD_PRELOAD_STATUSES: readonly DashboardPreloadStatus[];
-export const DASHBOARD_PRELOAD_STATE_MAX_AGE_MS: number;
 
 export function resetDashboardPreload(options?: { leaderboardMaxEntries?: number }): void;
 export function markDashboardMainContentVisible(): void;

--- a/dashboard/src/lib/dashboard-preload.d.ts
+++ b/dashboard/src/lib/dashboard-preload.d.ts
@@ -1,0 +1,140 @@
+export type DashboardPreloadTarget = "limits" | "leaderboard";
+
+export type DashboardPreloadStatus =
+  | "idle"
+  | "pending"
+  | "fulfilled"
+  | "rejected"
+  | "skipped";
+
+export type DashboardPreloadStateSource =
+  | "dashboard-existing"
+  | "silent-preload"
+  | "page-load"
+  | "manual-refresh";
+
+export interface DashboardPreloadCacheEntry<TData = unknown> {
+  targetKey: DashboardPreloadTarget;
+  status: DashboardPreloadStatus;
+  data: TData | null;
+  error: string | null;
+  source: DashboardPreloadStateSource;
+  generatedAt: number;
+  updatedAt: number;
+  contextKey: string;
+}
+
+export interface DashboardPreloadSnapshot {
+  sessionId: string;
+  createdAt: number;
+  completedAt: number | null;
+  startedAfterMainContentVisible: boolean;
+  cache: {
+    limits: DashboardPreloadCacheEntry | null;
+    leaderboard: {
+      maxEntries: number;
+      size: number;
+      keys: string[];
+    };
+  };
+  targets: Record<
+    DashboardPreloadTarget,
+    {
+      key: DashboardPreloadTarget;
+      route: string;
+      resourceStatus: DashboardPreloadStatus;
+      stateStatus: DashboardPreloadStatus;
+      error: string | null;
+    }
+  >;
+}
+
+export interface DashboardPreloadContext {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+export interface DashboardPreloadStateOptions {
+  activeContextKey?: string;
+  context?: DashboardPreloadContext;
+  contextKey?: string;
+  error?: unknown;
+  generatedAt?: number;
+  source?: DashboardPreloadStateSource;
+  status?: DashboardPreloadStatus;
+}
+
+export interface LeaderboardPreloadOptions extends DashboardPreloadContext {
+  accessMode?: string;
+  authLoading?: boolean;
+  baseUrl?: string;
+  cloudUser?: { id?: string | null } | null;
+  mockEnabled?: boolean;
+  offset?: number;
+  pageSize?: number;
+  period?: string;
+  signedIn?: boolean;
+  userId?: string | null;
+}
+
+export const DASHBOARD_PRELOAD_TARGETS: readonly DashboardPreloadTarget[];
+export const DASHBOARD_PRELOAD_STATUSES: readonly DashboardPreloadStatus[];
+export const DASHBOARD_PRELOAD_STATE_MAX_AGE_MS: number;
+
+export function resetDashboardPreload(options?: { leaderboardMaxEntries?: number }): void;
+export function markDashboardMainContentVisible(): void;
+export function getDashboardPreloadSnapshot(): DashboardPreloadSnapshot;
+export function buildDashboardPreloadContextKey(
+  targetKey: DashboardPreloadTarget,
+  context?: DashboardPreloadContext,
+): string;
+export function skipDashboardPreloadTarget(
+  targetKey: DashboardPreloadTarget,
+  reason?: unknown,
+): DashboardPreloadCacheEntry<null>;
+export function preloadDashboardPageResource(
+  targetKey: DashboardPreloadTarget,
+  options?: { loader?: () => Promise<unknown> },
+): Promise<unknown | null>;
+export function preloadDashboardPageResources(options?: {
+  loaders?: Partial<Record<DashboardPreloadTarget, () => Promise<unknown>>>;
+}): Promise<Array<unknown | null>>;
+export function publishReusablePageState<TData = unknown>(
+  targetKey: DashboardPreloadTarget,
+  state?: DashboardPreloadStateOptions & { data?: TData | null },
+): DashboardPreloadCacheEntry<TData>;
+export function readReusablePageState<TData = unknown>(
+  targetKey: DashboardPreloadTarget,
+  contextKey?: string,
+): DashboardPreloadCacheEntry<TData> | null;
+export function consumeReusablePageState<TData = unknown>(
+  targetKey: DashboardPreloadTarget,
+  contextKey?: string,
+): DashboardPreloadCacheEntry<TData> | null;
+export function discardReusablePageState(
+  targetKey: DashboardPreloadTarget,
+  contextKey?: string,
+): boolean;
+export function publishUsageLimitsPreloadState<TData = unknown>(
+  data: TData | null,
+  options?: DashboardPreloadStateOptions,
+): DashboardPreloadCacheEntry<TData>;
+export function getUsageLimitsPreloadContextKey(context?: DashboardPreloadContext): string;
+export function readUsageLimitsPreloadState<TData = unknown>(
+  contextKey?: string,
+): DashboardPreloadCacheEntry<TData> | null;
+export function publishLeaderboardPreloadState<TData = unknown>(
+  data: TData | null,
+  options?: DashboardPreloadStateOptions,
+): DashboardPreloadCacheEntry<TData>;
+export function readLeaderboardPreloadState<TData = unknown>(
+  contextKey: string,
+): DashboardPreloadCacheEntry<TData> | null;
+export function consumeLeaderboardPreloadState<TData = unknown>(
+  contextKey: string,
+): DashboardPreloadCacheEntry<TData> | null;
+export function discardLeaderboardPreloadState(contextKey: string): boolean;
+export function getLeaderboardPreloadPageSize(): number;
+export function getLeaderboardPreloadContextKey(options?: LeaderboardPreloadOptions): string;
+export function preloadLeaderboardDefaultState<TData = unknown>(
+  options?: LeaderboardPreloadOptions,
+): Promise<DashboardPreloadCacheEntry<TData> | null>;

--- a/dashboard/src/lib/dashboard-preload.d.ts
+++ b/dashboard/src/lib/dashboard-preload.d.ts
@@ -63,7 +63,7 @@ export interface DashboardPreloadStateOptions {
   status?: DashboardPreloadStatus;
 }
 
-export interface LeaderboardPreloadOptions extends DashboardPreloadContext {
+export interface LeaderboardPreloadOptions {
   accessMode?: string;
   authLoading?: boolean;
   baseUrl?: string;

--- a/dashboard/src/lib/dashboard-preload.js
+++ b/dashboard/src/lib/dashboard-preload.js
@@ -32,8 +32,6 @@ const PAGE_STATE_SOURCES = Object.freeze([
   "page-load",
   "manual-refresh",
 ]);
-export const DASHBOARD_PRELOAD_STATE_MAX_AGE_MS = 60_000;
-
 let sessionCounter = 0;
 let session;
 
@@ -405,7 +403,7 @@ function getLeaderboardPreloadAccessMode(options = {}) {
   if (typeof options.accessMode === "string" && options.accessMode.trim()) {
     return options.accessMode.trim();
   }
-  if (Boolean(options.mockEnabled)) return "mock";
+  if (options.mockEnabled) return "mock";
   if (options.baseUrl) return "cloud";
   return "unavailable";
 }

--- a/dashboard/src/lib/dashboard-preload.js
+++ b/dashboard/src/lib/dashboard-preload.js
@@ -1,0 +1,519 @@
+import { getLeaderboard } from "./api";
+
+export const DASHBOARD_PRELOAD_TARGETS = Object.freeze(["limits", "leaderboard"]);
+
+export const DASHBOARD_PRELOAD_STATUSES = Object.freeze([
+  "idle",
+  "pending",
+  "fulfilled",
+  "rejected",
+  "skipped",
+]);
+
+const TARGET_ROUTES = Object.freeze({
+  limits: "/limits",
+  leaderboard: "/leaderboard",
+});
+
+const DEFAULT_RESOURCE_LOADERS = Object.freeze({
+  limits: () => import("../pages/LimitsPage.jsx"),
+  leaderboard: () => import("../pages/LeaderboardPage.jsx"),
+});
+
+const LEADERBOARD_DEFAULT_PERIOD = "total";
+const LEADERBOARD_DEFAULT_OFFSET = 0;
+const LEADERBOARD_DEFAULT_PAGE_SIZE = 20;
+const LEADERBOARD_PAGE_SIZE_OPTIONS = Object.freeze([10, 20, 50, 100]);
+const LEADERBOARD_PAGE_SIZE_STORAGE_KEY = "tokentracker:leaderboard:pageSize";
+const LEADERBOARD_DEFAULT_MAX_ENTRIES = 20;
+const PAGE_STATE_SOURCES = Object.freeze([
+  "dashboard-existing",
+  "silent-preload",
+  "page-load",
+  "manual-refresh",
+]);
+export const DASHBOARD_PRELOAD_STATE_MAX_AGE_MS = 60_000;
+
+let sessionCounter = 0;
+let session;
+
+class WindowSessionCache {
+  constructor(options = {}) {
+    this.limits = null;
+    this.leaderboard = new Map();
+    this.leaderboardMaxEntries = normalizeLeaderboardMaxEntries(options.leaderboardMaxEntries);
+  }
+
+  read(targetKey, contextKey) {
+    assertTargetKey(targetKey);
+    if (targetKey === "limits") {
+      if (!this.limits || this.limits.contextKey !== contextKey) return null;
+      return cloneCacheEntry(this.limits);
+    }
+    if (!contextKey) return null;
+    return cloneCacheEntry(this.leaderboard.get(contextKey));
+  }
+
+  write(entry, options = {}) {
+    if (entry.targetKey === "limits") {
+      this.limits = entry;
+      return;
+    }
+    if (this.leaderboard.has(entry.contextKey)) {
+      this.leaderboard.delete(entry.contextKey);
+    }
+    this.leaderboard.set(entry.contextKey, entry);
+    this.evictLeaderboardEntries(options.activeContextKey || entry.contextKey);
+  }
+
+  evictLeaderboardEntries(activeContextKey = null) {
+    while (this.leaderboard.size > this.leaderboardMaxEntries) {
+      const evictionKey =
+        Array.from(this.leaderboard.keys()).find((key) => key !== activeContextKey) ||
+        this.leaderboard.keys().next().value;
+      this.leaderboard.delete(evictionKey);
+    }
+  }
+
+  snapshot() {
+    return {
+      limits: cloneCacheEntry(this.limits),
+      leaderboard: {
+        maxEntries: this.leaderboardMaxEntries,
+        size: this.leaderboard.size,
+        keys: Array.from(this.leaderboard.keys()),
+      },
+    };
+  }
+}
+
+class DashboardWindowSession {
+  constructor(options = {}) {
+    sessionCounter += 1;
+    this.sessionId = `dashboard-preload-${sessionCounter}`;
+    this.createdAt = Date.now();
+    this.completedAt = null;
+    this.startedAfterMainContentVisible = false;
+    this.cache = new WindowSessionCache(options);
+    this.targets = {
+      limits: createTarget("limits"),
+      leaderboard: createTarget("leaderboard"),
+    };
+  }
+}
+
+function createTarget(key) {
+  return {
+    key,
+    route: TARGET_ROUTES[key],
+    resourceStatus: "idle",
+    stateStatus: "idle",
+    error: null,
+    resourcePromise: null,
+    resourceModule: null,
+    resourceRequestId: 0,
+    statePromise: null,
+    stateRequestId: 0,
+    pendingStateContextKey: null,
+  };
+}
+
+function createSession(options = {}) {
+  return new DashboardWindowSession(options);
+}
+
+function normalizeLeaderboardMaxEntries(value) {
+  const maxEntries = Number(value);
+  if (!Number.isInteger(maxEntries) || maxEntries < 1) {
+    return LEADERBOARD_DEFAULT_MAX_ENTRIES;
+  }
+  return maxEntries;
+}
+
+session = createSession();
+
+function assertTargetKey(targetKey) {
+  if (!DASHBOARD_PRELOAD_TARGETS.includes(targetKey)) {
+    throw new Error(`Unknown dashboard preload target: ${targetKey}`);
+  }
+}
+
+function normalizeError(error) {
+  if (!error) return null;
+  if (typeof error === "string") return error;
+  return error.message || String(error);
+}
+
+function normalizePageStateSource(source, fallback) {
+  if (PAGE_STATE_SOURCES.includes(source)) return source;
+  return fallback;
+}
+
+function normalizeGeneratedAt(value) {
+  const generatedAt = Number(value);
+  if (Number.isFinite(generatedAt)) return generatedAt;
+  return Date.now();
+}
+
+function cloneCacheEntry(entry) {
+  if (!entry) return null;
+  return { ...entry };
+}
+
+function targetSnapshot(target) {
+  return {
+    key: target.key,
+    route: target.route,
+    resourceStatus: target.resourceStatus,
+    stateStatus: target.stateStatus,
+    error: target.error,
+  };
+}
+
+function updateCompletedAt() {
+  const settled = DASHBOARD_PRELOAD_TARGETS.every((key) => {
+    const target = session.targets[key];
+    return (
+      target.resourceStatus === "fulfilled" ||
+      target.resourceStatus === "rejected" ||
+      target.resourceStatus === "skipped"
+    );
+  });
+  session.completedAt = settled ? Date.now() : null;
+}
+
+export function resetDashboardPreload(options = {}) {
+  session = createSession(options);
+}
+
+export function markDashboardMainContentVisible() {
+  session.startedAfterMainContentVisible = true;
+}
+
+export function getDashboardPreloadSnapshot() {
+  return {
+    sessionId: session.sessionId,
+    createdAt: session.createdAt,
+    completedAt: session.completedAt,
+    startedAfterMainContentVisible: session.startedAfterMainContentVisible,
+    cache: session.cache.snapshot(),
+    targets: {
+      limits: targetSnapshot(session.targets.limits),
+      leaderboard: targetSnapshot(session.targets.leaderboard),
+    },
+  };
+}
+
+export function buildDashboardPreloadContextKey(targetKey, context = {}) {
+  assertTargetKey(targetKey);
+  const entries = Object.entries(context)
+    .filter(([, value]) => value !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value === null ? "null" : String(value)}`);
+  return `${targetKey}:${entries.join("|")}`;
+}
+
+export function skipDashboardPreloadTarget(targetKey, reason = "skipped") {
+  assertTargetKey(targetKey);
+  const target = session.targets[targetKey];
+  target.resourceStatus = "skipped";
+  target.stateStatus = "skipped";
+  target.error = normalizeError(reason);
+  target.resourceRequestId += 1;
+  target.resourcePromise = Promise.resolve(null);
+  const skippedState = {
+    targetKey,
+    status: "skipped",
+    data: null,
+    error: target.error,
+    source: "silent-preload",
+    generatedAt: Date.now(),
+    updatedAt: Date.now(),
+    contextKey: buildDashboardPreloadContextKey(targetKey, { skipped: target.error || "true" }),
+  };
+  updateCompletedAt();
+  return skippedState;
+}
+
+export function preloadDashboardPageResource(targetKey, options = {}) {
+  assertTargetKey(targetKey);
+  const target = session.targets[targetKey];
+  if (target.resourceStatus === "skipped") {
+    return Promise.resolve(null);
+  }
+  if (target.resourceStatus === "fulfilled") {
+    return Promise.resolve(target.resourceModule);
+  }
+  if (target.resourceStatus === "pending" && target.resourcePromise) {
+    return target.resourcePromise;
+  }
+
+  const loader = options.loader || DEFAULT_RESOURCE_LOADERS[targetKey];
+  const requestId = target.resourceRequestId + 1;
+  target.resourceRequestId = requestId;
+  target.resourceStatus = "pending";
+  target.error = null;
+  const promise = Promise.resolve()
+    .then(() => loader())
+    .then((module) => {
+      if (target.resourceRequestId !== requestId || target.resourcePromise !== promise) {
+        return null;
+      }
+      target.resourceStatus = "fulfilled";
+      target.resourceModule = module;
+      target.error = null;
+      updateCompletedAt();
+      return module;
+    })
+    .catch((error) => {
+      if (target.resourceRequestId !== requestId || target.resourcePromise !== promise) {
+        return null;
+      }
+      target.resourceStatus = "rejected";
+      target.error = normalizeError(error);
+      updateCompletedAt();
+      return null;
+    });
+
+  target.resourcePromise = promise;
+  return promise;
+}
+
+export function preloadDashboardPageResources(options = {}) {
+  const loaders = options.loaders || {};
+  return Promise.all(
+    DASHBOARD_PRELOAD_TARGETS.map((targetKey) =>
+      preloadDashboardPageResource(targetKey, { loader: loaders[targetKey] }),
+    ),
+  );
+}
+
+export function publishReusablePageState(targetKey, state) {
+  assertTargetKey(targetKey);
+  const target = session.targets[targetKey];
+  const status = state?.status || "fulfilled";
+  const cacheEntry = {
+    targetKey,
+    status,
+    data: state?.data ?? null,
+    error: normalizeError(state?.error),
+    source: normalizePageStateSource(state?.source, "silent-preload"),
+    generatedAt: normalizeGeneratedAt(state?.generatedAt),
+    updatedAt: Date.now(),
+    contextKey: state?.contextKey || buildDashboardPreloadContextKey(targetKey),
+  };
+
+  target.stateStatus = status;
+  if (status === "rejected") {
+    target.error = cacheEntry.error;
+  } else if (status === "skipped") {
+    target.error = cacheEntry.error;
+  } else if (status === "fulfilled") {
+    target.error = null;
+    session.cache.write(cacheEntry, { activeContextKey: state?.activeContextKey });
+  }
+  return cloneCacheEntry(cacheEntry);
+}
+
+export function readReusablePageState(targetKey, contextKey) {
+  assertTargetKey(targetKey);
+  return session.cache.read(targetKey, contextKey);
+}
+
+export function consumeReusablePageState(targetKey, contextKey) {
+  return readReusablePageState(targetKey, contextKey);
+}
+
+export function discardReusablePageState(targetKey, contextKey) {
+  assertTargetKey(targetKey);
+  const target = session.targets[targetKey];
+  let discarded = false;
+  if (target.pendingStateContextKey === contextKey) {
+    target.stateRequestId += 1;
+    target.statePromise = null;
+    target.pendingStateContextKey = null;
+    if (target.stateStatus === "pending") {
+      target.stateStatus = "idle";
+    }
+    discarded = true;
+  }
+  return discarded;
+}
+
+export function publishUsageLimitsPreloadState(data, options = {}) {
+  return publishReusablePageState("limits", {
+    data,
+    source: options.source || "dashboard-existing",
+    contextKey: options.contextKey || getUsageLimitsPreloadContextKey(options.context || {}),
+    generatedAt: options.generatedAt,
+    status: options.status || "fulfilled",
+    error: options.error,
+  });
+}
+
+export function getUsageLimitsPreloadContextKey(context = {}) {
+  return buildDashboardPreloadContextKey("limits", { state: "current", ...context });
+}
+
+export function readUsageLimitsPreloadState(contextKey = getUsageLimitsPreloadContextKey()) {
+  return readReusablePageState("limits", contextKey);
+}
+
+export function publishLeaderboardPreloadState(data, options = {}) {
+  return publishReusablePageState("leaderboard", {
+    activeContextKey: options.activeContextKey,
+    data,
+    source: options.source || "silent-preload",
+    contextKey: options.contextKey || getLeaderboardPreloadContextKey(options.context || {}),
+    generatedAt: options.generatedAt,
+    status: options.status || "fulfilled",
+    error: options.error,
+  });
+}
+
+export function readLeaderboardPreloadState(contextKey) {
+  return readReusablePageState("leaderboard", contextKey);
+}
+
+export function consumeLeaderboardPreloadState(contextKey) {
+  return consumeReusablePageState("leaderboard", contextKey);
+}
+
+export function discardLeaderboardPreloadState(contextKey) {
+  return discardReusablePageState("leaderboard", contextKey);
+}
+
+export function getLeaderboardPreloadPageSize() {
+  if (typeof window === "undefined") return LEADERBOARD_DEFAULT_PAGE_SIZE;
+  try {
+    const raw = window.localStorage.getItem(LEADERBOARD_PAGE_SIZE_STORAGE_KEY);
+    const pageSize = Number(raw);
+    if (LEADERBOARD_PAGE_SIZE_OPTIONS.includes(pageSize)) return pageSize;
+  } catch {
+    // Ignore storage errors and keep the page's default page size.
+  }
+  return LEADERBOARD_DEFAULT_PAGE_SIZE;
+}
+
+function getLeaderboardPreloadUserId(options = {}) {
+  const explicitUserId = options.userId;
+  if (explicitUserId !== undefined) return explicitUserId || null;
+  return options.cloudUser?.id || null;
+}
+
+function getLeaderboardPreloadAccessMode(options = {}) {
+  if (typeof options.accessMode === "string" && options.accessMode.trim()) {
+    return options.accessMode.trim();
+  }
+  if (Boolean(options.mockEnabled)) return "mock";
+  if (options.baseUrl) return "cloud";
+  return "unavailable";
+}
+
+export function getLeaderboardPreloadContextKey(options = {}) {
+  const mockEnabled = Boolean(options.mockEnabled);
+  const baseUrl = options.baseUrl ?? "";
+  return buildDashboardPreloadContextKey("leaderboard", {
+    accessMode: getLeaderboardPreloadAccessMode({ ...options, baseUrl, mockEnabled }),
+    baseUrl,
+    mockEnabled,
+    offset: options.offset ?? LEADERBOARD_DEFAULT_OFFSET,
+    pageSize: options.pageSize ?? getLeaderboardPreloadPageSize(),
+    period: options.period || LEADERBOARD_DEFAULT_PERIOD,
+    userId: getLeaderboardPreloadUserId(options),
+  });
+}
+
+function publishSkippedLeaderboardState(reason, contextKey) {
+  const target = session.targets.leaderboard;
+  target.stateRequestId += 1;
+  target.statePromise = null;
+  target.pendingStateContextKey = null;
+  return publishLeaderboardPreloadState(null, {
+    contextKey,
+    status: "skipped",
+    error: reason,
+  });
+}
+
+export function preloadLeaderboardDefaultState(options = {}) {
+  const mockEnabled = Boolean(options.mockEnabled);
+  const baseUrl = options.baseUrl ?? "";
+  const accessMode = getLeaderboardPreloadAccessMode({ ...options, baseUrl, mockEnabled });
+  const period = options.period || LEADERBOARD_DEFAULT_PERIOD;
+  const pageSize = options.pageSize ?? getLeaderboardPreloadPageSize();
+  const offset = options.offset ?? LEADERBOARD_DEFAULT_OFFSET;
+  const userId = getLeaderboardPreloadUserId(options);
+  const contextKey = getLeaderboardPreloadContextKey({
+    accessMode,
+    baseUrl,
+    mockEnabled,
+    offset,
+    pageSize,
+    period,
+    userId,
+  });
+
+  if (!mockEnabled && options.authLoading) {
+    return Promise.resolve(publishSkippedLeaderboardState("auth-loading", contextKey));
+  }
+  if (!mockEnabled && !options.signedIn && accessMode !== "public") {
+    return Promise.resolve(publishSkippedLeaderboardState("not-signed-in", contextKey));
+  }
+  if (!mockEnabled && !baseUrl) {
+    return Promise.resolve(publishSkippedLeaderboardState("missing-base-url", contextKey));
+  }
+  if (!mockEnabled && accessMode === "unavailable") {
+    return Promise.resolve(publishSkippedLeaderboardState("access-unavailable", contextKey));
+  }
+
+  const target = session.targets.leaderboard;
+  const existing = readLeaderboardPreloadState(contextKey);
+  if (existing) return Promise.resolve(existing);
+  if (
+    target.stateStatus === "pending" &&
+    target.statePromise &&
+    target.pendingStateContextKey === contextKey
+  ) {
+    return target.statePromise;
+  }
+
+  const requestId = target.stateRequestId + 1;
+  target.stateRequestId = requestId;
+  target.stateStatus = "pending";
+  target.pendingStateContextKey = contextKey;
+  target.error = null;
+
+  const promise = Promise.resolve()
+    .then(() =>
+      getLeaderboard({
+        baseUrl,
+        userId,
+        period,
+        limit: pageSize,
+        offset,
+      }),
+    )
+    .then((data) => {
+      if (target.stateRequestId !== requestId || target.statePromise !== promise) {
+        return null;
+      }
+      target.pendingStateContextKey = null;
+      return publishLeaderboardPreloadState(data, { contextKey });
+    })
+    .catch((error) => {
+      if (target.stateRequestId !== requestId || target.statePromise !== promise) {
+        return null;
+      }
+      target.pendingStateContextKey = null;
+      publishLeaderboardPreloadState(null, {
+        contextKey,
+        status: "rejected",
+        error,
+      });
+      return null;
+    });
+
+  target.statePromise = promise;
+  return promise;
+}

--- a/dashboard/src/lib/dashboard-preload.js
+++ b/dashboard/src/lib/dashboard-preload.js
@@ -64,6 +64,17 @@ class WindowSessionCache {
     this.evictLeaderboardEntries(options.activeContextKey || entry.contextKey);
   }
 
+  delete(targetKey, contextKey) {
+    assertTargetKey(targetKey);
+    if (targetKey === "limits") {
+      if (this.limits?.contextKey !== contextKey) return false;
+      this.limits = null;
+      return true;
+    }
+    if (!contextKey) return false;
+    return this.leaderboard.delete(contextKey);
+  }
+
   evictLeaderboardEntries(activeContextKey = null) {
     while (this.leaderboard.size > this.leaderboardMaxEntries) {
       const evictionKey =
@@ -298,7 +309,7 @@ export function publishReusablePageState(targetKey, state) {
     source: normalizePageStateSource(state?.source, "silent-preload"),
     generatedAt: normalizeGeneratedAt(state?.generatedAt),
     updatedAt: Date.now(),
-    contextKey: state?.contextKey || buildDashboardPreloadContextKey(targetKey),
+    contextKey: state?.contextKey || buildDashboardPreloadContextKey(targetKey, state?.context || {}),
   };
 
   target.stateStatus = status;
@@ -325,7 +336,7 @@ export function consumeReusablePageState(targetKey, contextKey) {
 export function discardReusablePageState(targetKey, contextKey) {
   assertTargetKey(targetKey);
   const target = session.targets[targetKey];
-  let discarded = false;
+  let discarded = session.cache.delete(targetKey, contextKey);
   if (target.pendingStateContextKey === contextKey) {
     target.stateRequestId += 1;
     target.statePromise = null;
@@ -435,6 +446,7 @@ function publishSkippedLeaderboardState(reason, contextKey) {
 }
 
 export function preloadLeaderboardDefaultState(options = {}) {
+  const sessionAtStart = session;
   const mockEnabled = Boolean(options.mockEnabled);
   const baseUrl = options.baseUrl ?? "";
   const accessMode = getLeaderboardPreloadAccessMode({ ...options, baseUrl, mockEnabled });
@@ -465,7 +477,7 @@ export function preloadLeaderboardDefaultState(options = {}) {
     return Promise.resolve(publishSkippedLeaderboardState("access-unavailable", contextKey));
   }
 
-  const target = session.targets.leaderboard;
+  const target = sessionAtStart.targets.leaderboard;
   const existing = readLeaderboardPreloadState(contextKey);
   if (existing) return Promise.resolve(existing);
   if (
@@ -493,14 +505,22 @@ export function preloadLeaderboardDefaultState(options = {}) {
       }),
     )
     .then((data) => {
-      if (target.stateRequestId !== requestId || target.statePromise !== promise) {
+      if (
+        session !== sessionAtStart ||
+        target.stateRequestId !== requestId ||
+        target.statePromise !== promise
+      ) {
         return null;
       }
       target.pendingStateContextKey = null;
       return publishLeaderboardPreloadState(data, { contextKey });
     })
     .catch((error) => {
-      if (target.stateRequestId !== requestId || target.statePromise !== promise) {
+      if (
+        session !== sessionAtStart ||
+        target.stateRequestId !== requestId ||
+        target.statePromise !== promise
+      ) {
         return null;
       }
       target.pendingStateContextKey = null;

--- a/dashboard/src/lib/dashboard-preload.leaderboard.test.js
+++ b/dashboard/src/lib/dashboard-preload.leaderboard.test.js
@@ -1,0 +1,332 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getDashboardPreloadSnapshot,
+  getLeaderboardPreloadContextKey,
+  getLeaderboardPreloadPageSize,
+  preloadLeaderboardDefaultState,
+  publishLeaderboardPreloadState,
+  readLeaderboardPreloadState,
+  resetDashboardPreload,
+} from "./dashboard-preload.js";
+import { getLeaderboard } from "./api";
+
+vi.mock("./api", () => ({
+  getLeaderboard: vi.fn(),
+}));
+
+describe("leaderboard default state preload", () => {
+  beforeEach(() => {
+    resetDashboardPreload();
+    getLeaderboard.mockReset();
+    window.localStorage.clear();
+  });
+
+  it("builds the default leaderboard context from period, page size, offset, user, mock, base URL and access mode", async () => {
+    window.localStorage.setItem("tokentracker:leaderboard:pageSize", "50");
+    const data = {
+      entries: [{ rank: 1, display_name: "Ada", total_tokens: 1200 }],
+      page: 1,
+      total_pages: 1,
+      total_entries: 1,
+    };
+    getLeaderboard.mockResolvedValue(data);
+
+    const contextKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+
+    expect(getLeaderboardPreloadPageSize()).toBe(50);
+    expect(contextKey).toBe(
+      "leaderboard:accessMode=cloud|baseUrl=https://edge.example|mockEnabled=false|offset=0|pageSize=50|period=total|userId=user-1",
+    );
+
+    await expect(
+      preloadLeaderboardDefaultState({
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: "user-1",
+      }),
+    ).resolves.toMatchObject({
+      status: "fulfilled",
+      data,
+      contextKey,
+    });
+
+    expect(getLeaderboard).toHaveBeenCalledWith({
+      baseUrl: "https://edge.example",
+      userId: "user-1",
+      period: "total",
+      limit: 50,
+      offset: 0,
+    });
+    expect(getLeaderboard.mock.calls[0][0]).not.toHaveProperty("accessToken");
+    expect(getLeaderboard.mock.calls[0][0]).not.toHaveProperty("Authorization");
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data });
+  });
+
+  it("separates readable leaderboard cache by every data access context dimension", () => {
+    const baseOptions = {
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      offset: 0,
+      pageSize: 20,
+      period: "total",
+      userId: "user-1",
+    };
+    const contextKey = getLeaderboardPreloadContextKey(baseOptions);
+    const data = { entries: [{ rank: 1, display_name: "Ada" }], page: 1 };
+
+    publishLeaderboardPreloadState(data, { contextKey });
+
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+      status: "fulfilled",
+      data,
+    });
+
+    for (const variant of [
+      { period: "week" },
+      { pageSize: 50 },
+      { offset: 20 },
+      { userId: "user-2" },
+      { baseUrl: "https://other.example" },
+      { mockEnabled: true, accessMode: "mock" },
+      { accessMode: "public" },
+    ]) {
+      const variantKey = getLeaderboardPreloadContextKey({
+        ...baseOptions,
+        ...variant,
+      });
+
+      expect(variantKey).not.toBe(contextKey);
+      expect(readLeaderboardPreloadState(variantKey)).toBeNull();
+    }
+  });
+
+  it("skips silently when no leaderboard base URL is configured outside mock mode", async () => {
+    await expect(
+      preloadLeaderboardDefaultState({
+        baseUrl: "",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: "user-1",
+      }),
+    ).resolves.toMatchObject({ status: "skipped" });
+
+    expect(getLeaderboard).not.toHaveBeenCalled();
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      stateStatus: "skipped",
+      error: "missing-base-url",
+    });
+    expect(readLeaderboardPreloadState(getLeaderboardPreloadContextKey({ baseUrl: "", mockEnabled: false }))).toBeNull();
+  });
+
+  it("allows mock leaderboard preload while cloud auth is still loading", async () => {
+    getLeaderboard.mockResolvedValue({ entries: [], page: 1, total_entries: 0 });
+
+    await expect(
+      preloadLeaderboardDefaultState({
+        baseUrl: "",
+        mockEnabled: true,
+        signedIn: false,
+        authLoading: true,
+        userId: null,
+      }),
+    ).resolves.toMatchObject({ status: "fulfilled" });
+
+    expect(getLeaderboard).toHaveBeenCalledWith({
+      baseUrl: "",
+      userId: null,
+      period: "total",
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("allows signed-out public leaderboard preload when a base URL is configured", async () => {
+    const data = { entries: [{ rank: 1, display_name: "Public User" }], page: 1, total_entries: 1 };
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "public",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: null,
+    });
+    getLeaderboard.mockResolvedValue(data);
+
+    await expect(
+      preloadLeaderboardDefaultState({
+        accessMode: "public",
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: false,
+        authLoading: false,
+        userId: null,
+      }),
+    ).resolves.toMatchObject({
+      status: "fulfilled",
+      data,
+      contextKey,
+    });
+
+    expect(getLeaderboard).toHaveBeenCalledWith({
+      baseUrl: "https://edge.example",
+      userId: null,
+      period: "total",
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("records fetch failures without throwing to callers or readable page state", async () => {
+    getLeaderboard.mockRejectedValue(new Error("network down"));
+
+    await expect(
+      preloadLeaderboardDefaultState({
+        baseUrl: "https://edge.example",
+        mockEnabled: false,
+        signedIn: true,
+        authLoading: false,
+        userId: "user-1",
+      }),
+    ).resolves.toBeNull();
+
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      stateStatus: "rejected",
+      error: "network down",
+    });
+    expect(
+      readLeaderboardPreloadState(
+        getLeaderboardPreloadContextKey({
+          baseUrl: "https://edge.example",
+          mockEnabled: false,
+          userId: "user-1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("does not let rejected leaderboard state overwrite an existing fulfilled cache entry", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    const data = { entries: [{ rank: 1, display_name: "Ada" }], page: 1 };
+
+    publishLeaderboardPreloadState(data, { contextKey });
+    publishLeaderboardPreloadState(null, {
+      contextKey,
+      status: "rejected",
+      error: "network down",
+    });
+
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      stateStatus: "rejected",
+      error: "network down",
+    });
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+      status: "fulfilled",
+      data,
+      contextKey,
+    });
+  });
+
+  it("reads fulfilled leaderboard state repeatedly without consuming it", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    const data = { entries: [{ rank: 1, display_name: "Ada" }], page: 1 };
+
+    publishLeaderboardPreloadState(data, { contextKey });
+
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data });
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data });
+  });
+
+  it("evicts older leaderboard contexts when the window-session cache reaches its configured max", () => {
+    resetDashboardPreload({ leaderboardMaxEntries: 2 });
+    const firstKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "total",
+      userId: "user-1",
+    });
+    const secondKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "week",
+      userId: "user-1",
+    });
+    const thirdKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "month",
+      userId: "user-1",
+    });
+
+    publishLeaderboardPreloadState({ entries: [{ display_name: "First" }] }, { contextKey: firstKey });
+    publishLeaderboardPreloadState({ entries: [{ display_name: "Second" }] }, { contextKey: secondKey });
+    publishLeaderboardPreloadState({ entries: [{ display_name: "Third" }] }, { contextKey: thirdKey });
+
+    expect(getDashboardPreloadSnapshot().cache.leaderboard).toMatchObject({
+      maxEntries: 2,
+      size: 2,
+      keys: [secondKey, thirdKey],
+    });
+    expect(readLeaderboardPreloadState(firstKey)).toBeNull();
+    expect(readLeaderboardPreloadState(secondKey)).toMatchObject({
+      data: { entries: [{ display_name: "Second" }] },
+    });
+    expect(readLeaderboardPreloadState(thirdKey)).toMatchObject({
+      data: { entries: [{ display_name: "Third" }] },
+    });
+  });
+
+  it("does not evict the active leaderboard context when trimming old entries", () => {
+    resetDashboardPreload({ leaderboardMaxEntries: 2 });
+    const activeKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "total",
+      userId: "user-1",
+    });
+    const oldKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "week",
+      userId: "user-1",
+    });
+    const newKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "month",
+      userId: "user-1",
+    });
+
+    publishLeaderboardPreloadState({ entries: [{ display_name: "Active" }] }, { contextKey: activeKey });
+    publishLeaderboardPreloadState({ entries: [{ display_name: "Old" }] }, { contextKey: oldKey });
+    publishLeaderboardPreloadState(
+      { entries: [{ display_name: "New" }] },
+      {
+        activeContextKey: activeKey,
+        contextKey: newKey,
+      },
+    );
+
+    expect(getDashboardPreloadSnapshot().cache.leaderboard.keys).toEqual([activeKey, newKey]);
+    expect(readLeaderboardPreloadState(activeKey)).toMatchObject({
+      data: { entries: [{ display_name: "Active" }] },
+    });
+    expect(readLeaderboardPreloadState(oldKey)).toBeNull();
+    expect(readLeaderboardPreloadState(newKey)).toMatchObject({
+      data: { entries: [{ display_name: "New" }] },
+    });
+  });
+});

--- a/dashboard/src/lib/dashboard-preload.leaderboard.test.js
+++ b/dashboard/src/lib/dashboard-preload.leaderboard.test.js
@@ -14,6 +14,16 @@ vi.mock("./api", () => ({
   getLeaderboard: vi.fn(),
 }));
 
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe("leaderboard default state preload", () => {
   beforeEach(() => {
     resetDashboardPreload();
@@ -208,6 +218,37 @@ describe("leaderboard default state preload", () => {
         }),
       ),
     ).toBeNull();
+  });
+
+  it("does not let an in-flight preload repopulate cache after reset", async () => {
+    const pending = deferred();
+    const data = { entries: [{ rank: 1, display_name: "Ada" }], page: 1 };
+    const contextKey = getLeaderboardPreloadContextKey({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    getLeaderboard.mockReturnValue(pending.promise);
+
+    const preload = preloadLeaderboardDefaultState({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      signedIn: true,
+      authLoading: false,
+      userId: "user-1",
+    });
+    await Promise.resolve();
+    expect(getDashboardPreloadSnapshot().targets.leaderboard.stateStatus).toBe("pending");
+
+    resetDashboardPreload();
+    pending.resolve(data);
+
+    await expect(preload).resolves.toBeNull();
+    expect(readLeaderboardPreloadState(contextKey)).toBeNull();
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      stateStatus: "idle",
+      error: null,
+    });
   });
 
   it("does not let rejected leaderboard state overwrite an existing fulfilled cache entry", () => {

--- a/dashboard/src/lib/dashboard-preload.silent.test.js
+++ b/dashboard/src/lib/dashboard-preload.silent.test.js
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  preloadDashboardPageResource,
+  preloadLeaderboardDefaultState,
+  resetDashboardPreload,
+} from "./dashboard-preload.js";
+import { getLeaderboard } from "./api";
+import { runCloudUsageSyncNow } from "./cloud-sync";
+import { refreshLeaderboard } from "./api";
+
+vi.mock("./api", () => ({
+  getLeaderboard: vi.fn(),
+  refreshLeaderboard: vi.fn(),
+}));
+
+vi.mock("./cloud-sync", () => ({
+  runCloudUsageSyncNow: vi.fn(),
+}));
+
+describe("dashboard preload silent side effects", () => {
+  beforeEach(() => {
+    resetDashboardPreload();
+    getLeaderboard.mockReset();
+    refreshLeaderboard.mockReset();
+    runCloudUsageSyncNow.mockReset();
+  });
+
+  it("preloads leaderboard data directly without mounting the page or triggering visible side effects", async () => {
+    const pageLoader = vi.fn(() => Promise.resolve({ LeaderboardPage: () => null }));
+    const openLoginModal = vi.fn();
+    const navigate = vi.fn();
+    const toast = vi.fn();
+    getLeaderboard.mockResolvedValue({ entries: [], page: 1, total_entries: 0 });
+
+    await preloadDashboardPageResource("leaderboard", { loader: pageLoader });
+    await preloadLeaderboardDefaultState({
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      signedIn: true,
+      authLoading: false,
+      userId: "user-1",
+      openLoginModal,
+      navigate,
+      toast,
+    });
+
+    expect(pageLoader).toHaveBeenCalledTimes(1);
+    expect(getLeaderboard).toHaveBeenCalledTimes(1);
+    expect(openLoginModal).not.toHaveBeenCalled();
+    expect(runCloudUsageSyncNow).not.toHaveBeenCalled();
+    expect(refreshLeaderboard).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/lib/dashboard-preload.test.js
+++ b/dashboard/src/lib/dashboard-preload.test.js
@@ -1,0 +1,385 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildDashboardPreloadContextKey,
+  getUsageLimitsPreloadContextKey,
+  getDashboardPreloadSnapshot,
+  preloadDashboardPageResource,
+  publishLeaderboardPreloadState,
+  publishUsageLimitsPreloadState,
+  readLeaderboardPreloadState,
+  readUsageLimitsPreloadState,
+  resetDashboardPreload,
+  skipDashboardPreloadTarget,
+} from "./dashboard-preload.js";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("dashboard preload state", () => {
+  beforeEach(() => {
+    resetDashboardPreload();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("initializes fixed targets with idle resource and window-session cache status", () => {
+    expect(getDashboardPreloadSnapshot()).toMatchObject({
+      cache: {
+        limits: null,
+        leaderboard: {
+          maxEntries: 20,
+          size: 0,
+        },
+      },
+      targets: {
+        limits: { resourceStatus: "idle", stateStatus: "idle", error: null },
+        leaderboard: { resourceStatus: "idle", stateStatus: "idle", error: null },
+      },
+    });
+  });
+
+  it("publishes reusable state only for a matching context key", () => {
+    const contextKey = buildDashboardPreloadContextKey("limits", {
+      baseUrl: "http://localhost:7680",
+      mode: "local",
+    });
+    const data = { usage: { daily: 10 } };
+
+    publishUsageLimitsPreloadState(data, { contextKey, source: "dashboard-existing" });
+
+    expect(readUsageLimitsPreloadState(contextKey)).toMatchObject({
+      targetKey: "limits",
+      status: "fulfilled",
+      data,
+      error: null,
+      source: "dashboard-existing",
+      contextKey,
+    });
+    expect(readUsageLimitsPreloadState(`${contextKey}|stale`)).toBeNull();
+  });
+
+  it("reads fulfilled usage limits cache repeatedly without consuming it", () => {
+    const data = { usage: { daily: 10 } };
+
+    publishUsageLimitsPreloadState(data, { source: "dashboard-existing" });
+
+    expect(readUsageLimitsPreloadState()).toMatchObject({
+      status: "fulfilled",
+      data,
+      source: "dashboard-existing",
+    });
+    expect(readUsageLimitsPreloadState()).toMatchObject({
+      status: "fulfilled",
+      data,
+      source: "dashboard-existing",
+    });
+  });
+
+  it("uses the default limits context when publishing and reading usage limits state", () => {
+    const data = { usage: { daily: 12 } };
+
+    publishUsageLimitsPreloadState(data);
+
+    expect(getUsageLimitsPreloadContextKey()).toBe(
+      buildDashboardPreloadContextKey("limits", { state: "current" }),
+    );
+    expect(readUsageLimitsPreloadState()).toMatchObject({
+      targetKey: "limits",
+      status: "fulfilled",
+      data,
+      source: "dashboard-existing",
+      contextKey: getUsageLimitsPreloadContextKey(),
+    });
+  });
+
+  it("keeps fulfilled window-session cache readable without a freshness TTL", () => {
+    const data = { usage: { daily: 12 } };
+
+    publishUsageLimitsPreloadState(data, {
+      generatedAt: Date.now() - 24 * 60 * 60 * 1000,
+    });
+
+    expect(readUsageLimitsPreloadState()).toMatchObject({
+      status: "fulfilled",
+      data,
+    });
+  });
+
+  it("supports all window-session cache write sources for fulfilled state", () => {
+    for (const source of ["dashboard-existing", "silent-preload", "page-load", "manual-refresh"]) {
+      const data = { source };
+
+      publishUsageLimitsPreloadState(data, { source });
+
+      expect(readUsageLimitsPreloadState()).toMatchObject({
+        status: "fulfilled",
+        data,
+        source,
+      });
+    }
+  });
+
+  it("does not let rejected usage limits results overwrite an existing fulfilled cache", () => {
+    const data = { usage: { daily: 12 } };
+
+    publishUsageLimitsPreloadState(data, { source: "page-load" });
+    publishUsageLimitsPreloadState(null, {
+      status: "rejected",
+      source: "manual-refresh",
+      error: "network down",
+    });
+
+    expect(getDashboardPreloadSnapshot().targets.limits).toMatchObject({
+      stateStatus: "rejected",
+      error: "network down",
+    });
+    expect(readUsageLimitsPreloadState()).toMatchObject({
+      status: "fulfilled",
+      data,
+      source: "page-load",
+    });
+  });
+
+  it("clears window-session cache on reset", () => {
+    const firstSessionId = getDashboardPreloadSnapshot().sessionId;
+    publishUsageLimitsPreloadState({ usage: { daily: 12 } });
+
+    resetDashboardPreload();
+
+    expect(getDashboardPreloadSnapshot().sessionId).not.toBe(firstSessionId);
+    expect(readUsageLimitsPreloadState()).toBeNull();
+  });
+
+  it("keeps preloaded leaderboard state readable inside the same window session", () => {
+    const data = { rows: [{ user_id: "user-1", total_tokens: 100 }] };
+    const contextKey = buildDashboardPreloadContextKey("leaderboard", {
+      offset: 0,
+      pageSize: 20,
+      period: "total",
+      userId: "user-1",
+    });
+
+    publishLeaderboardPreloadState(data, {
+      contextKey,
+      generatedAt: Date.now() - 30_000,
+    });
+
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+      status: "fulfilled",
+      data,
+    });
+  });
+
+  it("keeps leaderboard state scoped by context key", () => {
+    const contextKey = buildDashboardPreloadContextKey("leaderboard", {
+      offset: 0,
+      pageSize: 50,
+      period: "week",
+      userId: "user-1",
+    });
+    const data = { rows: [{ user_id: "user-1", total_tokens: 100 }] };
+
+    publishLeaderboardPreloadState(data, { contextKey, source: "silent-preload" });
+
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+      targetKey: "leaderboard",
+      status: "fulfilled",
+      data,
+      source: "silent-preload",
+      contextKey,
+    });
+    expect(
+      readLeaderboardPreloadState(
+        buildDashboardPreloadContextKey("leaderboard", {
+          offset: 50,
+          pageSize: 50,
+          period: "week",
+          userId: "user-1",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("reuses pending and fulfilled resource preloads for duplicate calls", async () => {
+    const pending = deferred();
+    const loader = vi.fn(() => pending.promise);
+
+    const first = preloadDashboardPageResource("limits", { loader });
+    const second = preloadDashboardPageResource("limits", { loader });
+
+    expect(first).toBe(second);
+    await Promise.resolve();
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(getDashboardPreloadSnapshot().targets.limits.resourceStatus).toBe("pending");
+
+    pending.resolve({ LimitsPage: () => null });
+    await expect(first).resolves.toEqual({ LimitsPage: expect.any(Function) });
+
+    const fulfilled = preloadDashboardPageResource("limits", { loader });
+    await expect(fulfilled).resolves.toEqual({ LimitsPage: expect.any(Function) });
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(getDashboardPreloadSnapshot().targets.limits.resourceStatus).toBe("fulfilled");
+  });
+
+  it("records resource failures internally without throwing to callers", async () => {
+    const loader = vi.fn(() => Promise.reject(new Error("chunk unavailable")));
+
+    await expect(preloadDashboardPageResource("leaderboard", { loader })).resolves.toBeNull();
+
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      resourceStatus: "rejected",
+      error: "chunk unavailable",
+    });
+  });
+
+  it("keeps skipped targets silent and reusable reads ignorable", async () => {
+    skipDashboardPreloadTarget("leaderboard", "auth-loading");
+
+    await expect(preloadDashboardPageResource("leaderboard", { loader: vi.fn() })).resolves.toBeNull();
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      resourceStatus: "skipped",
+      stateStatus: "skipped",
+      error: "auth-loading",
+    });
+    expect(readLeaderboardPreloadState("leaderboard:any")).toBeNull();
+  });
+
+  it("does not let skipped state overwrite existing fulfilled page data cache", () => {
+    const contextKey = buildDashboardPreloadContextKey("leaderboard", {
+      offset: 0,
+      pageSize: 20,
+      period: "total",
+    });
+    const data = { rows: [{ user_id: "user-1", total_tokens: 100 }] };
+
+    publishLeaderboardPreloadState(data, { contextKey });
+    publishLeaderboardPreloadState(null, {
+      contextKey,
+      status: "skipped",
+      error: "auth-loading",
+    });
+
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      stateStatus: "skipped",
+      error: "auth-loading",
+    });
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+      status: "fulfilled",
+      data,
+    });
+  });
+
+  it("does not let stale pending resource preload overwrite a newer skipped target", async () => {
+    const pending = deferred();
+    const loader = vi.fn(() => pending.promise);
+    const preload = preloadDashboardPageResource("limits", { loader });
+
+    await Promise.resolve();
+    skipDashboardPreloadTarget("limits", "not-eligible");
+    pending.resolve({ LimitsPage: () => null });
+
+    await expect(preload).resolves.toBeNull();
+    expect(getDashboardPreloadSnapshot().targets.limits).toMatchObject({
+      resourceStatus: "skipped",
+      stateStatus: "skipped",
+      error: "not-eligible",
+    });
+  });
+
+  it("keeps page data cache separate when resource preload fails", async () => {
+    const data = { usage: { daily: 12 } };
+    const loader = vi.fn(() => Promise.reject(new Error("chunk unavailable")));
+
+    publishUsageLimitsPreloadState(data);
+    await expect(preloadDashboardPageResource("limits", { loader })).resolves.toBeNull();
+
+    expect(getDashboardPreloadSnapshot().targets.limits).toMatchObject({
+      resourceStatus: "rejected",
+      stateStatus: "fulfilled",
+      error: "chunk unavailable",
+    });
+    expect(readUsageLimitsPreloadState()).toMatchObject({
+      status: "fulfilled",
+      data,
+    });
+  });
+
+  it("clears stale target errors when window-session cache becomes fulfilled", () => {
+    const contextKey = buildDashboardPreloadContextKey("leaderboard", {
+      offset: 0,
+      pageSize: 50,
+      period: "week",
+    });
+
+    publishLeaderboardPreloadState(null, {
+      contextKey,
+      status: "rejected",
+      error: "network down",
+    });
+    expect(getDashboardPreloadSnapshot().targets.leaderboard.error).toBe("network down");
+
+    publishLeaderboardPreloadState({ rows: [] }, { contextKey });
+
+    expect(getDashboardPreloadSnapshot().targets.leaderboard).toMatchObject({
+      stateStatus: "fulfilled",
+      error: null,
+    });
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+      status: "fulfilled",
+      data: { rows: [] },
+      error: null,
+    });
+  });
+
+  it("does not persist page data cache to browser storage, IndexedDB, or a server", () => {
+    const localStorageSetItem = vi.spyOn(Storage.prototype, "setItem");
+    const fetchSpy = vi.fn();
+    const indexedDB = {
+      open: vi.fn(),
+      deleteDatabase: vi.fn(),
+    };
+    vi.stubGlobal("fetch", fetchSpy);
+    vi.stubGlobal("indexedDB", indexedDB);
+
+    publishUsageLimitsPreloadState({ usage: { daily: 12 } });
+    publishLeaderboardPreloadState(
+      { rows: [{ user_id: "user-1", total_tokens: 100 }] },
+      {
+        contextKey: buildDashboardPreloadContextKey("leaderboard", {
+          offset: 0,
+          pageSize: 20,
+          period: "total",
+        }),
+      },
+    );
+
+    expect(readUsageLimitsPreloadState()).toMatchObject({ status: "fulfilled" });
+    expect(localStorageSetItem).not.toHaveBeenCalled();
+    expect(indexedDB.open).not.toHaveBeenCalled();
+    expect(indexedDB.deleteDatabase).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("dashboard preload route boundary", () => {
+  it("keeps NativeAuthCallbackPage eager-imported while target pages stay lazy-loaded", () => {
+    const appSource = readFileSync(join(process.cwd(), "src/App.jsx"), "utf8");
+
+    expect(appSource).toContain('import { NativeAuthCallbackPage } from "./pages/NativeAuthCallbackPage.jsx";');
+    expect(appSource).not.toMatch(/const\s+NativeAuthCallbackPage\s*=\s*lazy\(/);
+    expect(appSource).toContain('import("./pages/LimitsPage.jsx")');
+    expect(appSource).toContain('import("./pages/LeaderboardPage.jsx")');
+  });
+});

--- a/dashboard/src/lib/dashboard-preload.test.js
+++ b/dashboard/src/lib/dashboard-preload.test.js
@@ -3,12 +3,15 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildDashboardPreloadContextKey,
+  discardLeaderboardPreloadState,
   getUsageLimitsPreloadContextKey,
   getDashboardPreloadSnapshot,
   preloadDashboardPageResource,
   publishLeaderboardPreloadState,
+  publishReusablePageState,
   publishUsageLimitsPreloadState,
   readLeaderboardPreloadState,
+  readReusablePageState,
   readUsageLimitsPreloadState,
   resetDashboardPreload,
   skipDashboardPreloadTarget,
@@ -210,6 +213,40 @@ describe("dashboard preload state", () => {
         }),
       ),
     ).toBeNull();
+  });
+
+  it("uses state.context when publishing generic reusable page state", () => {
+    const context = {
+      offset: 0,
+      pageSize: 50,
+      period: "week",
+      userId: "user-1",
+    };
+    const contextKey = buildDashboardPreloadContextKey("leaderboard", context);
+    const data = { rows: [{ user_id: "user-1", total_tokens: 100 }] };
+
+    publishReusablePageState("leaderboard", { data, context });
+
+    expect(readReusablePageState("leaderboard", contextKey)).toMatchObject({
+      status: "fulfilled",
+      data,
+      contextKey,
+    });
+    expect(readReusablePageState("leaderboard", buildDashboardPreloadContextKey("leaderboard"))).toBeNull();
+  });
+
+  it("discards fulfilled leaderboard cache entries by context key", () => {
+    const contextKey = buildDashboardPreloadContextKey("leaderboard", {
+      offset: 0,
+      pageSize: 20,
+      period: "total",
+    });
+    const data = { rows: [{ user_id: "user-1", total_tokens: 100 }] };
+
+    publishLeaderboardPreloadState(data, { contextKey });
+
+    expect(discardLeaderboardPreloadState(contextKey)).toBe(true);
+    expect(readLeaderboardPreloadState(contextKey)).toBeNull();
   });
 
   it("reuses pending and fulfilled resource preloads for duplicate calls", async () => {

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useActivityHeatmap } from "../hooks/use-activity-heatmap.js";
 import { useProjectUsageSummary } from "../hooks/use-project-usage-summary";
 import { useTrendData } from "../hooks/use-trend-data.js";
@@ -24,6 +24,7 @@ import {
 } from "../lib/format";
 import { shouldShowInstallCard } from "../lib/install-status";
 import { getMockNow, isMockEnabled } from "../lib/mock-data";
+import { publishUsageLimitsPreloadState } from "../lib/dashboard-preload.js";
 import { buildFleetData, buildTopModels, resolveDisplayTokens } from "../lib/model-breakdown";
 import { safeWriteClipboard, safeWriteClipboardImage } from "../lib/safe-browser";
 import { isScreenshotModeEnabled } from "../lib/screenshot-mode";
@@ -117,6 +118,7 @@ export function DashboardPage({
   publicToken = null,
   signInUrl = "/sign-in",
   signUpUrl = "/sign-up",
+  onMainContentVisible,
 }) {
   const { resolvedLocale } = useLocale();
   const { currency, rate } = useCurrency();
@@ -144,6 +146,7 @@ export function DashboardPage({
   const [installCopied, setInstallCopied] = useState(false);
   const [sessionExpiredCopied, setSessionExpiredCopied] = useState(false);
   const [manualSyncLoading, setManualSyncLoading] = useState(false);
+  const mainContentVisibleNotifiedRef = useRef(false);
   const mockEnabled = isMockEnabled();
   const authTokenAllowed = signedIn && !sessionSoftExpired;
   const authAccessToken = useMemo(() => {
@@ -515,6 +518,12 @@ export function DashboardPage({
     data: usageLimits,
     refresh: refreshUsageLimits,
   } = useUsageLimits();
+
+  useEffect(() => {
+    if (usageLimits && typeof usageLimits === "object") {
+      publishUsageLimitsPreloadState(usageLimits);
+    }
+  }, [usageLimits]);
 
   const detailsDateKey = useMemo(() => {
     if (period === "day") return "hour";
@@ -1206,6 +1215,14 @@ export function DashboardPage({
   // 使用上面定义的 isLocalMode
   const requireAuthGate = !signedIn && !mockEnabled && !sessionSoftExpired && !isLocalMode;
   const showAuthGate = requireAuthGate && !publicMode;
+
+  useEffect(() => {
+    if (mainContentVisibleNotifiedRef.current) return;
+    if (showExpiredGate || showAuthGate) return;
+    if (usageLoadingState) return;
+    mainContentVisibleNotifiedRef.current = true;
+    onMainContentVisible?.();
+  }, [onMainContentVisible, showAuthGate, showExpiredGate, usageLoadingState]);
 
   return (
     <>

--- a/dashboard/src/pages/LeaderboardPage.jsx
+++ b/dashboard/src/pages/LeaderboardPage.jsx
@@ -39,6 +39,11 @@ import {
   getLeaderboard,
   refreshLeaderboard,
 } from "../lib/api";
+import {
+  getLeaderboardPreloadContextKey,
+  publishLeaderboardPreloadState,
+  readLeaderboardPreloadState,
+} from "../lib/dashboard-preload.js";
 import { getCloudSyncEnabled, setCloudSyncEnabled } from "../lib/cloud-sync-prefs";
 import { runCloudUsageSyncNow } from "../lib/cloud-sync";
 import { LeaderboardAvatar } from "../components/LeaderboardAvatar.jsx";
@@ -298,11 +303,6 @@ export function LeaderboardPage({
     }
   }, []);
   const [listReloadToken, setListReloadToken] = useState(0);
-  const [listState, setListState] = useState(() => ({
-    loading: false,
-    error: null,
-    data: null,
-  }));
 
   const [cloudSyncOn, setCloudSyncOn] = useState(() => getCloudSyncEnabled());
   const [syncing, setSyncing] = useState(false);
@@ -339,12 +339,70 @@ export function LeaderboardPage({
     const safePage = clampInt(listPage, { min: 1, max: 1_000_000, fallback: 1 });
     return (safePage - 1) * pageSize;
   }, [listPage, pageSize]);
+  const leaderboardAccessMode = useMemo(() => {
+    if (mockEnabled) return "mock";
+    if (authLoading) return "unavailable";
+    if (cloudSignedIn) return "cloud";
+    if (signedIn) return "local";
+    if (leaderboardBaseUrl) return "public";
+    return "unavailable";
+  }, [authLoading, cloudSignedIn, leaderboardBaseUrl, mockEnabled, signedIn]);
+
+  const leaderboardPreloadContextKey = useMemo(
+    () =>
+      getLeaderboardPreloadContextKey({
+        accessMode: leaderboardAccessMode,
+        baseUrl: leaderboardBaseUrl,
+        mockEnabled,
+        userId: cloudUser?.id || null,
+        period,
+        pageSize,
+        offset: listOffset,
+      }),
+    [cloudUser?.id, leaderboardAccessMode, leaderboardBaseUrl, listOffset, mockEnabled, pageSize, period],
+  );
+
+  const [listState, setListState] = useState(() => {
+    const preloadedState = readLeaderboardPreloadState(leaderboardPreloadContextKey);
+    if (preloadedState) {
+      return {
+        loading: false,
+        error: null,
+        data: preloadedState.data,
+        contextKey: leaderboardPreloadContextKey,
+      };
+    }
+    return {
+      loading: false,
+      error: null,
+      data: null,
+      contextKey: null,
+    };
+  });
 
   useEffect(() => {
     // Mock leaderboard uses local getMockLeaderboard(); real data needs InsForge URL from getLeaderboardBaseUrl().
-    if (!leaderboardBaseUrl && !mockEnabled) return;
+    if ((!leaderboardBaseUrl && !mockEnabled) || (!mockEnabled && leaderboardAccessMode === "unavailable")) {
+      setListState({ loading: false, error: null, data: null, contextKey: null });
+      return;
+    }
+    const cachedState = readLeaderboardPreloadState(leaderboardPreloadContextKey);
     let active = true;
-    setListState((prev) => ({ ...prev, loading: true, error: null }));
+    if (cachedState) {
+      setListState({
+        loading: false,
+        error: null,
+        data: cachedState.data,
+        contextKey: leaderboardPreloadContextKey,
+      });
+    } else {
+      setListState({
+        loading: true,
+        error: null,
+        data: null,
+        contextKey: null,
+      });
+    }
     (async () => {
       const data = await getLeaderboard({
         baseUrl: leaderboardBaseUrl,
@@ -354,17 +412,35 @@ export function LeaderboardPage({
         offset: listOffset,
       });
       if (!active) return;
-      setListState({ loading: false, error: null, data });
+      publishLeaderboardPreloadState(data, {
+        activeContextKey: leaderboardPreloadContextKey,
+        contextKey: leaderboardPreloadContextKey,
+        source: listReloadToken > 0 ? "manual-refresh" : "page-load",
+      });
+      setListState({
+        loading: false,
+        error: null,
+        data,
+        contextKey: leaderboardPreloadContextKey,
+      });
     })().catch((err) => {
       if (!active) return;
-      setListState({ loading: false, error: normalizeLeaderboardError(err), data: null });
+      const error = normalizeLeaderboardError(err);
+      setListState((prev) => {
+        if (prev.contextKey === leaderboardPreloadContextKey && prev.data) {
+          return { ...prev, loading: false, error };
+        }
+        return { loading: false, error, data: null, contextKey: null };
+      });
     });
     return () => {
       active = false;
     };
   }, [
     leaderboardBaseUrl,
+    leaderboardAccessMode,
     cloudUser?.id,
+    leaderboardPreloadContextKey,
     listOffset,
     listReloadToken,
     mockEnabled,
@@ -372,7 +448,35 @@ export function LeaderboardPage({
     pageSize,
   ]);
 
-  const listData = listState.data;
+  const renderCachedState = useMemo(() => {
+    if (listState.contextKey === leaderboardPreloadContextKey) return null;
+    return readLeaderboardPreloadState(leaderboardPreloadContextKey);
+  }, [leaderboardPreloadContextKey, listState.contextKey]);
+  const currentListState = useMemo(() => {
+    if (listState.contextKey === leaderboardPreloadContextKey) return listState;
+    if (renderCachedState) {
+      return {
+        loading: false,
+        error: null,
+        data: renderCachedState.data,
+        contextKey: leaderboardPreloadContextKey,
+      };
+    }
+    return {
+      loading: Boolean(leaderboardBaseUrl || mockEnabled) && leaderboardAccessMode !== "unavailable",
+      error: null,
+      data: null,
+      contextKey: leaderboardPreloadContextKey,
+    };
+  }, [
+    leaderboardAccessMode,
+    leaderboardBaseUrl,
+    leaderboardPreloadContextKey,
+    listState,
+    mockEnabled,
+    renderCachedState,
+  ]);
+  const listData = currentListState.data;
 
   const totalPages = listData?.total_pages ?? null;
   const totalEntries = listData?.total_entries ?? 0;
@@ -426,12 +530,12 @@ export function LeaderboardPage({
 
   const hasEntries = Array.isArray(displayEntries) && displayEntries.length !== 0;
   let listBody = null;
-  if (listState.loading) {
+  if (currentListState.loading && !hasEntries) {
     listBody = <LeaderboardSkeleton rows={pageSize} />;
-  } else if (listState.error) {
+  } else if (currentListState.error && !hasEntries) {
     listBody = (
       <div className="px-6 py-12 text-center">
-        <p className="text-sm text-red-500 dark:text-red-400">{listState.error}</p>
+        <p className="text-sm text-red-500 dark:text-red-400">{currentListState.error}</p>
       </div>
     );
   } else if (hasEntries) {
@@ -628,7 +732,7 @@ export function LeaderboardPage({
               : "text-oai-gray-500 dark:text-oai-gray-400 hover:bg-oai-gray-100 dark:hover:bg-oai-gray-800 hover:text-oai-black dark:hover:text-white"
           )}
           onClick={() => setListPage(p)}
-          disabled={listState.loading}
+          disabled={currentListState.loading}
         >
           {String(p)}
         </button>
@@ -675,7 +779,7 @@ export function LeaderboardPage({
                   <button
                     key={p}
                     onClick={() => handlePeriodChange(p)}
-                    disabled={listState.loading}
+                    disabled={currentListState.loading}
                     className={cn(
                       "px-3 sm:px-4 h-7 text-sm font-medium rounded-full flex items-center justify-center transition-colors relative",
                       isActive
@@ -704,7 +808,7 @@ export function LeaderboardPage({
               meLabel={meLabel}
               onOpenProfile={me?.user_id ? () => openProfileModal(me.user_id) : undefined}
               onJumpToMe={handleJumpToMe}
-              canJump={myPage != null && !onMyPage && !listState.loading}
+              canJump={myPage != null && !onMyPage && !currentListState.loading}
               className="shrink-0"
             />
           </div>
@@ -735,6 +839,11 @@ export function LeaderboardPage({
           )}
 
           <div className="rounded-xl border border-oai-gray-200 dark:border-oai-gray-800 overflow-hidden">
+            {currentListState.error && hasEntries ? (
+              <div className="border-b border-oai-gray-200 dark:border-oai-gray-800 px-6 py-3">
+                <p className="text-sm text-red-500 dark:text-red-400">{currentListState.error}</p>
+              </div>
+            ) : null}
             {listBody}
 
             <div className="px-6 py-3 border-t border-oai-gray-200 dark:border-oai-gray-800 flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
@@ -747,7 +856,7 @@ export function LeaderboardPage({
                     id="leaderboard-page-size"
                     value={pageSize}
                     onChange={(e) => setPageSize(Number(e.target.value))}
-                    disabled={listState.loading}
+                    disabled={currentListState.loading}
                     className="appearance-none pl-3 pr-8 py-1 rounded-md bg-white dark:bg-oai-gray-950 border border-oai-gray-300 dark:border-oai-gray-700 text-oai-gray-700 dark:text-oai-gray-300 hover:border-oai-gray-400 dark:hover:border-oai-gray-600 focus:outline-none focus:ring-2 focus:ring-oai-brand-500 disabled:opacity-50 transition-colors"
                   >
                     {PAGE_SIZE_OPTIONS.map((n) => (
@@ -765,12 +874,12 @@ export function LeaderboardPage({
               <button
                 className={cn(
                   "px-3 py-1.5 text-sm font-medium text-oai-gray-500 dark:text-oai-gray-400 rounded-md transition-colors",
-                  canPrev && !listState.loading
+                  canPrev && !currentListState.loading
                     ? "hover:bg-oai-gray-100 dark:hover:bg-oai-gray-800 hover:text-oai-black dark:hover:text-white"
                     : "opacity-50 cursor-not-allowed"
                 )}
                 onClick={() => setListPage((p) => Math.max(1, p - 1))}
-                disabled={!canPrev || listState.loading}
+                disabled={!canPrev || currentListState.loading}
               >
                 {copy("leaderboard.pagination.prev")}
               </button>
@@ -778,12 +887,12 @@ export function LeaderboardPage({
               <button
                 className={cn(
                   "px-3 py-1.5 text-sm font-medium text-oai-gray-500 dark:text-oai-gray-400 rounded-md transition-colors",
-                  canNext && !listState.loading
+                  canNext && !currentListState.loading
                     ? "hover:bg-oai-gray-100 dark:hover:bg-oai-gray-800 hover:text-oai-black dark:hover:text-white"
                     : "opacity-50 cursor-not-allowed"
                 )}
                 onClick={() => setListPage((p) => p + 1)}
-                disabled={!canNext || listState.loading}
+                disabled={!canNext || currentListState.loading}
               >
                 {copy("leaderboard.pagination.next")}
               </button>

--- a/dashboard/src/pages/LeaderboardPage.jsx
+++ b/dashboard/src/pages/LeaderboardPage.jsx
@@ -427,10 +427,10 @@ export function LeaderboardPage({
       if (!active) return;
       const error = normalizeLeaderboardError(err);
       setListState((prev) => {
-        if (prev.contextKey === leaderboardPreloadContextKey && prev.data) {
+        if (prev.contextKey === leaderboardPreloadContextKey) {
           return { ...prev, loading: false, error };
         }
-        return { loading: false, error, data: null, contextKey: null };
+        return { loading: false, error, data: null, contextKey: leaderboardPreloadContextKey };
       });
     });
     return () => {

--- a/dashboard/src/pages/LeaderboardPage.test.jsx
+++ b/dashboard/src/pages/LeaderboardPage.test.jsx
@@ -1,0 +1,417 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getLeaderboardPreloadContextKey,
+  publishLeaderboardPreloadState,
+  readLeaderboardPreloadState,
+  resetDashboardPreload,
+} from "../lib/dashboard-preload.js";
+import { getLeaderboard } from "../lib/api";
+import { runCloudUsageSyncNow } from "../lib/cloud-sync";
+import { LeaderboardPage } from "./LeaderboardPage.jsx";
+
+const openLoginModalMock = vi.hoisted(() => vi.fn());
+const insforgeAuthMock = vi.hoisted(() => ({
+  signedIn: true,
+  loading: false,
+  user: { id: "user-1" },
+}));
+
+vi.mock("../lib/api", () => ({
+  getLeaderboard: vi.fn(),
+  refreshLeaderboard: vi.fn(),
+}));
+
+vi.mock("../lib/cloud-sync", () => ({
+  runCloudUsageSyncNow: vi.fn(),
+}));
+
+vi.mock("../lib/config", () => ({
+  getLeaderboardBaseUrl: () => "https://edge.example",
+}));
+
+vi.mock("../lib/mock-data", () => ({
+  isMockEnabled: () => false,
+}));
+
+vi.mock("../contexts/LoginModalContext.jsx", () => ({
+  useLoginModal: () => ({ openLoginModal: openLoginModalMock }),
+}));
+
+vi.mock("../contexts/InsforgeAuthContext.jsx", () => ({
+  useInsforgeAuth: () => insforgeAuthMock,
+}));
+
+vi.mock("../hooks/useCurrency.js", () => ({
+  useCurrency: () => ({ currency: "USD", rate: 1 }),
+}));
+
+vi.mock("../components/LeaderboardSkeleton.jsx", () => ({
+  LeaderboardSkeleton: () => <div data-testid="leaderboard-skeleton" />,
+}));
+
+vi.mock("../components/LeaderboardAvatar.jsx", () => ({
+  LeaderboardAvatar: ({ displayName }) => <span data-testid="avatar">{displayName}</span>,
+}));
+
+const preloadedData = {
+  entries: [
+    {
+      rank: 1,
+      user_id: "preloaded-user",
+      display_name: "Preloaded User",
+      total_tokens: 1234,
+      estimated_cost_usd: 1.23,
+    },
+  ],
+  me: null,
+  page: 1,
+  total_pages: 1,
+  total_entries: 1,
+  from: null,
+  to: null,
+  generated_at: null,
+};
+
+function renderLeaderboard(initialEntry = "/leaderboard", props = {}) {
+  const tree = React.createElement(
+    MemoryRouter,
+    { initialEntries: [initialEntry] },
+    React.createElement(LeaderboardPage, {
+      auth: props.auth ?? null,
+      signedIn: props.signedIn ?? true,
+      sessionSoftExpired: false,
+    }),
+  );
+  return render(props.strict ? <React.StrictMode>{tree}</React.StrictMode> : tree);
+}
+
+describe("LeaderboardPage window-session cache reuse", () => {
+  beforeEach(() => {
+    resetDashboardPreload();
+    getLeaderboard.mockReset();
+    runCloudUsageSyncNow.mockReset();
+    runCloudUsageSyncNow.mockResolvedValue(undefined);
+    openLoginModalMock.mockReset();
+    insforgeAuthMock.signedIn = true;
+    insforgeAuthMock.loading = false;
+    insforgeAuthMock.user = { id: "user-1" };
+    window.localStorage.clear();
+  });
+
+  it("renders a matching cache immediately and starts a background refresh", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    renderLeaderboard("/leaderboard", { auth: () => Promise.resolve("test-token") });
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+    expect(screen.queryByTestId("leaderboard-skeleton")).not.toBeInTheDocument();
+    expect(getLeaderboard).toHaveBeenCalledWith({
+      baseUrl: "https://edge.example",
+      userId: "user-1",
+      period: "total",
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("keeps matching cache visible under React StrictMode without render-time consumption", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    renderLeaderboard("/leaderboard", { strict: true });
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+    expect(screen.queryByTestId("leaderboard-skeleton")).not.toBeInTheDocument();
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data: preloadedData });
+  });
+
+  it("updates the matching cache when the background refresh succeeds", async () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    const refreshedData = {
+      ...preloadedData,
+      entries: [
+        {
+          rank: 1,
+          user_id: "refreshed-user",
+          display_name: "Refreshed User",
+          total_tokens: 4321,
+          estimated_cost_usd: 4.32,
+        },
+      ],
+    };
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockResolvedValue(refreshedData);
+
+    renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Refreshed User").length).toBeGreaterThan(0);
+      expect(readLeaderboardPreloadState(contextKey)).toMatchObject({
+        data: refreshedData,
+        source: "page-load",
+      });
+    });
+  });
+
+  it("keeps cached data visible when the background refresh fails", async () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockRejectedValue(new Error("network down"));
+
+    renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.getByText(/network down/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("leaderboard-skeleton")).not.toBeInTheDocument();
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data: preloadedData });
+  });
+
+  it("keeps the existing loading path when the preload context does not match the page defaults", () => {
+    const staleContextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      pageSize: 50,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey: staleContextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    renderLeaderboard();
+
+    expect(screen.queryByText("Preloaded User")).not.toBeInTheDocument();
+    expect(screen.getByTestId("leaderboard-skeleton")).toBeInTheDocument();
+    expect(getLeaderboard).toHaveBeenCalledWith({
+      baseUrl: "https://edge.example",
+      userId: "user-1",
+      period: "total",
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("does not fetch or write readable cache while auth access context is unavailable", () => {
+    insforgeAuthMock.loading = true;
+    insforgeAuthMock.signedIn = false;
+    insforgeAuthMock.user = null;
+    const cloudContextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey: cloudContextKey });
+    getLeaderboard.mockResolvedValue({
+      ...preloadedData,
+      entries: [{ rank: 1, user_id: "bad", display_name: "Should Not Fetch" }],
+    });
+
+    renderLeaderboard();
+
+    expect(getLeaderboard).not.toHaveBeenCalled();
+    expect(screen.queryAllByText("Preloaded User")).toHaveLength(0);
+    expect(readLeaderboardPreloadState(cloudContextKey)).toMatchObject({ data: preloadedData });
+    expect(
+      readLeaderboardPreloadState(
+        getLeaderboardPreloadContextKey({
+          accessMode: "unavailable",
+          baseUrl: "https://edge.example",
+          mockEnabled: false,
+          userId: null,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it("keeps signed-out public leaderboard reads available when base URL is configured", async () => {
+    insforgeAuthMock.loading = false;
+    insforgeAuthMock.signedIn = false;
+    insforgeAuthMock.user = null;
+    const publicData = {
+      ...preloadedData,
+      entries: [
+        {
+          rank: 1,
+          user_id: "public-user",
+          display_name: "Public User",
+          total_tokens: 321,
+          estimated_cost_usd: 0.32,
+        },
+      ],
+    };
+    getLeaderboard.mockResolvedValue(publicData);
+
+    renderLeaderboard("/leaderboard", { signedIn: false });
+
+    await waitFor(() => {
+      expect(getLeaderboard).toHaveBeenCalledWith({
+        baseUrl: "https://edge.example",
+        userId: null,
+        period: "total",
+        limit: 20,
+        offset: 0,
+      });
+      expect(screen.getAllByText("Public User").length).toBeGreaterThan(0);
+    });
+    expect(
+      readLeaderboardPreloadState(
+        getLeaderboardPreloadContextKey({
+          accessMode: "public",
+          baseUrl: "https://edge.example",
+          mockEnabled: false,
+          userId: null,
+        }),
+      ),
+    ).toMatchObject({ data: publicData });
+  });
+
+  it("reuses matching cache again after remounting in the same window session", () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    const first = renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+
+    first.unmount();
+    renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+    expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data: preloadedData });
+  });
+
+  it("uses the matching cache for pageSize-specific contexts", () => {
+    window.localStorage.setItem("tokentracker:leaderboard:pageSize", "50");
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      pageSize: 50,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+    expect(getLeaderboard).toHaveBeenCalledWith({
+      baseUrl: "https://edge.example",
+      userId: "user-1",
+      period: "total",
+      limit: 50,
+      offset: 0,
+    });
+  });
+
+  it("does not show old context data after period changes, but reuses matching cached context when returning", async () => {
+    const user = userEvent.setup();
+    const totalContextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    const weekContextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      period: "week",
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey: totalContextKey });
+    publishLeaderboardPreloadState(
+      {
+        ...preloadedData,
+        entries: [
+          {
+            rank: 1,
+            user_id: "week-user",
+            display_name: "Week User",
+            total_tokens: 777,
+            estimated_cost_usd: 0.77,
+          },
+        ],
+      },
+      { contextKey: weekContextKey },
+    );
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Week" }));
+    });
+
+    expect(screen.getAllByText("Week User").length).toBeGreaterThan(0);
+    expect(screen.queryAllByText("Preloaded User")).toHaveLength(0);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "All" }));
+    });
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+  });
+
+  it("clears the visible rows instead of rendering stale data when switching to an uncached context", async () => {
+    const user = userEvent.setup();
+    const totalContextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    publishLeaderboardPreloadState(preloadedData, { contextKey: totalContextKey });
+    getLeaderboard.mockReturnValue(new Promise(() => {}));
+
+    renderLeaderboard();
+
+    expect(screen.getAllByText("Preloaded User").length).toBeGreaterThan(0);
+
+    await act(async () => {
+      await user.click(screen.getByRole("button", { name: "Week" }));
+    });
+
+    expect(screen.queryAllByText("Preloaded User")).toHaveLength(0);
+    expect(screen.getByTestId("leaderboard-skeleton")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/pages/LeaderboardPage.test.jsx
+++ b/dashboard/src/pages/LeaderboardPage.test.jsx
@@ -197,6 +197,24 @@ describe("LeaderboardPage window-session cache reuse", () => {
     expect(readLeaderboardPreloadState(contextKey)).toMatchObject({ data: preloadedData });
   });
 
+  it("shows an error when cold-start fetch fails without cached data", async () => {
+    const contextKey = getLeaderboardPreloadContextKey({
+      accessMode: "cloud",
+      baseUrl: "https://edge.example",
+      mockEnabled: false,
+      userId: "user-1",
+    });
+    getLeaderboard.mockRejectedValue(new Error("network down"));
+
+    renderLeaderboard();
+
+    await waitFor(() => {
+      expect(screen.getByText(/network down/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("leaderboard-skeleton")).not.toBeInTheDocument();
+    expect(readLeaderboardPreloadState(contextKey)).toBeNull();
+  });
+
   it("keeps the existing loading path when the preload context does not match the page defaults", () => {
     const staleContextKey = getLeaderboardPreloadContextKey({
       accessMode: "cloud",

--- a/dashboard/src/pages/LimitsPage.jsx
+++ b/dashboard/src/pages/LimitsPage.jsx
@@ -8,13 +8,19 @@ import { LimitsPageSkeleton } from "../components/LimitsPageSkeleton.jsx";
 import { UsageLimitsPanel } from "../ui/dashboard/components/UsageLimitsPanel.jsx";
 import { LocalOnlyNotice } from "../components/LocalOnlyNotice.jsx";
 import { isMockEnabled } from "../lib/mock-data";
+import { readUsageLimitsPreloadState } from "../lib/dashboard-preload.js";
 
 const IS_LOCAL_HOST =
   typeof window !== "undefined" &&
   (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
 
 export function LimitsPage() {
-  const { data: usageLimits, error, isLoading } = useUsageLimits({ initialRefresh: true });
+  const preloadedUsageLimits = readUsageLimitsPreloadState();
+  const { data: usageLimits, error, isLoading } = useUsageLimits(
+    preloadedUsageLimits
+      ? { initialRefresh: true, initialState: preloadedUsageLimits, publishToPreloadCache: true }
+      : { initialRefresh: true, publishToPreloadCache: true },
+  );
   const prefs = useLimitsDisplayPrefs();
 
   // Limits read the local plan/rate-limit tier from the machine running the

--- a/dashboard/src/pages/LimitsPage.test.jsx
+++ b/dashboard/src/pages/LimitsPage.test.jsx
@@ -1,20 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  publishUsageLimitsPreloadState,
+  resetDashboardPreload,
+} from "../lib/dashboard-preload.js";
 import { LimitsPage } from "./LimitsPage.jsx";
 
+const useUsageLimitsMock = vi.hoisted(() => vi.fn());
+
 vi.mock("../hooks/use-usage-limits", () => ({
-  useUsageLimits: () => ({
-    data: {
-      kimi: {
-        configured: true,
-        error: null,
-        primary_window: { used_percent: 64, reset_at: "2026-05-04T06:02:56.054Z" },
-      },
-    },
-    error: null,
-    isLoading: false,
-  }),
+  useUsageLimits: useUsageLimitsMock,
 }));
 
 vi.mock("../hooks/use-limits-display-prefs.js", () => ({
@@ -25,14 +21,45 @@ vi.mock("../hooks/use-limits-display-prefs.js", () => ({
 }));
 
 vi.mock("../ui/dashboard/components/UsageLimitsPanel.jsx", () => ({
-  UsageLimitsPanel: ({ kimi }) => (
+  UsageLimitsPanel: ({ kimi, codex }) => (
     <div data-testid="limits-panel">
       {kimi?.configured ? "Kimi connected" : "Kimi missing"}
+      {codex?.configured ? " Codex connected" : ""}
     </div>
   ),
 }));
 
+vi.mock("../components/LimitsPageSkeleton.jsx", () => ({
+  LimitsPageSkeleton: () => <div data-testid="limits-skeleton" />,
+}));
+
+const apiLimits = {
+  kimi: {
+    configured: true,
+    error: null,
+    primary_window: { used_percent: 64, reset_at: "2026-05-04T06:02:56.054Z" },
+  },
+};
+
+const preloadedLimits = {
+  codex: {
+    configured: true,
+    error: null,
+    primary_window: { used_percent: 22, reset_at: 1_779_999_999 },
+  },
+};
+
 describe("LimitsPage", () => {
+  beforeEach(() => {
+    resetDashboardPreload();
+    useUsageLimitsMock.mockReset();
+    useUsageLimitsMock.mockImplementation(() => ({
+      data: apiLimits,
+      error: null,
+      isLoading: false,
+    }));
+  });
+
   it("passes Kimi limits from the API response into the limits panel", () => {
     render(
       <MemoryRouter>
@@ -41,5 +68,44 @@ describe("LimitsPage", () => {
     );
 
     expect(screen.getByText("Kimi connected")).toBeInTheDocument();
+  });
+
+  it("uses matching preloaded limits as the hook initial state and skips the full skeleton", () => {
+    publishUsageLimitsPreloadState(preloadedLimits);
+    useUsageLimitsMock.mockImplementation((options) => ({
+      data: options.initialState?.data,
+      error: null,
+      isLoading: false,
+    }));
+
+    render(
+      <MemoryRouter>
+        <LimitsPage />
+      </MemoryRouter>,
+    );
+
+    expect(useUsageLimitsMock).toHaveBeenCalledWith({
+      initialRefresh: true,
+      initialState: expect.objectContaining({
+        data: preloadedLimits,
+        source: "dashboard-existing",
+      }),
+      publishToPreloadCache: true,
+    });
+    expect(screen.queryByTestId("limits-skeleton")).not.toBeInTheDocument();
+    expect(screen.getByTestId("limits-panel")).toHaveTextContent("Codex connected");
+  });
+
+  it("keeps the initialRefresh path when no preloaded state exists", () => {
+    render(
+      <MemoryRouter>
+        <LimitsPage />
+      </MemoryRouter>,
+    );
+
+    expect(useUsageLimitsMock).toHaveBeenCalledWith({
+      initialRefresh: true,
+      publishToPreloadCache: true,
+    });
   });
 });


### PR DESCRIPTION
## Why

Opening the limits and leaderboard pages currently waits for the route chunk and data fetch after navigation. Those pages are common follow-up destinations from the dashboard, so they can feel slower than necessary even though the dashboard already has enough idle time after the main view is visible.

## What changed

- Adds a deferred dashboard preloader that starts only after the main dashboard content is visible.
- Preloads the limits and leaderboard page chunks without hidden-mounting either page.
- Adds a window-session in-memory cache for usage limits and leaderboard contexts.
- Reuses matching cached limits and leaderboard data immediately, then refreshes in the background with stale-while-revalidate behavior.
- Updates the cache after successful page loads and manual refreshes while preserving cached data when a background refresh fails.
- Keeps auth/privacy boundaries unchanged and leaves NativeAuthCallbackPage eager-imported.

## Validation

- npm --prefix dashboard test -- --run src/lib/dashboard-preload.test.js src/lib/dashboard-preload.leaderboard.test.js src/lib/dashboard-preload.silent.test.js src/hooks/use-usage-limits.test.tsx src/pages/LimitsPage.test.jsx src/pages/LeaderboardPage.test.jsx src/App.preload.test.jsx src/App.navigation-preload.test.jsx
- npm run dashboard:build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent dashboard preloading for page resources and leaderboard default state to speed navigation and reduce wait times.
  * Preload-aware leaderboard and limits handling to surface cached data immediately when available.

* **Refactoring**
  * Pages and hooks updated to read/publish preload state and better coordinate background refreshes and access-mode gating.

* **Tests**
  * Extensive test suites added to validate preload behavior, cache semantics, and route/interactivity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->