### PR TITLE
fix(dashboard): render usage-trend zoom modal inline so it shows in the Windows WebView2 host

### DIFF
--- a/dashboard/src/ui/dashboard/components/TrendMonitorZoomModal.jsx
+++ b/dashboard/src/ui/dashboard/components/TrendMonitorZoomModal.jsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { createPortal } from "react-dom";
 import { Popover } from "@base-ui/react/popover";
 import { X, ChevronLeft, ChevronRight, Terminal } from "lucide-react";
 import { copy } from "../../../lib/copy";
@@ -184,7 +183,15 @@ export function TrendMonitorZoomModal({
     ? formatUsdCurrency(stats.totalCostUsd, { currency, rate })
     : null;
 
-  return createPortal(
+  // Render inline (NOT createPortal to document.body). The fixed-position
+  // overlay still covers the viewport — no ancestor establishes a containing
+  // block for `position: fixed` (verified: only overflow, no transform/filter).
+  // In the Windows WebView2 host's transparent composition, overlays portaled
+  // directly under <body> (outside #root) mount and composite in the renderer
+  // but are NOT presented on-screen, so the modal looked like it "didn't open".
+  // The 3D heatmap modal renders inline for the same reason and works. macOS
+  // WKWebView / browsers are unaffected either way.
+  return (
     <div
       onAnimationEnd={handleAnimationEnd}
       onClick={(e) => {
@@ -418,7 +425,6 @@ export function TrendMonitorZoomModal({
           </div>
         </div>
       </div>
-    </div>,
-    document.body,
+    </div>
   );
 }


### PR DESCRIPTION
## Problem

On the Windows tray app, clicking the Usage Trend "expand to full screen" button did nothing — the zoom modal never appeared. macOS worked fine.

## Root cause

`TrendMonitorZoomModal` rendered via `createPortal(..., document.body)`. In the Windows WebView2 host's transparent composition, an overlay portaled directly under `<body>` (outside `#root`) **mounts and composites in the renderer but is not presented on-screen** — so the modal was in the DOM (verified via CDP) yet invisible. The 3D heatmap modal, which renders **inline** inside `#root`, was unaffected.

## Fix

Render the zoom modal inline instead of portaling to `document.body`, matching the working 3D heatmap modal. The `fixed inset-0` overlay still covers the viewport — no ancestor establishes a containing block for `position: fixed` (only `overflow`, no `transform`/`filter`), so there's no clipping.

Not gated to Windows: the inline render is visually identical on macOS/web (same pattern the 3D modal already uses there). Verified on Windows WebView2 (modal now opens) and on macOS WKWebView (no regression).

`TrendMonitor.test.jsx` (10) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal rendering behavior for better compatibility across different browser and host configurations.

* **Documentation**
  * Added inline documentation explaining the rendering approach for specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->