### PR TITLE
fix(mac): update settings sync state

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/NativeBridge.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/NativeBridge.swift
@@ -42,6 +42,13 @@ final class NativeBridge {
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.pushSettings() }
             .store(in: &cancellables)
+
+        viewModel.$isSyncing
+            .removeDuplicates()
+            .dropFirst()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.pushSettings() }
+            .store(in: &cancellables)
     }
 
     /// Compact "configured && error==nil" snapshot per provider — collapses

--- a/test/native-bridge-sync-feedback.test.js
+++ b/test/native-bridge-sync-feedback.test.js
@@ -1,0 +1,28 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+const nativeBridgePath = path.join(
+  repoRoot,
+  "TokenTrackerBar",
+  "TokenTrackerBar",
+  "Services",
+  "NativeBridge.swift",
+);
+
+test("NativeBridge pushes settings when sync state changes", () => {
+  const source = fs.readFileSync(nativeBridgePath, "utf8");
+
+  assert.match(
+    source,
+    /"isSyncing":\s*viewModel\?\.isSyncing\s*\?\?\s*false/,
+    "settings payload should expose the current sync state",
+  );
+  assert.match(
+    source,
+    /viewModel\.\$isSyncing[\s\S]*?\.sink\s*\{\s*\[weak self\]\s*_\s*in\s*self\?\.pushSettings\(\)\s*\}/,
+    "sync state changes should be pushed to the dashboard settings UI",
+  );
+});


### PR DESCRIPTION
## Summary

- push native settings updates when the macOS dashboard view model enters or leaves manual sync
- add a regression test that keeps the settings payload and `isSyncing` publisher wiring in place

## Why

The Settings page already renders the "Sync now" button from the native `isSyncing` setting, and the native bridge already includes that field in its payload. However, the bridge only pushed settings when provider availability changed. Pressing "Sync now" could therefore start a sync without sending a fresh settings event to the WebView, making the button feel inert.

## How

`NativeBridge.configure` now subscribes to `DashboardViewModel.$isSyncing`, de-duplicates changes, and reuses the existing `pushSettings()` path. This keeps the fix scoped to UI state propagation; sync execution, server APIs, token accounting, and dashboard routing are unchanged.

## Validation

- `node --test test/native-bridge-sync-feedback.test.js`
- `npm test`
- Manual macOS app smoke test: built and opened a local TokenTrackerBar bundle, verified the native Settings page shows sync feedback after pressing "Sync now".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard UI sync state feedback. The interface now correctly updates to reflect changes in syncing availability, ensuring users see accurate, real-time sync status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->