### PR TITLE
fix(edge): display name silently reverts after editing (drop nonexistent updated_at column)

### DIFF
--- a/dashboard/edge-patches/tokentracker-public-visibility.ts
+++ b/dashboard/edge-patches/tokentracker-public-visibility.ts
@@ -182,14 +182,16 @@ export default async function (req: Request): Promise<Response> {
     // here so the POST still returned 200 with an optimistic result, the UI
     // showed "saved", but the next GET read back the unchanged name — the
     // display name silently reverted on every revisit. Do not re-add it.
+    // Trim + cap once so the saved value and the returned value can't drift.
+    let normalizedDisplayName: string | null | undefined = undefined;
     if (typeof body.display_name === "string") {
-      const trimmed = body.display_name.trim().slice(0, 50);
+      normalizedDisplayName = body.display_name.trim().slice(0, 50) || null;
       const { error: profileErr } = await client.database
         .from("tokentracker_user_profiles")
         .upsert(
           {
             user_id: userId,
-            display_name: trimmed || null,
+            display_name: normalizedDisplayName,
           },
           { onConflict: "user_id" },
         );
@@ -201,7 +203,7 @@ export default async function (req: Request): Promise<Response> {
     const result: Record<string, unknown> = { updated_at: now };
     if (body.enabled !== undefined) result.enabled = Boolean(body.enabled);
     if (body.anonymous !== undefined) result.anonymous = Boolean(body.anonymous);
-    if (typeof body.display_name === "string") result.display_name = body.display_name.trim().slice(0, 50) || null;
+    if (normalizedDisplayName !== undefined) result.display_name = normalizedDisplayName;
     if (normalizedGithubUrl !== undefined) result.github_url = normalizedGithubUrl;
     if (body.show_github_url !== undefined) result.show_github_url = Boolean(body.show_github_url);
     return json(result);

--- a/dashboard/edge-patches/tokentracker-public-visibility.ts
+++ b/dashboard/edge-patches/tokentracker-public-visibility.ts
@@ -175,17 +175,27 @@ export default async function (req: Request): Promise<Response> {
       );
     }
 
-    // Update display_name in user_profiles
+    // Update display_name in user_profiles.
+    // NOTE: tokentracker_user_profiles has NO `updated_at` column (unlike
+    // tokentracker_user_settings). Including it made the upsert fail with
+    // Postgres 42703 ("column ... does not exist"); the error was swallowed
+    // here so the POST still returned 200 with an optimistic result, the UI
+    // showed "saved", but the next GET read back the unchanged name — the
+    // display name silently reverted on every revisit. Do not re-add it.
     if (typeof body.display_name === "string") {
       const trimmed = body.display_name.trim().slice(0, 50);
-      await client.database.from("tokentracker_user_profiles").upsert(
-        {
-          user_id: userId,
-          display_name: trimmed || null,
-          updated_at: now,
-        },
-        { onConflict: "user_id" },
-      );
+      const { error: profileErr } = await client.database
+        .from("tokentracker_user_profiles")
+        .upsert(
+          {
+            user_id: userId,
+            display_name: trimmed || null,
+          },
+          { onConflict: "user_id" },
+        );
+      if (profileErr) {
+        return json({ error: profileErr.message || "Failed to save display name" }, 500);
+      }
     }
 
     const result: Record<string, unknown> = { updated_at: now };


### PR DESCRIPTION
## Symptom

Editing the **display name** in Settings appears to succeed, but navigating to another menu and back to Settings reverts it to the previous name. Reproduces on **both macOS and Windows** (they share the same cloud edge function), so this is not a native-shell issue.

The GitHub-URL field and the public/anonymous toggles right next to it persist fine — only the display name reverts.

## Root cause (verified against the live backend)

Querying production InsForge directly:

```
tokentracker_user_profiles.display_name  → exists, readable
tokentracker_user_profiles.updated_at    → does NOT exist
  → Postgres 42703 "column tokentracker_user_profiles.updated_at does not exist"
```

`tokentracker-public-visibility`'s POST upserts the display name into `tokentracker_user_profiles` **with an `updated_at` column that table doesn't have**, so the upsert fails with 42703. But the call was `await ...upsert(...)` **without checking the returned `error`** — so the POST still returned `200` with an optimistic result body. The UI showed "saved", nothing was written, and the next `GET` read back the unchanged `display_name` → silent revert on every revisit.

Why only the display name: `github_url` / `enabled` / `anonymous` are written to a *different* table, `tokentracker_user_settings`, which **does** have an `updated_at` column — so those persist.

## Fix

- Drop `updated_at` from the `tokentracker_user_profiles` upsert (the column doesn't exist; nothing reads it either).
- Check the returned `error` and return `500` on failure, so a future schema mismatch surfaces instead of silently faking success.
- The `tokentracker_user_settings` upsert is unchanged (its `updated_at` column exists).

## Deployment note ⚠️

This is an **InsForge edge function** (`dashboard/edge-patches/`). There is no automated deploy path in the repo for these — they're applied manually to InsForge. **Rebuilding the dashboard / desktop apps will NOT make this fix take effect.** A maintainer must redeploy `tokentracker-public-visibility` to InsForge. After deployment, no client/app changes are needed (both platforms call the cloud function).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Display name updates are now normalized (trimmed and limited to 50 characters) before saving.
  * The saved/displayed name reflects this normalized value consistently.
  * If saving the display name fails, the system now returns an explicit error instead of failing silently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->