### PR TITLE
feat(dashboard): add client-side search on My Skills tab

### DIFF
--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -557,6 +557,7 @@ skills.detail.remove_confirm_hint,ui,SkillsPage,SkillDetailPanel,detail_remove_c
 skills.filter.agent_label,ui,SkillsPage,SkillsPage,filter_agent_label,"Agent",,active
 skills.filter.agent_all,ui,SkillsPage,SkillsPage,filter_agent_all,"All agents",,active
 skills.filter.clear,ui,SkillsPage,SkillsPage,filter_clear,"Clear filters",,active
+skills.my.placeholder,ui,SkillsPage,SkillsPage,my_placeholder,"Filter installed skills…",,active
 skills.filter.result_count,ui,SkillsPage,SkillsPage,filter_result_count,"{{filtered}} of {{total}} skills",,active
 skills.filter.result_count_browse,ui,SkillsPage,SkillsPage,filter_result_count_browse,"{{count}} results",,active
 skills.empty.no_match,ui,SkillsPage,SkillsPage,empty_no_match,"No skills match the current filters.",,active

--- a/dashboard/src/content/copy.csv
+++ b/dashboard/src/content/copy.csv
@@ -547,6 +547,7 @@ skills.toast.installed,ui,SkillsPage,SkillsPage,toast_installed,"Installed {{nam
 skills.action.remove,ui,SkillsPage,SkillsPage,action_remove,Remove,,active
 skills.action.search,ui,SkillsPage,SkillsPage,action_search,Search,,active
 skills.action.search_aria,ui,SkillsPage,SkillsPage,action_search_aria,"Search skills",,active
+skills.action.search_clear,ui,SkillsPage,SkillsPage,action_search_clear,"Clear search",,active
 skills.target.synced_summary,ui,SkillsPage,InstalledSkillRow,target_synced_summary,"Synced to {{targets}}",,active
 skills.target.synced_none,ui,SkillsPage,InstalledSkillRow,target_synced_none,"Not synced to any agent",,active
 skills.row.open_details,ui,SkillsPage,InstalledSkillRow,row_open_details,"Open details for {{name}}",,active

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -222,6 +222,7 @@
   "skills.filter.agent_label": "Agent",
   "skills.filter.agent_all": "すべての agent",
   "skills.filter.clear": "フィルターをクリア",
+  "skills.my.placeholder": "インストール済みの skills を絞り込み…",
   "skills.filter.result_count": "{{filtered}} / {{total}} 個の skill",
   "skills.filter.result_count_browse": "{{count}} 件の結果",
   "skills.empty.no_match": "現在のフィルターに一致する skill はありません。",

--- a/dashboard/src/content/i18n/ja/core.json
+++ b/dashboard/src/content/i18n/ja/core.json
@@ -212,6 +212,7 @@
   "skills.action.remove": "削除",
   "skills.action.search": "検索",
   "skills.action.search_aria": "skills を検索",
+  "skills.action.search_clear": "検索をクリア",
   "skills.target.synced_summary": "{{targets}} に同期済み",
   "skills.target.synced_none": "まだどの agent にも同期されていません",
   "skills.row.open_details": "{{name}} の詳細を表示",

--- a/dashboard/src/content/i18n/ko/core.json
+++ b/dashboard/src/content/i18n/ko/core.json
@@ -222,6 +222,7 @@
   "skills.filter.agent_label": "Agent",
   "skills.filter.agent_all": "모든 agent",
   "skills.filter.clear": "필터 지우기",
+  "skills.my.placeholder": "설치된 skills 필터…",
   "skills.filter.result_count": "skill {{filtered}} / {{total}}개",
   "skills.filter.result_count_browse": "결과 {{count}}개",
   "skills.empty.no_match": "현재 필터에 일치하는 skill이 없습니다.",

--- a/dashboard/src/content/i18n/ko/core.json
+++ b/dashboard/src/content/i18n/ko/core.json
@@ -212,6 +212,7 @@
   "skills.action.remove": "제거",
   "skills.action.search": "검색",
   "skills.action.search_aria": "skills 검색",
+  "skills.action.search_clear": "검색 지우기",
   "skills.target.synced_summary": "{{targets}}에 동기화됨",
   "skills.target.synced_none": "어떤 agent에도 동기화되지 않음",
   "skills.row.open_details": "{{name}} 세부 정보 열기",

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -212,6 +212,7 @@
   "skills.action.remove": "移除",
   "skills.action.search": "搜尋",
   "skills.action.search_aria": "搜尋 skills",
+  "skills.action.search_clear": "清除搜尋",
   "skills.target.synced_summary": "已同步到 {{targets}}",
   "skills.target.synced_none": "尚未同步到任何 agent",
   "skills.row.open_details": "檢視 {{name}} 詳情",

--- a/dashboard/src/content/i18n/zh-TW/core.json
+++ b/dashboard/src/content/i18n/zh-TW/core.json
@@ -222,6 +222,7 @@
   "skills.filter.agent_label": "Agent",
   "skills.filter.agent_all": "全部 agent",
   "skills.filter.clear": "清除篩選",
+  "skills.my.placeholder": "篩選已安裝的 skills…",
   "skills.filter.result_count": "{{filtered}} / {{total}} 個 skill",
   "skills.filter.result_count_browse": "{{count}} 個結果",
   "skills.empty.no_match": "當前篩選下沒有匹配的 skill。",

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -222,6 +222,7 @@
   "skills.filter.agent_label": "Agent",
   "skills.filter.agent_all": "全部 agent",
   "skills.filter.clear": "清除筛选",
+  "skills.my.placeholder": "筛选已安装的 skills…",
   "skills.filter.result_count": "{{filtered}} / {{total}} 个 skill",
   "skills.filter.result_count_browse": "{{count}} 个结果",
   "skills.empty.no_match": "当前筛选下没有匹配的 skill。",

--- a/dashboard/src/content/i18n/zh/core.json
+++ b/dashboard/src/content/i18n/zh/core.json
@@ -212,6 +212,7 @@
   "skills.action.remove": "移除",
   "skills.action.search": "搜索",
   "skills.action.search_aria": "搜索 skills",
+  "skills.action.search_clear": "清除搜索",
   "skills.target.synced_summary": "已同步到 {{targets}}",
   "skills.target.synced_none": "尚未同步到任何 agent",
   "skills.row.open_details": "查看 {{name}} 详情",

--- a/dashboard/src/pages/SkillsPage.jsx
+++ b/dashboard/src/pages/SkillsPage.jsx
@@ -225,9 +225,13 @@ function FilterToolbar({
   totalCount,
   anyFilter,
   onClearFilters,
+  searchQuery,
+  onSearchQuery,
+  searchPlaceholder,
 }) {
   return (
-    <div className="mb-2 flex flex-wrap items-center gap-2 pt-1 text-xs text-oai-gray-600 dark:text-oai-gray-300">
+    <div className="mb-2 space-y-2 pt-1">
+      <div className="flex flex-wrap items-center gap-2 text-xs text-oai-gray-600 dark:text-oai-gray-300">
       <Select.Root value={agentFilter} onValueChange={onAgentFilter}>
         <Select.Trigger
           aria-label={copy("skills.filter.agent_label")}
@@ -293,6 +297,18 @@ function FilterToolbar({
           {copy("skills.filter.clear")}
         </button>
       ) : null}
+      </div>
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-oai-gray-400" aria-hidden />
+        <Input
+          type="search"
+          value={searchQuery}
+          onChange={(event) => onSearchQuery(event.target.value)}
+          aria-label={copy("skills.action.search_aria")}
+          placeholder={searchPlaceholder}
+          className="pl-9 !border-oai-gray-200 dark:!border-oai-gray-800 focus:!border-oai-gray-400 focus:!ring-oai-gray-400/20 dark:focus:!border-oai-gray-500 dark:focus:!ring-oai-gray-500/20"
+        />
+      </div>
     </div>
   );
 }
@@ -366,6 +382,9 @@ function MySkillsView({
   onAgentFilter,
   anyFilter,
   onClearFilters,
+  searchQuery,
+  onSearchQuery,
+  searchPlaceholder,
   selectedId,
   onSelect,
   onToggleTarget,
@@ -398,6 +417,9 @@ function MySkillsView({
           totalCount={totalCount}
           anyFilter={anyFilter}
           onClearFilters={onClearFilters}
+          searchQuery={searchQuery}
+          onSearchQuery={onSearchQuery}
+          searchPlaceholder={searchPlaceholder}
         />
       )}
       {items.length === 0 ? (
@@ -664,6 +686,8 @@ export function SkillsPage() {
   const [source, setSource] = useState(SOURCE_ALL);
   const [query, setQuery] = useState("");
   const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [myQuery, setMyQuery] = useState("");
+  const [myDebouncedQuery, setMyDebouncedQuery] = useState("");
   const [repoInput, setRepoInput] = useState("");
   const [manageOpen, setManageOpen] = useState(false);
   const [agentFilter, setAgentFilter] = useState("all");
@@ -842,6 +866,11 @@ export function SkillsPage() {
     const timer = setTimeout(() => setDebouncedQuery(query), 200);
     return () => clearTimeout(timer);
   }, [query]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setMyDebouncedQuery(myQuery), 200);
+    return () => clearTimeout(timer);
+  }, [myQuery]);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -1083,11 +1112,21 @@ export function SkillsPage() {
   const mySkills = installedData.skills || [];
 
   const filteredMySkills = useMemo(() => {
-    if (agentFilter === "all") return mySkills;
-    return mySkills.filter((skill) => (skill.targets || []).includes(agentFilter));
-  }, [mySkills, agentFilter]);
+    const byAgent =
+      agentFilter === "all"
+        ? mySkills
+        : mySkills.filter((skill) => (skill.targets || []).includes(agentFilter));
+    const q = myDebouncedQuery.trim().toLowerCase();
+    if (!q) return byAgent;
+    return byAgent.filter(
+      (skill) =>
+        (skill.name || "").toLowerCase().includes(q) ||
+        (skill.directory || "").toLowerCase().includes(q) ||
+        (skill.description || "").toLowerCase().includes(q),
+    );
+  }, [mySkills, agentFilter, myDebouncedQuery]);
 
-  const myAnyFilter = agentFilter !== "all";
+  const myAnyFilter = agentFilter !== "all" || myDebouncedQuery.trim() !== "";
 
   const selectedSkill = useMemo(() => {
     if (!selectedSkillId) return null;
@@ -1096,6 +1135,7 @@ export function SkillsPage() {
 
   const handleClearMyFilters = useCallback(() => {
     setAgentFilter("all");
+    setMyQuery("");
   }, []);
 
   const handleSelectSkill = useCallback((skill) => {
@@ -1190,6 +1230,9 @@ export function SkillsPage() {
         onAgentFilter={setAgentFilter}
         anyFilter={myAnyFilter}
         onClearFilters={handleClearMyFilters}
+        searchQuery={myQuery}
+        onSearchQuery={setMyQuery}
+        searchPlaceholder={copy("skills.my.placeholder")}
         selectedId={selectedSkillId}
         onSelect={handleSelectSkill}
         onToggleTarget={handleToggleTarget}

--- a/dashboard/src/pages/SkillsPage.jsx
+++ b/dashboard/src/pages/SkillsPage.jsx
@@ -230,8 +230,7 @@ function FilterToolbar({
   searchPlaceholder,
 }) {
   return (
-    <div className="mb-2 space-y-2 pt-1">
-      <div className="flex flex-wrap items-center gap-2 text-xs text-oai-gray-600 dark:text-oai-gray-300">
+    <div className="mb-2 flex flex-wrap items-center gap-2 pt-1 text-xs text-oai-gray-600 dark:text-oai-gray-300">
       <Select.Root value={agentFilter} onValueChange={onAgentFilter}>
         <Select.Trigger
           aria-label={copy("skills.filter.agent_label")}
@@ -283,7 +282,43 @@ function FilterToolbar({
         </Select.Portal>
       </Select.Root>
 
-      <span className="text-oai-gray-500 dark:text-oai-gray-400">
+      <div className="relative w-56 max-w-full">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-oai-gray-400" aria-hidden />
+        <Input
+          type="search"
+          value={searchQuery}
+          onChange={(event) => onSearchQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape" && searchQuery) {
+              event.preventDefault();
+              onSearchQuery("");
+            }
+          }}
+          aria-label={copy("skills.action.search_aria")}
+          placeholder={searchPlaceholder}
+          className="h-8 pl-9 pr-8 !border-oai-gray-200 dark:!border-oai-gray-800 focus:!border-oai-gray-400 focus:!ring-oai-gray-400/20 dark:focus:!border-oai-gray-500 dark:focus:!ring-oai-gray-500/20 [&::-webkit-search-cancel-button]:appearance-none"
+        />
+        <button
+          type="button"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => onSearchQuery("")}
+          aria-label={copy("skills.action.search_clear")}
+          aria-hidden={!searchQuery}
+          tabIndex={searchQuery ? 0 : -1}
+          className={cn(
+            "absolute right-2 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-oai-gray-400 transition duration-150 ease-out before:absolute before:-inset-1.5 before:content-[''] hover:bg-oai-gray-100 hover:text-oai-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-oai-gray-400/40 motion-reduce:transition-none dark:hover:bg-oai-gray-800 dark:hover:text-oai-gray-200",
+            searchQuery ? "scale-100 opacity-100" : "pointer-events-none scale-90 opacity-0",
+          )}
+        >
+          <XIcon className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      </div>
+
+      <span
+        role="status"
+        aria-live="polite"
+        className="ml-auto shrink-0 tabular-nums text-oai-gray-500 dark:text-oai-gray-400"
+      >
         {copy("skills.filter.result_count", { filtered: filteredCount, total: totalCount })}
       </span>
 
@@ -291,24 +326,12 @@ function FilterToolbar({
         <button
           type="button"
           onClick={onClearFilters}
-          className="ml-auto inline-flex h-7 items-center gap-1 rounded-full bg-oai-gray-100 px-2.5 text-[11px] font-medium text-oai-gray-700 transition hover:bg-oai-gray-200 focus:outline-none focus:ring-2 focus:ring-oai-gray-400/30 dark:bg-oai-gray-800/70 dark:text-oai-gray-200 dark:hover:bg-oai-gray-700"
+          className="shrink-0 inline-flex h-7 items-center gap-1 rounded-full bg-oai-gray-100 px-2.5 text-[11px] font-medium text-oai-gray-700 transition hover:bg-oai-gray-200 focus:outline-none focus:ring-2 focus:ring-oai-gray-400/30 dark:bg-oai-gray-800/70 dark:text-oai-gray-200 dark:hover:bg-oai-gray-700"
         >
           <XIcon className="h-3 w-3" aria-hidden />
           {copy("skills.filter.clear")}
         </button>
       ) : null}
-      </div>
-      <div className="relative">
-        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-oai-gray-400" aria-hidden />
-        <Input
-          type="search"
-          value={searchQuery}
-          onChange={(event) => onSearchQuery(event.target.value)}
-          aria-label={copy("skills.action.search_aria")}
-          placeholder={searchPlaceholder}
-          className="pl-9 !border-oai-gray-200 dark:!border-oai-gray-800 focus:!border-oai-gray-400 focus:!ring-oai-gray-400/20 dark:focus:!border-oai-gray-500 dark:focus:!ring-oai-gray-500/20"
-        />
-      </div>
     </div>
   );
 }
@@ -868,7 +891,7 @@ export function SkillsPage() {
   }, [query]);
 
   useEffect(() => {
-    const timer = setTimeout(() => setMyDebouncedQuery(myQuery), 200);
+    const timer = setTimeout(() => setMyDebouncedQuery(myQuery), 120);
     return () => clearTimeout(timer);
   }, [myQuery]);
 
@@ -1126,7 +1149,10 @@ export function SkillsPage() {
     );
   }, [mySkills, agentFilter, myDebouncedQuery]);
 
-  const myAnyFilter = agentFilter !== "all" || myDebouncedQuery.trim() !== "";
+  // Search is not a "filter": the search box owns its own clear (×). The
+  // toolbar "Clear filters" pill is gated on the agent filter only, so typing
+  // a query never makes it appear.
+  const myAnyFilter = agentFilter !== "all";
 
   const selectedSkill = useMemo(() => {
     if (!selectedSkillId) return null;

--- a/dashboard/src/pages/SkillsPage.test.jsx
+++ b/dashboard/src/pages/SkillsPage.test.jsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { copy } from "../lib/copy";
 import {
@@ -41,11 +42,19 @@ beforeEach(() => {
     ],
     skills: [
       {
-        id: "sample-skill",
-        name: "Sample Skill",
-        directory: "sample-skill",
-        description: "Keeps the installed list visible.",
+        id: "alpha-skill",
+        name: "Alpha Skill",
+        directory: "alpha-skill",
+        description: "First installed skill.",
         targets: ["claude", "grok", "antigravity"],
+        managed: true,
+      },
+      {
+        id: "beta-skill",
+        name: "Beta Skill",
+        directory: "beta-skill",
+        description: "Second installed skill.",
+        targets: ["claude"],
         managed: true,
       },
     ],
@@ -67,13 +76,57 @@ describe("SkillsPage", () => {
   it("renders installed skills instead of the empty state", async () => {
     render(<SkillsPage />);
 
-    expect(await screen.findByText("Sample Skill")).toBeInTheDocument();
-    expect(screen.getByText("Keeps the installed list visible.")).toBeInTheDocument();
-    expect(screen.getByText("Grok")).toBeInTheDocument();
-    expect(screen.getByText("Antigravity")).toBeInTheDocument();
+    expect(await screen.findByText("Alpha Skill")).toBeInTheDocument();
+    expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+    expect(screen.getByText("First installed skill.")).toBeInTheDocument();
+    expect(
+      screen.getByRole("searchbox", { name: copy("skills.action.search_aria") }),
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(screen.queryByText(copy("skills.empty.my"))).not.toBeInTheDocument();
+    });
+  });
+
+  it("filters the My tab list client-side by search query", async () => {
+    const user = userEvent.setup();
+    render(<SkillsPage />);
+
+    expect(await screen.findByText("Alpha Skill")).toBeInTheDocument();
+    expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: copy("skills.action.search_aria"),
+    });
+    await user.type(searchInput, "alpha");
+
+    await waitFor(() => {
+      expect(screen.getByText("Alpha Skill")).toBeInTheDocument();
+      expect(screen.queryByText("Beta Skill")).not.toBeInTheDocument();
+    });
+    expect(searchSkills).not.toHaveBeenCalled();
+  });
+
+  it("clears My tab search when clear filters is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SkillsPage />);
+
+    expect(await screen.findByText("Alpha Skill")).toBeInTheDocument();
+
+    const searchInput = screen.getByRole("searchbox", {
+      name: copy("skills.action.search_aria"),
+    });
+    await user.type(searchInput, "alpha");
+
+    await waitFor(() => {
+      expect(screen.queryByText("Beta Skill")).not.toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: copy("skills.filter.clear") }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Beta Skill")).toBeInTheDocument();
+      expect(searchInput).toHaveValue("");
     });
   });
 });


### PR DESCRIPTION
PR Goal: Add client-side search on the My Skills tab to filter the already-loaded list (AND with agent filter).

Scope

• My tab search UI + debounced filter (name / directory / description)
• Composes with agent filter; clear resets both
• Copy + tests only (dashboard/)

Codex Context

• Delta: feat(dashboard): add client-side search on My Skills tab (3ec13db)
• Invariants: Filter getInstalledSkills() data only; no searchSkills, no FS scan; AND with agent filter
• Edge cases: Empty query; no matches + clear; agent + search; separate myQuery from Browse tab
• Tests: npm --prefix dashboard run test -- SkillsPage.test.jsx — 3 passed; npm run validate:copy — ok
• Out of scope: Count denominator UX (x / total vs x / agent-total); Command Palette

Risk Layer Trigger

None checked.

Regression Test Gate

• Surface: My tab list filtering / filter toolbar
• Verification: [x] SkillsPage.test.jsx (render, filter, clear)
• Uncovered: Full dashboard build; manual Browse tab regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a search field (with clear action) to filter installed skills on the "My" tab with debounced client-side filtering and clear/reset behavior.

* **Localization**
  * Added Japanese, Korean, Traditional Chinese, and Simplified Chinese strings for the search placeholder and clear action.

* **Tests**
  * Updated and added tests covering the new search, client-side filtering, and clear filters behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->