### PR TITLE
fix(dashboard): localize the custom date-range calendar to the selected language

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -587,6 +587,7 @@ skills.toast.removed,ui,SkillsPage,SkillsPage,toast_removed,"Removed {{name}}.",
 shared.action.undo,shared,*,Shared,action_undo,"Undo",,active
 shared.action.dismiss,shared,*,Shared,action_dismiss,"Dismiss",,active
 shared.action.cancel,shared,*,Shared,action_cancel,"Cancel",,active
+shared.action.apply,shared,*,Shared,action_apply,"Apply",,active
 skills.empty.my,ui,SkillsPage,SkillsPage,empty_my,"No skills yet. Open Discover to search and install.",,active
 skills.empty.my_cta,ui,SkillsPage,SkillsPage,empty_my_cta,"Browse",,active
 skills.empty.browse,ui,SkillsPage,SkillsPage,empty_browse,"No skills found for this source.",,active

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -250,6 +250,7 @@
   "skills.toast.removed": "{{name}} を削除しました。",
   "shared.action.undo": "元に戻す",
   "shared.action.cancel": "キャンセル",
+  "shared.action.apply": "適用",
   "skills.empty.my": "まだ skill がありません。「探す」で検索またはインストールしましょう。",
   "skills.empty.my_cta": "探しに行く",
   "skills.empty.browse": "このソースにはスキルが見つかりませんでした。",

--- a/dashboard/src/content/i18n/ko/core.json
+++ b/dashboard/src/content/i18n/ko/core.json
@@ -250,6 +250,7 @@
   "skills.toast.removed": "{{name}}을(를) 제거했습니다.",
   "shared.action.undo": "실행 취소",
   "shared.action.cancel": "취소",
+  "shared.action.apply": "적용",
   "skills.empty.my": "아직 skill이 없습니다. 둘러보기를 열어 검색하고 설치하세요.",
   "skills.empty.my_cta": "둘러보기",
   "skills.empty.browse": "이 출처에서 skill을 찾을 수 없습니다.",

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -250,6 +250,7 @@
   "skills.toast.removed": "已移除 {{name}}。",
   "shared.action.undo": "撤銷",
   "shared.action.cancel": "取消",
+  "shared.action.apply": "套用",
   "skills.empty.my": "還沒有 skill。去「發現」搜尋或安裝。",
   "skills.empty.my_cta": "去發現",
   "skills.empty.browse": "這個來源下沒有找到技能。",

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -250,6 +250,7 @@
   "skills.toast.removed": "已移除 {{name}}。",
   "shared.action.undo": "撤销",
   "shared.action.cancel": "取消",
+  "shared.action.apply": "应用",
   "skills.empty.my": "还没有 skill。去「发现」搜索或安装。",
   "skills.empty.my_cta": "去发现",
   "skills.empty.browse": "这个来源下没有找到技能。",

--- a/dashboard/src/lib/copy.ts
+++ b/dashboard/src/lib/copy.ts
@@ -176,6 +176,13 @@ export function setCopyLocale(locale: any) {
   currentLocale = normalizeResolvedLocale(locale);
 }
 
+// The resolved locale that copy() is currently translating into. Mirrors the
+// same module-level state copy() reads, so components can localize non-string
+// output (e.g. date-fns formatting) without depending on LocaleProvider context.
+export function getCopyLocale() {
+  return currentLocale;
+}
+
 export function copy(key: any, params?: AnyRecord) {
   const registry = getRegistry();
   const record = registry.map.get(key);

--- a/dashboard/src/ui/dashboard/components/DateRangePopover.jsx
+++ b/dashboard/src/ui/dashboard/components/DateRangePopover.jsx
@@ -1,18 +1,37 @@
 import React, { useState, useMemo } from "react";
 import { DayPicker } from "react-day-picker";
 import { format } from "date-fns";
+import { enUS, zhCN, zhTW, ja, ko } from "date-fns/locale";
 import { Button } from "../../components";
+import { copy, getCopyLocale } from "../../../lib/copy";
+
+// Map the dashboard's resolved locale to a date-fns locale object so the
+// calendar (month captions + weekday headers) and the in-popover date summary
+// render in the selected language instead of always English.
+const DATE_FNS_LOCALES = {
+  en: enUS,
+  "zh-CN": zhCN,
+  "zh-TW": zhTW,
+  ja,
+  ko,
+};
+
+/** Resolve a dashboard locale (en/zh-CN/zh-TW/ja/ko) to a date-fns Locale. */
+export function getDateFnsLocale(resolvedLocale) {
+  return DATE_FNS_LOCALES[resolvedLocale] || enUS;
+}
 
 /**
  * Format a YYYY-MM-DD string to short display like "Mar 1".
+ * Pass a date-fns `locale` (see getDateFnsLocale) to localize the month name.
  */
-export function formatDateShort(dateStr) {
+export function formatDateShort(dateStr, locale) {
   if (!dateStr) return "";
   const parts = dateStr.split("-");
   if (parts.length !== 3) return dateStr;
   const d = new Date(Number(parts[0]), Number(parts[1]) - 1, Number(parts[2]));
   if (!Number.isFinite(d.getTime())) return dateStr;
-  return format(d, "MMM d");
+  return format(d, "MMM d", locale ? { locale } : undefined);
 }
 
 /**
@@ -35,6 +54,8 @@ export function DateRangePopover({ from, to, onApply, onCancel }) {
 
   const [range, setRange] = useState(initialRange);
 
+  const dateLocale = getDateFnsLocale(getCopyLocale());
+
   const handleApply = () => {
     if (!range?.from) return;
     const fromStr = format(range.from, "yyyy-MM-dd");
@@ -48,6 +69,7 @@ export function DateRangePopover({ from, to, onApply, onCancel }) {
     <div className="p-4">
       <DayPicker
         mode="range"
+        locale={dateLocale}
         selected={range}
         onSelect={setRange}
         numberOfMonths={2}
@@ -84,17 +106,17 @@ export function DateRangePopover({ from, to, onApply, onCancel }) {
       <div className="flex items-center justify-end gap-2 mt-4 pt-3 border-t border-oai-gray-200 dark:border-oai-gray-700">
         {hasSelection && range.from && (
           <span className="text-xs text-oai-gray-500 dark:text-oai-gray-400 mr-auto">
-            {format(range.from, "MMM d, yyyy")}
+            {format(range.from, "MMM d, yyyy", { locale: dateLocale })}
             {range.to && range.to.getTime() !== range.from.getTime()
-              ? ` — ${format(range.to, "MMM d, yyyy")}`
+              ? ` — ${format(range.to, "MMM d, yyyy", { locale: dateLocale })}`
               : ""}
           </span>
         )}
         <Button variant="secondary" size="sm" onClick={onCancel}>
-          Cancel
+          {copy("shared.action.cancel")}
         </Button>
         <Button variant="primary" size="sm" onClick={handleApply} disabled={!hasSelection}>
-          Apply
+          {copy("shared.action.apply")}
         </Button>
       </div>
     </div>

--- a/dashboard/src/ui/dashboard/components/UsageOverview.jsx
+++ b/dashboard/src/ui/dashboard/components/UsageOverview.jsx
@@ -5,9 +5,9 @@ import { Popover } from "@base-ui/react/popover";
 import { Card, Button, Counter } from "../../components";
 import { useTheme } from "../../../hooks/useTheme.js";
 import { useCurrency } from "../../../hooks/useCurrency.js";
-import { copy } from "../../../lib/copy";
+import { copy, getCopyLocale } from "../../../lib/copy";
 import { CURRENCY_USD, getCurrencySymbol } from "../../../lib/currency";
-import { DateRangePopover, formatDateShort } from "./DateRangePopover.jsx";
+import { DateRangePopover, formatDateShort, getDateFnsLocale } from "./DateRangePopover.jsx";
 import { ProviderIcon } from "./ProviderIcon.jsx";
 import { formatCompactNumber, formatUsdCurrency } from "../../../lib/format";
 import { ContextBreakdownPanel } from "./ContextBreakdownPanel.jsx";
@@ -135,6 +135,7 @@ export function UsageOverview({
   to,
 }) {
   const tabs = normalizePeriods(periods);
+  const dateLocale = getDateFnsLocale(getCopyLocale());
   const summaryCounterValue = parseAnimatedCounterValue(String(summaryValue ?? ""));
   // The digit-by-digit Counter renders at a fixed 72px and would clip on
   // phones. Below sm we drop it and render the plain value, which scales
@@ -188,7 +189,7 @@ export function UsageOverview({
 
               if (p.key === "custom") {
                 const customLabel = isActive && customFrom && customTo
-                  ? `${formatDateShort(customFrom)} — ${formatDateShort(customTo)}`
+                  ? `${formatDateShort(customFrom, dateLocale)} — ${formatDateShort(customTo, dateLocale)}`
                   : p.label;
 
                 return (


### PR DESCRIPTION
## Problem

In the token-stats **custom** date-range picker, everything rendered in English regardless of the chosen UI language:
- the react-day-picker calendar (month captions + weekday headers),
- the trigger button's date label (e.g. `Jun 1 — Jun 6`),
- the in-popover date summary,
- the **Cancel** / **Apply** buttons.

`DayPicker` got no `locale` and none of the `date-fns` `format()` calls passed one, and the two buttons were hardcoded strings.

## Fix

- Map the dashboard's resolved locale (`en` / `zh-CN` / `zh-TW` / `ja` / `ko`) to a `date-fns` locale and pass it to `DayPicker` and every `format()` call (exported `getDateFnsLocale`).
- `formatDateShort` now accepts a locale so the trigger label localizes too.
- Replace hardcoded **Cancel** / **Apply** with copy keys: reuse `shared.action.cancel`, add `shared.action.apply` + zh/zh-TW/ja/ko translations.
- Read the locale via a new non-throwing `getCopyLocale()` (the same module-level locale `copy()` already uses) rather than the `useLocale()` context hook, so the widely-rendered `UsageOverview` keeps working in tests without a `LocaleProvider` wrapper.

This is shared dashboard code (not gated behind `isNativeWindowsApp()`), so it fixes **macOS, Windows, and web** alike.

## Verification

- `npm --prefix dashboard run typecheck` — clean
- `npm --prefix dashboard test` — back to the 2 pre-existing unrelated failures (SkillsPage, UsageLimitsPanel); `UsageOverview` passes
- `npm run validate:copy` — ok (new `shared.action.apply` recognized as used)
- `npm run validate:ui-hardcode` — ok
- Manually verified in the Windows WebView2 app (zh-CN): calendar, trigger label, summary, and buttons all localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization support for the "Apply" action button in Japanese, Korean, Traditional Chinese, and Simplified Chinese.
  * Improved date formatting localization in date range pickers and usage reports to respect user language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->