### PR TITLE
fix(dashboard): scroll activity heatmap to current month when switching 3D→2D

### DIFF
--- a/dashboard/src/ui/dashboard/components/ActivityHeatmap.jsx
+++ b/dashboard/src/ui/dashboard/components/ActivityHeatmap.jsx
@@ -281,9 +281,15 @@ export function ActivityHeatmap({
   }, [view, embedded]);
 
   useEffect(() => {
+    // Re-run on `view` too: the 2D grid is conditionally rendered, so when the
+    // user starts in 3D the scroll container isn't mounted. Switching to 2D
+    // mounts it fresh at scrollLeft=0 (oldest months) — without `view` in the
+    // deps this effect wouldn't fire again and the grid would default to ~12
+    // months ago instead of the current month (rightmost).
+    if (view !== "2d") return;
     const el = scrollRef.current;
     if (el) el.scrollLeft = el.scrollWidth;
-  }, [heatmap?.weeks]);
+  }, [heatmap?.weeks, view]);
 
   useEffect(() => {
     const el = scrollRef.current;


### PR DESCRIPTION
## What

When the activity heatmap is switched from the 3D view back to the 2D view, the grid now scrolls to the **current month** (rightmost) instead of defaulting to ~12 months ago (leftmost).

## Why

The 2D grid is conditionally rendered, so its scroll container isn't mounted while the 3D view is active. The "scroll to latest" effect only depended on `heatmap.weeks`, so switching from 3D back to 2D mounted the grid fresh at `scrollLeft = 0` (oldest months) without re-running the effect.

## Fix

Add `view` to the effect deps (guarded to the `2d` branch) so the grid scrolls to the rightmost/current month on every switch into 2D.

Affects both the macOS and Windows apps, which bundle the same dashboard. Reproduced and verified in the Windows WebView2 host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the activity heatmap scroll positioning that occurred when toggling between different view modes. The heatmap now correctly scrolls to display the latest data, ensuring consistent behavior regardless of your starting view perspective.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->