### PR TITLE
ci(release-windows): upload version-less assets only, matching the macOS DMG

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -147,18 +147,23 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           $tag = "v$env:VERSION"
-          $zip = "TokenTracker-win-x64-v$env:VERSION.zip"
-          $setup = "TokenTrackerWin/installer/Output/TokenTracker-Setup-v$env:VERSION.exe"
-          # Stable, version-less aliases so the landing page can deep-link
-          # releases/latest/download/<name> without knowing the version. The
-          # versioned names stay too (clearer when browsing the release page).
-          $setupStable = "TokenTracker-Setup.exe"
-          $zipStable = "TokenTracker-win-x64.zip"
-          Copy-Item $setup $setupStable -Force
-          Copy-Item $zip $zipStable -Force
+          # Build artifacts carry the version in their filename (clearer on the
+          # runner / in the Inno output folder).
+          $zipBuilt = "TokenTracker-win-x64-v$env:VERSION.zip"
+          $setupBuilt = "TokenTrackerWin/installer/Output/TokenTracker-Setup-v$env:VERSION.exe"
+          # Upload version-less names ONLY, matching the macOS DMG (which ships a
+          # single version-less TokenTrackerBar.dmg). The landing page / READMEs
+          # deep-link releases/latest/download/TokenTracker-Setup.exe, so the asset
+          # names must be stable; the release heading already shows the version, so
+          # a second versioned copy of each asset would just be a redundant
+          # duplicate on the release page.
+          $setup = "TokenTracker-Setup.exe"
+          $zip = "TokenTracker-win-x64.zip"
+          Copy-Item $setupBuilt $setup -Force
+          Copy-Item $zipBuilt $zip -Force
           gh release view $tag 2>$null
           if ($LASTEXITCODE -eq 0) {
-            gh release upload $tag $zip $setup $setupStable $zipStable --clobber
+            gh release upload $tag $zip $setup --clobber
           } else {
-            gh release create $tag $zip $setup $setupStable $zipStable --title $tag --generate-notes
+            gh release create $tag $zip $setup --title $tag --generate-notes
           }

--- a/test/release-windows-workflow.test.js
+++ b/test/release-windows-workflow.test.js
@@ -106,11 +106,33 @@ test("workflow builds the installer with Inno Setup", () => {
   );
 });
 
-test("workflow attaches BOTH the zip and the installer to a GitHub release", () => {
+test("workflow attaches the zip and the installer to a GitHub release", () => {
   const content = loadWorkflow();
   assert.ok(content.includes("gh release"));
   assert.ok(content.includes("TokenTracker-win-x64"), "zip asset");
-  assert.ok(content.includes("TokenTracker-Setup-v"), "installer asset");
+  assert.ok(content.includes("TokenTracker-Setup"), "installer asset");
+});
+
+test("workflow uploads version-less assets only (no versioned duplicate)", () => {
+  const content = loadWorkflow();
+  // The gh release upload/create lines must reference the stable $zip / $setup
+  // vars, not the versioned build artifacts ($zipBuilt / $setupBuilt), so the
+  // release page shows a single copy of each Windows asset — mirroring the
+  // version-less macOS DMG instead of doubling up versioned + stable names.
+  const ghLines = content
+    .split("\n")
+    .filter((l) => /gh release (upload|create)/.test(l));
+  assert.ok(ghLines.length >= 1, "should have a gh release upload/create line");
+  for (const line of ghLines) {
+    assert.ok(
+      !/Built/.test(line),
+      `must not upload versioned build artifact: ${line.trim()}`
+    );
+    assert.ok(
+      /\$zip\b/.test(line) && /\$setup\b/.test(line),
+      `must upload the stable $zip + $setup aliases: ${line.trim()}`
+    );
+  }
 });
 
 test("workflow uploads a stable version-less installer alias for landing deep links", () => {


### PR DESCRIPTION
## Problem

The Windows release attaches each artifact **twice** — a versioned name and a version-less alias — so the release page shows four Windows assets where macOS shows one:

| | |
|---|---|
| `TokenTracker-Setup-v0.35.0.exe` | `TokenTracker-Setup.exe` |
| `TokenTracker-win-x64-v0.35.0.zip` | `TokenTracker-win-x64.zip` |

(identical sha256 — pure duplicates)

The version-less alias is **required**: the landing page and READMEs deep-link `releases/latest/download/TokenTracker-Setup.exe`, which can't carry a version in the URL. The versioned copy was only "nicer when browsing", but the release heading already shows the version.

## Fix

Keep building with versioned filenames on the runner, but **upload only the version-less names** (copied from the versioned build artifacts). Each Windows release now ships exactly one installer + one zip, mirroring the single version-less `TokenTrackerBar.dmg`.

Workflow tests updated to assert the `gh release upload/create` lines reference the stable `$zip`/`$setup` aliases and never the versioned build artifacts. `npm test` for both `release-windows-workflow.test.js` (27) and `release-dmg-workflow.test.js` (17) pass.

> Note: this fixes future releases. The existing v0.35.0 duplicates would need a one-time manual cleanup on the release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Windows release asset uploads to provide cleaner downloads with stable, version-less filenames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->