### PR TITLE
feat(windows): align desktop pet quips with macOS + persist currency

### DIFF
--- a/TokenTrackerWin/Currency.cs
+++ b/TokenTrackerWin/Currency.cs
@@ -1,9 +1,18 @@
+using System.IO;
+using System.Text.Json.Nodes;
+
 namespace TokenTrackerWin;
 
 /// <summary>
 /// Mirror of the dashboard's <c>lib/currency.ts</c> symbol + default-rate table.
 /// The tray reads the user's chosen currency (and live rates) from the WebView's
 /// localStorage; these are the fallbacks when a rate is missing.
+///
+/// The chosen symbol + rate are also cached natively (native-settings.json, alongside
+/// the locale/theme prefs) so the floating pet can show the right currency on a cold
+/// launch — when only the pet is on screen and the dashboard WebView (the live source)
+/// hasn't been created yet, there'd otherwise be nothing to read and the pet would fall
+/// back to USD even though the app last ran in, say, CNY.
 /// </summary>
 internal static class Currency
 {
@@ -23,4 +32,50 @@ internal static class Currency
 
     public static decimal DefaultRate(string? code) =>
         code is not null && Map.TryGetValue(code, out var m) ? m.DefaultRate : 1m;
+
+    // ── Native cache (native-settings.json) ────────────────────────────
+
+    private static readonly string SettingsPath = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "TokenTracker",
+        "native-settings.json");
+
+    /// <summary>Cache the live currency symbol + USD→currency rate so a cold-launched pet
+    /// matches the app's last-used unit before the dashboard WebView exists.</summary>
+    public static void Persist(string symbol, decimal rate)
+    {
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(SettingsPath)!);
+            var settings = ReadSettingsObject();
+            settings["CurrencySymbol"] = symbol;
+            settings["CurrencyRate"] = JsonValue.Create(rate);
+            File.WriteAllText(SettingsPath, settings.ToJsonString());
+        }
+        catch { /* best-effort native cache */ }
+    }
+
+    /// <summary>The last cached (symbol, rate), or null if none has been stored yet.</summary>
+    public static (string Symbol, decimal Rate)? ReadPersisted()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath)) return null;
+            var settings = JsonNode.Parse(File.ReadAllText(SettingsPath))?.AsObject();
+            if (settings?["CurrencySymbol"]?.GetValue<string>() is not { Length: > 0 } symbol) return null;
+            var rate = settings["CurrencyRate"]?.GetValue<decimal>() ?? 1m;
+            return (symbol, rate > 0 ? rate : 1m);
+        }
+        catch { return null; }
+    }
+
+    private static JsonObject ReadSettingsObject()
+    {
+        try
+        {
+            if (!File.Exists(SettingsPath)) return new JsonObject();
+            return JsonNode.Parse(File.ReadAllText(SettingsPath))?.AsObject() ?? new JsonObject();
+        }
+        catch { return new JsonObject(); }
+    }
 }

--- a/TokenTrackerWin/PetWindow.cs
+++ b/TokenTrackerWin/PetWindow.cs
@@ -49,8 +49,7 @@ internal sealed class PetWindow : Window
     private decimal _curRate = 1m;
     private string _locale = "en";
     private bool _syncing;
-    private long _tokens;
-    private decimal _costUsd;
+    private UsagePoller.UsageStats _stats;
     private bool _connected = true;
 
     /// <summary>Raised (on the UI thread) when the user right-clicks the pet — the host shows a context menu.</summary>
@@ -59,6 +58,15 @@ internal sealed class PetWindow : Window
     public PetWindow(ServerManager server)
     {
         _server = server;
+
+        // Seed the currency from the native cache so the very first push (on page load)
+        // already carries the app's last-used unit — no USD flash before the tray's
+        // RefreshSummary lands, and correct even when the dashboard was never opened.
+        if (Currency.ReadPersisted() is { } cached)
+        {
+            _curSymbol = cached.Symbol;
+            _curRate = cached.Rate;
+        }
 
         Title = Constants.AppDisplayName + " Pet";
         var (w, h) = SizeDimensions(CurrentSize);
@@ -333,14 +341,15 @@ internal sealed class PetWindow : Window
     }
 
     /// <summary>
-    /// Push today's usage (the SAME numbers the tray's UsagePoller fetched) so the
-    /// pet's bubble + animation tier always match the tray exactly — no independent
-    /// polling, no drift.
+    /// Push the usage stats (the SAME numbers the tray's UsagePoller fetched) so the
+    /// pet's bubble + animation tier + data-rich quip pool always match the tray exactly
+    /// — no independent polling, no drift. Today's tokens/cost drive the hover bubble and
+    /// animation tier; the rolling / heatmap / top-model figures feed the quip pool
+    /// (mirroring the macOS companion).
     /// </summary>
-    public void ApplyUsage(long tokens, decimal costUsd)
+    public void ApplyStats(UsagePoller.UsageStats stats)
     {
-        _tokens = tokens;
-        _costUsd = costUsd;
+        _stats = stats;
         PushContext();
     }
 
@@ -354,20 +363,36 @@ internal sealed class PetWindow : Window
     private void PushContext()
     {
         if (!_coreReady) return;
+        var inv = System.Globalization.CultureInfo.InvariantCulture;
         var sym = System.Text.Json.JsonSerializer.Serialize(_curSymbol);
-        var rate = _curRate.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var rate = _curRate.ToString(inv);
         var loc = System.Text.Json.JsonSerializer.Serialize(_locale);
         var syncing = _syncing ? "true" : "false";
-        var cost = _costUsd.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var cost = _stats.TodayCostUsd.ToString(inv);
         var connected = _connected ? "true" : "false";
+        var statsJson = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            todayTokens = _stats.TodayTokens,
+            todayCostUsd = _stats.TodayCostUsd,
+            conversations = _stats.TodayConversations,
+            last7dTokens = _stats.Last7dTokens,
+            last7dActiveDays = _stats.Last7dActiveDays,
+            last30dTokens = _stats.Last30dTokens,
+            last30dAvgPerDay = _stats.Last30dAvgPerDay,
+            streakDays = _stats.StreakDays,
+            activeDaysAllTime = _stats.ActiveDaysAllTime,
+            topModels = (_stats.TopModels ?? Array.Empty<UsagePoller.TopModelStat>())
+                .Select(m => new { name = m.Name, percent = m.Percent, source = m.Source }),
+        });
         try
         {
             _ = _webView.CoreWebView2.ExecuteScriptAsync(
                 $"window.__ttPetCurrency={{symbol:{sym},rate:{rate}}};" +
                 $"window.__ttPetLocale={loc};" +
                 $"window.__ttPetSyncing={syncing};" +
-                $"window.__ttPetTokens={_tokens};" +
+                $"window.__ttPetTokens={_stats.TodayTokens};" +
                 $"window.__ttPetCostUsd={cost};" +
+                $"window.__ttPetStats={statsJson};" +
                 $"window.__ttPetConnected={connected};" +
                 "window.dispatchEvent(new Event('pet:currency'));" +
                 "window.dispatchEvent(new Event('pet:locale'));" +
@@ -466,13 +491,17 @@ internal sealed class PetWindow : Window
         };
     }
 
-    // Height includes a ~28px top band reserved for the hover/quip bubble (pet.jsx
-    // BUBBLE_BAND) so the bubble floats above Clawd instead of overlapping it.
+    // Height includes a ~46px top band reserved for the hover/quip bubble (pet.jsx
+    // BUBBLE_BAND) so the bubble floats above Clawd instead of overlapping it. The band
+    // is sized for a two-line bubble (the data-rich quips wrap), and the widths are a
+    // little roomier than the sprite needs so longer lines have horizontal space. The
+    // sprite tracks (height − band), so these heights keep it the same visual size as
+    // before the taller band.
     private static (double Width, double Height) SizeDimensions(string size) => size switch
     {
-        SizeSmall => (140, 120),
-        SizeLarge => (196, 176),
-        _ => (164, 144),
+        SizeSmall => (150, 138),
+        SizeLarge => (210, 194),
+        _ => (180, 162),
     };
 
     /// <summary>The persisted size choice (defaults to medium).</summary>

--- a/TokenTrackerWin/TrayApplicationContext.cs
+++ b/TokenTrackerWin/TrayApplicationContext.cs
@@ -184,6 +184,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
             {
                 EnsurePet();
                 _petWindow!.ShowPet();
+                _poller.IncludeRichStats = true;   // gather the pet's quip-pool stats
                 UpdatePetMenuText();
                 RefreshSummary();
             }));
@@ -350,10 +351,13 @@ internal sealed class TrayApplicationContext : ApplicationContext
         _petWindow!.TogglePet();
         _petWindow.StoreVisible(_petWindow.IsVisible);
         UpdatePetMenuText();
+        // The pet's quip pool needs the heatmap + model-breakdown stats; only gather them
+        // (two extra calls per poll) while the pet is actually on screen.
+        _poller.IncludeRichStats = _petWindow.IsVisible;
         if (_petWindow.IsVisible)
         {
             RefreshSummary();      // push the current numbers right away
-            _poller.RefreshNow();  // and fetch the freshest
+            _poller.RefreshNow();  // and fetch the freshest (now incl. rich stats)
         }
     }
 
@@ -417,6 +421,7 @@ internal sealed class TrayApplicationContext : ApplicationContext
         if (_petWindow is null) return;
         _petWindow.HidePet();
         _petWindow.StoreVisible(false);
+        _poller.IncludeRichStats = false;   // stop gathering the pet-only stats
         UpdatePetMenuText();
     }
 
@@ -425,8 +430,11 @@ internal sealed class TrayApplicationContext : ApplicationContext
         if (_dashboard is not null) return;
         _dashboard = new DashboardWindow(_server);
         // Re-render the cost when the dashboard reports a currency change (and once
-        // it has loaded, so we pick up the user's chosen currency right away).
-        _dashboard.CurrencyChanged += () => PostToUi(RefreshSummary);
+        // it has loaded, so we pick up the user's chosen currency right away), and cache
+        // it natively so a future cold-launched pet shows the same unit before the
+        // dashboard exists. CurrencyChanged only fires once the page is loaded, so the
+        // read here is real (never the transient USD default).
+        _dashboard.CurrencyChanged += () => PostToUi(() => { RefreshSummary(); PersistCurrencyFromDashboard(); });
         _dashboard.LocaleChanged += () => PostToUi(RefreshLocaleFromDashboard);
         _dashboard.ThemeChanged += () => PostToUi(RefreshThemeFromDashboard);
     }
@@ -534,10 +542,13 @@ internal sealed class TrayApplicationContext : ApplicationContext
     /// <summary>Render the today summary into the menu + tooltip, in the user's currency.</summary>
     private async void RefreshSummary()
     {
-        // Convert USD → the dashboard's chosen currency (read from its localStorage).
+        // Convert USD → the dashboard's chosen currency. The live source is the dashboard
+        // WebView's localStorage; before it exists (cold launch with only the pet on
+        // screen) fall back to the natively-cached symbol/rate so the pet matches the
+        // app's last-used unit instead of flashing USD.
         var (symbol, rate) = _dashboard is not null
             ? await _dashboard.ReadCurrencyAsync()
-            : ("$", 1m);
+            : Currency.ReadPersisted() ?? ("$", 1m);
         // Push currency + language to the pet even before the first usage poll lands, so
         // a freshly launched pet never sits in default USD/English until polling finishes
         // (connection state is owned by OnServerStatusChanged).
@@ -546,13 +557,13 @@ internal sealed class TrayApplicationContext : ApplicationContext
 
         if (_lastStats is not { } s)
         {
-            _petWindow?.ApplyUsage(0, 0m);
+            _petWindow?.ApplyStats(default);
             _summaryItem.Text = $"{_strings.TodayTitle}: {_strings.NoData}";
             return;
         }
 
         // Feed the floating pet the SAME numbers the tray shows (same poller, same moment).
-        _petWindow?.ApplyUsage(s.TodayTokens, s.TodayCostUsd);
+        _petWindow?.ApplyStats(s);
         _petWindow?.ApplyConnected(_server.Status == ServerManager.ServerStatus.Running);
         var cost = symbol + (s.TodayCostUsd * rate).ToString("0.00", CultureInfo.InvariantCulture);
         var text = s.TodayTokens <= 0
@@ -563,6 +574,16 @@ internal sealed class TrayApplicationContext : ApplicationContext
         // The tray-icon tooltip stays the app name (set once in the ctor). The floating
         // pet now surfaces live usage, so the hover tooltip no longer mirrors the summary.
         RefreshTrayIconForTheme();
+    }
+
+    /// <summary>Cache the dashboard's current currency natively so a cold-launched pet
+    /// (no dashboard WebView yet) can show the right unit. Only called from the
+    /// CurrencyChanged handler, where the read reflects a real, loaded value.</summary>
+    private async void PersistCurrencyFromDashboard()
+    {
+        if (_dashboard is null) return;
+        var (symbol, rate) = await _dashboard.ReadCurrencyAsync();
+        Currency.Persist(symbol, rate);
     }
 
     private void PostToUi(Action action)

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -5,18 +5,46 @@ using System.Text.Json;
 namespace TokenTrackerWin;
 
 /// <summary>
-/// Polls the local server's usage-summary endpoint for today's totals so the
-/// tray can show "Today &lt;tokens&gt; · &lt;cost&gt;" (the Windows stand-in for the
-/// macOS menu-bar stat display — the tray can't render inline text, so the
-/// numbers surface in the tooltip + menu header).
+/// Polls the local server's usage endpoints for the figures the tray + floating pet
+/// surface. The tray only needs today's totals ("Today &lt;tokens&gt; · &lt;cost&gt;"),
+/// but the desktop pet mirrors the macOS companion's data-rich quip pool, so when the
+/// pet is visible the poller also gathers the rolling / heatmap / top-model stats the
+/// macOS <c>DashboardViewModel</c> feeds its <c>quipPool</c>.
+///
+/// The 7-day / 30-day rolling stats + today's conversation count come <b>free</b> from
+/// the same usage-summary call the tray already makes (the endpoint returns a
+/// <c>rolling</c> block). The heatmap (all-time active days) and model breakdown (top
+/// models) need their own calls, so they are gated behind <see cref="IncludeRichStats"/>
+/// — only fetched while the pet is on screen, never wasted when it's hidden.
 /// </summary>
 internal sealed class UsagePoller : IDisposable
 {
-    public readonly record struct UsageStats(long TodayTokens, decimal TodayCostUsd);
+    /// <summary>One of the pet's "top models" (name + share + provider), mirroring macOS TopModel.</summary>
+    public readonly record struct TopModelStat(string Name, string Percent, string Source);
+
+    public readonly record struct UsageStats(
+        long TodayTokens,
+        decimal TodayCostUsd,
+        int TodayConversations,
+        long Last7dTokens,
+        int Last7dActiveDays,
+        long Last30dTokens,
+        long Last30dAvgPerDay,
+        int StreakDays,
+        int ActiveDaysAllTime,
+        IReadOnlyList<TopModelStat> TopModels);
 
     private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(6) };
+    private static readonly IReadOnlyList<TopModelStat> NoModels = Array.Empty<TopModelStat>();
     private readonly Func<string> _baseUrl;
     private CancellationTokenSource? _cts;
+
+    /// <summary>
+    /// When true, each poll also gathers the heatmap + model-breakdown stats the pet's
+    /// quip pool uses (two extra calls). The tray sets this from the pet's visibility so
+    /// the extra work only happens while the pet is on screen.
+    /// </summary>
+    public volatile bool IncludeRichStats;
 
     /// <summary>Raised on the thread-pool with fresh stats. UI must marshal to the UI thread.</summary>
     public event Action<UsageStats>? StatsUpdated;
@@ -55,27 +83,58 @@ internal sealed class UsagePoller : IDisposable
         try
         {
             var today = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
-            var offsetMin = (int)DateTimeOffset.Now.Offset.TotalMinutes;
-            var tz = ResolveIanaTimeZone();
-            var url = $"{_baseUrl()}/functions/tokentracker-usage-summary"
-                      + $"?from={today}&to={today}&tz={Uri.EscapeDataString(tz)}"
-                      + $"&tz_offset_minutes={offsetMin}";
+            var tzQuery = TimeZoneQuery();
 
-            using var resp = await Http.GetAsync(url);
+            var summaryUrl = $"{_baseUrl()}/functions/tokentracker-usage-summary"
+                             + $"?from={today}&to={today}{tzQuery}";
+
+            using var resp = await Http.GetAsync(summaryUrl);
             if (!resp.IsSuccessStatusCode) return null;
 
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);
-            if (!doc.RootElement.TryGetProperty("totals", out var totals)) return null;
+            var root = doc.RootElement;
+            if (!root.TryGetProperty("totals", out var totals)) return null;
 
-            long tokens = totals.TryGetProperty("total_tokens", out var t)
-                ? t.GetInt64() : 0;
+            long tokens = GetLong(totals, "total_tokens");
+            int convos = (int)GetLong(totals, "conversation_count");
             decimal cost = 0m;
             if (totals.TryGetProperty("total_cost_usd", out var c)
                 && decimal.TryParse(c.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
                 cost = parsed;
 
-            return new UsageStats(tokens, cost);
+            // 7-day / 30-day rolling stats ride along in the same response — no extra call.
+            long l7Tokens = 0, l30Tokens = 0, l30Avg = 0;
+            int l7Active = 0;
+            if (root.TryGetProperty("rolling", out var rolling))
+            {
+                if (rolling.TryGetProperty("last_7d", out var l7))
+                {
+                    l7Active = (int)GetLong(l7, "active_days");
+                    if (l7.TryGetProperty("totals", out var l7t)) l7Tokens = GetLong(l7t, "billable_total_tokens");
+                }
+                if (rolling.TryGetProperty("last_30d", out var l30))
+                {
+                    l30Avg = GetLong(l30, "avg_per_active_day");
+                    if (l30.TryGetProperty("totals", out var l30t)) l30Tokens = GetLong(l30t, "billable_total_tokens");
+                }
+            }
+
+            // Heatmap (all-time active days / streak) + top models only when the pet wants them.
+            int streak = 0, activeAll = 0;
+            IReadOnlyList<TopModelStat> models = NoModels;
+            if (IncludeRichStats)
+            {
+                (streak, activeAll) = await FetchHeatmapAsync(tzQuery);
+                models = await FetchTopModelsAsync(today, tzQuery);
+            }
+
+            return new UsageStats(
+                tokens, cost, convos,
+                l7Tokens, l7Active,
+                l30Tokens, l30Avg,
+                streak, activeAll,
+                models);
         }
         catch
         {
@@ -83,7 +142,116 @@ internal sealed class UsagePoller : IDisposable
         }
     }
 
-    /// <summary>The endpoint expects an IANA tz; Windows uses its own ids, so convert.</summary>
+    /// <summary>Heatmap: all-time active days + current streak (streak is server-computed; the
+    /// local server returns 0, matching how the macOS pet reads it against the same backend).</summary>
+    private async Task<(int Streak, int ActiveDays)> FetchHeatmapAsync(string tzQuery)
+    {
+        try
+        {
+            var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}";
+            using var resp = await Http.GetAsync(url);
+            if (!resp.IsSuccessStatusCode) return (0, 0);
+            await using var stream = await resp.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+            var root = doc.RootElement;
+            return ((int)GetLong(root, "streak_days"), (int)GetLong(root, "active_days"));
+        }
+        catch { return (0, 0); }
+    }
+
+    /// <summary>
+    /// Top models over the last 30 days — a faithful port of the macOS
+    /// <c>DashboardViewModel.buildTopModels()</c>: dedupe by lowercased model name, keep the
+    /// provider from the highest-token row for that name, percent = tokens / total billable
+    /// (one decimal), sort by tokens desc then name asc, top 5.
+    /// </summary>
+    private async Task<IReadOnlyList<TopModelStat>> FetchTopModelsAsync(string today, string tzQuery)
+    {
+        try
+        {
+            var from = DateTime.Now.AddDays(-29).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+            var url = $"{_baseUrl()}/functions/tokentracker-usage-model-breakdown"
+                      + $"?from={from}&to={today}{tzQuery}";
+            using var resp = await Http.GetAsync(url);
+            if (!resp.IsSuccessStatusCode) return NoModels;
+            await using var stream = await resp.Content.ReadAsStreamAsync();
+            using var doc = await JsonDocument.ParseAsync(stream);
+            if (!doc.RootElement.TryGetProperty("sources", out var sources)
+                || sources.ValueKind != JsonValueKind.Array) return NoModels;
+
+            var tokensByKey = new Dictionary<string, long>();
+            var nameByKey = new Dictionary<string, string>();
+            var sourceByKey = new Dictionary<string, string>();
+            var weightByKey = new Dictionary<string, long>();
+            long totalTokensAll = 0;
+
+            foreach (var src in sources.EnumerateArray())
+            {
+                var srcName = src.TryGetProperty("source", out var sn) ? sn.GetString() ?? "" : "";
+                if (!src.TryGetProperty("models", out var modelsEl) || modelsEl.ValueKind != JsonValueKind.Array)
+                    continue;
+                foreach (var m in modelsEl.EnumerateArray())
+                {
+                    long mt = m.TryGetProperty("totals", out var mtotals) ? GetLong(mtotals, "billable_total_tokens") : 0;
+                    if (mt <= 0) continue;
+                    var name = m.TryGetProperty("model", out var mn) ? mn.GetString() ?? "" : "";
+                    if (string.IsNullOrEmpty(name)) name = "—";
+                    var key = name.ToLowerInvariant().Trim();
+                    if (key.Length == 0) continue;
+
+                    totalTokensAll += mt;
+                    tokensByKey[key] = tokensByKey.GetValueOrDefault(key) + mt;
+                    if (mt >= weightByKey.GetValueOrDefault(key))
+                    {
+                        weightByKey[key] = mt;
+                        nameByKey[key] = name;
+                        sourceByKey[key] = srcName;
+                    }
+                }
+            }
+
+            if (tokensByKey.Count == 0) return NoModels;
+            long totalTokens = totalTokensAll > 0 ? totalTokensAll : tokensByKey.Values.Sum();
+
+            return tokensByKey
+                .Select(kv => new
+                {
+                    Tokens = kv.Value,
+                    Stat = new TopModelStat(
+                        nameByKey.GetValueOrDefault(kv.Key, "—"),
+                        totalTokens > 0
+                            ? (kv.Value / (double)totalTokens * 100).ToString("0.0", CultureInfo.InvariantCulture)
+                            : "0.0",
+                        sourceByKey.GetValueOrDefault(kv.Key, "")),
+                })
+                .OrderByDescending(x => x.Tokens)
+                .ThenBy(x => x.Stat.Name, StringComparer.Ordinal)
+                .Take(5)
+                .Select(x => x.Stat)
+                .ToList();
+        }
+        catch { return NoModels; }
+    }
+
+    private static long GetLong(JsonElement obj, string name)
+    {
+        if (!obj.TryGetProperty(name, out var el)) return 0;
+        return el.ValueKind switch
+        {
+            JsonValueKind.Number => el.TryGetInt64(out var v) ? v : (long)el.GetDouble(),
+            JsonValueKind.String => long.TryParse(el.GetString(), NumberStyles.Any, CultureInfo.InvariantCulture, out var s) ? s : 0,
+            _ => 0,
+        };
+    }
+
+    /// <summary>The usage endpoints expect an IANA tz; Windows uses its own ids, so convert.</summary>
+    private static string TimeZoneQuery()
+    {
+        var offsetMin = (int)DateTimeOffset.Now.Offset.TotalMinutes;
+        var tz = ResolveIanaTimeZone();
+        return $"&tz={Uri.EscapeDataString(tz)}&tz_offset_minutes={offsetMin}";
+    }
+
     private static string ResolveIanaTimeZone()
     {
         try

--- a/dashboard/src/lib/pet-quips.js
+++ b/dashboard/src/lib/pet-quips.js
@@ -4,13 +4,14 @@
  * a standalone data module — like Strings.swift — rather than the dashboard copy
  * registry, because the pet is a minimal standalone entry without the i18n provider.
  *
- * Tiering matches macOS: today's token volume picks a tier pool. On a non-empty day
- * the tap quip is usage-aware — it bakes in today's real token count + cost (the
- * macOS companion's "today data" quips: tokensToday / tokensSpentToday / … ). Generic
- * personality lines are down-weighted to a ~25% minority so most taps reflect the
- * actual numbers rather than saying random nice things. macOS stays usage-dominant by
- * also mixing in 7d/30d/streak/model lines; the Windows pet only receives today's
- * figures from the host, so it down-weights personality directly instead.
+ * Full macOS parity: `buildQuipPool` reproduces the macOS companion's `quipPool`
+ * ordering 1:1 — today data (tokens + cost + tier) → 7d/30d rolling → heatmap
+ * streak/active days → top models → conversation count → personality. The native host
+ * now pushes ALL of these figures (window.__ttPetStats), the same ones macOS reads from
+ * its DashboardViewModel, so the Windows pet is no longer limited to today's numbers.
+ * The caller rotates through the pool by index on each tap (like macOS `quipIndex`):
+ * because the data-rich lines outnumber the handful of personality lines, most taps
+ * surface real numbers and personality stays a natural minority — no random weighting.
  */
 
 const QUIPS = {
@@ -133,6 +134,92 @@ const TODAY_QUIPS = {
   },
 };
 
+// Rolling / heatmap / top-model / conversation quips — ported 1:1 from the macOS
+// companion's quipPool (Strings.sevenDayTotal / activeDaysThisWeek / perfectStreak /
+// thirtyDayTotal / averagingPerDay / streakDays / activeDaysAllTime / topModel /
+// runnerUp / modelCount / multiToolSetup / conversationsToday / busyTalker). The native
+// host pushes these figures (window.__ttPetStats) — the same ones macOS reads from its
+// DashboardViewModel. Placeholders: {tokens} compact token count, {n} a count, {name}
+// model name, {percent} share (one decimal, no % — matching macOS), {names} provider
+// list, {s} English plural suffix.
+const STATS_QUIPS = {
+  "en": {
+    sevenDayTotal: "📅 7-day total: {tokens} tokens",
+    activeDaysThisWeek: "{n} active days this week",
+    perfectStreak: "🏆 7/7 active days — perfect streak!",
+    thirtyDayTotal: "📆 30-day total: {tokens} tokens",
+    averagingPerDay: "📊 Averaging ~{tokens}/day this month",
+    streakDays: "🔥 {n}-day streak! Keep it going",
+    activeDaysAllTime: "📈 {n} active days all-time!",
+    topModel: "🥇 Top model: {name} ({percent})",
+    runnerUp: "🥈 Runner-up: {name} at {percent}",
+    modelCount: "🧰 Using {n} different models",
+    multiToolSetup: "🔀 Multi-tool setup: {names}",
+    conversationsToday: "💬 {n} conversation{s} today",
+    busyTalker: "🗣️ {n} chats! Busy talker today",
+  },
+  "zh-CN": {
+    sevenDayTotal: "📅 7 天总计：{tokens} tokens",
+    activeDaysThisWeek: "本周 {n} 个活跃日",
+    perfectStreak: "🏆 7/7 活跃日，完美连续！",
+    thirtyDayTotal: "📆 30 天总计：{tokens} tokens",
+    averagingPerDay: "📊 本月平均约 {tokens}/天",
+    streakDays: "🔥 连续 {n} 天！继续保持",
+    activeDaysAllTime: "📈 累计 {n} 个活跃日！",
+    topModel: "🥇 最常用模型：{name}（{percent}）",
+    runnerUp: "🥈 第二名：{name}，{percent}",
+    modelCount: "🧰 使用了 {n} 个不同模型",
+    multiToolSetup: "🔀 多工具组合：{names}",
+    conversationsToday: "💬 今日 {n} 次对话",
+    busyTalker: "🗣️ {n} 次聊天，今天很忙",
+  },
+  "zh-TW": {
+    sevenDayTotal: "📅 7 天總計：{tokens} tokens",
+    activeDaysThisWeek: "本週 {n} 個活躍日",
+    perfectStreak: "🏆 7/7 活躍日，完美連續！",
+    thirtyDayTotal: "📆 30 天總計：{tokens} tokens",
+    averagingPerDay: "📊 本月平均約 {tokens}/天",
+    streakDays: "🔥 連續 {n} 天！繼續保持",
+    activeDaysAllTime: "📈 累計 {n} 個活躍日！",
+    topModel: "🥇 最常用模型：{name}（{percent}）",
+    runnerUp: "🥈 第二名：{name}，{percent}",
+    modelCount: "🧰 使用了 {n} 個不同模型",
+    multiToolSetup: "🔀 多工具組合：{names}",
+    conversationsToday: "💬 今日 {n} 次對話",
+    busyTalker: "🗣️ {n} 次聊天，今天很忙",
+  },
+  "ja": {
+    sevenDayTotal: "📅 7日間合計：{tokens} tokens",
+    activeDaysThisWeek: "今週 {n} アクティブ日",
+    perfectStreak: "🏆 7/7 アクティブ日 — 完璧な連続記録！",
+    thirtyDayTotal: "📆 30日間合計：{tokens} tokens",
+    averagingPerDay: "📊 今月は平均約 {tokens}/日",
+    streakDays: "🔥 {n}日連続！この調子で",
+    activeDaysAllTime: "📈 累計 {n} アクティブ日！",
+    topModel: "🥇 最も使用したモデル：{name}（{percent}）",
+    runnerUp: "🥈 2位：{name}（{percent}）",
+    modelCount: "🧰 {n} 種類のモデルを使用中",
+    multiToolSetup: "🔀 マルチツール構成：{names}",
+    conversationsToday: "💬 今日 {n} 件の会話",
+    busyTalker: "🗣️ {n} 回のチャット！今日はおしゃべり",
+  },
+  "ko": {
+    sevenDayTotal: "📅 7일 합계: {tokens} tokens",
+    activeDaysThisWeek: "이번 주 활동일 {n}일",
+    perfectStreak: "🏆 7/7 활동일 — 완벽한 연속 기록!",
+    thirtyDayTotal: "📆 30일 합계: {tokens} tokens",
+    averagingPerDay: "📊 이번 달 하루 평균 ~{tokens}",
+    streakDays: "🔥 {n}일 연속! 계속 가요",
+    activeDaysAllTime: "📈 누적 활동일 {n}일!",
+    topModel: "🥇 최다 사용 모델: {name} ({percent})",
+    runnerUp: "🥈 2위: {name}, {percent}",
+    modelCount: "🧰 서로 다른 모델 {n}개 사용 중",
+    multiToolSetup: "🔀 멀티 툴 구성: {names}",
+    conversationsToday: "💬 오늘 대화 {n}건",
+    busyTalker: "🗣️ 채팅 {n}회! 오늘 수다스럽네요",
+  },
+};
+
 // Shown (and used for tap quips) while a sync is in progress — ported from the
 // macOS app's syncingQuips.
 const SYNCING_QUIPS = {
@@ -186,47 +273,108 @@ function systemPetLocale() {
   }
 }
 
-function pick(arr) {
-  return arr[Math.floor(Math.random() * arr.length)] || "";
+/** Fill {key} placeholders from a vars map; unmatched braces are left as-is. */
+function fillVars(tpl, vars) {
+  return tpl.replace(/\{(\w+)\}/g, (m, k) => (k in vars ? String(vars[k]) : m));
 }
 
-function fill(tpl, tokensText, costText) {
-  return tpl.replace(/\{tokens\}/g, tokensText).replace(/\{cost\}/g, costText);
+/** Capitalize the first letter (matches macOS `String.capitalized` for single words). */
+function cap(s) {
+  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
 }
-
-// Share of taps that fall back to a generic personality line on a non-empty day; the
-// rest are usage-aware (bake in today's real figures). Keeps the pet feeling like it's
-// reacting to YOUR usage rather than saying random nice things.
-const PERSONALITY_CHANCE = 0.25;
 
 /**
- * Pick a random tap quip for the given locale.
- *
- * `ctx`: { tokens, tokensText, costText, costValue, isSyncing }
- *   - tokens     today's token count (number) — selects the tier / empty-day pool
- *   - tokensText today's tokens, pre-formatted exactly as the hover bubble shows
- *   - costText   today's cost, pre-formatted in the user's currency (e.g. "$3.45")
- *   - costValue  today's cost as a number (display currency) — gates the cost lines
- *   - isSyncing  show a syncing quip instead (matching macOS)
+ * Compact token formatter (1 decimal K/M/B) — matches the tray's UsagePoller.FormatTokens
+ * and the macOS TokenFormatter.formatCompact so every surface reads the same number.
  */
-export function pickQuip(locale, ctx = {}) {
-  const { tokens = 0, tokensText = "", costText = "", costValue = 0, isSyncing = false } = ctx;
+export function formatCompactTokens(n) {
+  if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(1) + "B";
+  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
+  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
+  return String(n);
+}
+
+/**
+ * Build the full tap-quip pool for the given locale — a faithful port of the macOS
+ * companion's `quipPool` (ClawdCompanionView.swift): today data → 7d/30d rolling →
+ * heatmap streak/active → top models → conversations → personality. The caller rotates
+ * through the returned list by index on each tap (matching macOS `quipIndex`), so the
+ * data-rich lines (the majority of the pool) dominate and the generic personality lines
+ * stay a natural minority — no random down-weighting needed.
+ *
+ * `ctx` (all optional): tokens, tokensText, costText, costValue, isSyncing (today);
+ * conversations; last7dTokens, last7dActiveDays; last30dTokens, last30dAvgPerDay;
+ * streakDays, activeDaysAllTime; topModels [{ name, percent, source }].
+ */
+export function buildQuipPool(locale, ctx = {}) {
+  const {
+    tokens = 0, tokensText = "", costText = "", costValue = 0, isSyncing = false,
+    conversations = 0,
+    last7dTokens = 0, last7dActiveDays = 0,
+    last30dTokens = 0, last30dAvgPerDay = 0,
+    streakDays = 0, activeDaysAllTime = 0,
+    topModels = [],
+  } = ctx;
   const loc = normalizePetLocale(locale);
-  if (isSyncing) return pick(SYNCING_QUIPS[loc] || SYNCING_QUIPS.en);
+  if (isSyncing) return SYNCING_QUIPS[loc] || SYNCING_QUIPS.en;
 
   const pool = QUIPS[loc] || QUIPS.en;
-  // Nothing logged yet — quiet-day lines + personality (no numbers to report).
-  if (tokens <= 0) return pick([...pool.empty, ...pool.personality]);
-
-  // Usage-aware lines first: today's real token/cost figures + the qualitative tier
-  // line. Cost lines only when today's cost rounds above zero (matches macOS).
   const today = TODAY_QUIPS[loc] || TODAY_QUIPS.en;
-  const dataLines = [
-    ...today.tokens,
-    ...(costValue >= 0.005 ? today.cost : []),
-    ...(pool[tierFor(tokens)] || []),
-  ].map((tpl) => fill(tpl, tokensText, costText));
+  const stats = STATS_QUIPS[loc] || STATS_QUIPS.en;
+  const todayVars = { tokens: tokensText, cost: costText };
+  const out = [];
 
-  if (Math.random() < PERSONALITY_CHANCE) return pick(pool.personality);
-  return pick(dataLines) || pick(pool.personality);
+  // === Today data ===
+  if (tokens <= 0) {
+    out.push(...pool.empty);
+  } else {
+    out.push(...today.tokens.map((t) => fillVars(t, todayVars)));
+    if (costValue >= 0.005) out.push(...today.cost.map((t) => fillVars(t, todayVars)));
+    out.push(...(pool[tierFor(tokens)] || []));
+  }
+
+  // === 7-day / 30-day rolling ===
+  if (last7dTokens > 0) {
+    out.push(fillVars(stats.sevenDayTotal, { tokens: formatCompactTokens(last7dTokens) }));
+    if (last7dActiveDays > 0) {
+      // macOS prepends the 🗓️ at the call site, not in the string.
+      out.push("🗓️ " + fillVars(stats.activeDaysThisWeek, { n: last7dActiveDays }));
+      if (last7dActiveDays >= 7) out.push(stats.perfectStreak);
+    }
+  }
+  if (last30dTokens > 0) {
+    out.push(fillVars(stats.thirtyDayTotal, { tokens: formatCompactTokens(last30dTokens) }));
+    if (last30dAvgPerDay > 0) {
+      out.push(fillVars(stats.averagingPerDay, { tokens: formatCompactTokens(last30dAvgPerDay) }));
+    }
+  }
+
+  // === Heatmap (streak / all-time active days) ===
+  if (streakDays > 1) out.push(fillVars(stats.streakDays, { n: streakDays }));
+  if (activeDaysAllTime > 30) out.push(fillVars(stats.activeDaysAllTime, { n: activeDaysAllTime }));
+
+  // === Top models ===
+  if (topModels.length > 0) {
+    const top = topModels[0];
+    out.push(fillVars(stats.topModel, { name: top.name, percent: top.percent }));
+    if (topModels.length >= 2) {
+      out.push(fillVars(stats.runnerUp, { name: topModels[1].name, percent: topModels[1].percent }));
+    }
+    if (topModels.length >= 3) out.push(fillVars(stats.modelCount, { n: topModels.length }));
+    const sources = [...new Set(topModels.map((m) => m.source).filter(Boolean))];
+    if (sources.length >= 2) {
+      out.push(fillVars(stats.multiToolSetup, { names: sources.map(cap).sort().join(" + ") }));
+    }
+  }
+
+  // === Conversation count ===
+  if (conversations > 0) {
+    out.push(fillVars(stats.conversationsToday, { n: conversations, s: conversations === 1 ? "" : "s" }));
+    if (conversations >= 10) out.push(fillVars(stats.busyTalker, { n: conversations }));
+  }
+
+  // === Personality (always) ===
+  out.push(...pool.personality);
+
+  return out.length ? out : pool.personality;
 }

--- a/dashboard/src/pet.jsx
+++ b/dashboard/src/pet.jsx
@@ -1,6 +1,11 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { pickQuip, normalizePetLocale, petLabels } from "./lib/pet-quips.js";
+import {
+  buildQuipPool,
+  formatCompactTokens as formatTokens,
+  normalizePetLocale,
+  petLabels,
+} from "./lib/pet-quips.js";
 
 /**
  * Standalone floating-pet entry for the Windows tray app (PetWindow.cs loads
@@ -30,8 +35,12 @@ const TAP_HOLD_MS = 2500;
 // so too small a value makes every click nudge the pet's position.
 const DRAG_THRESHOLD = 10;
 // Top band reserved for the bubble so it never overlaps Clawd (the host sizes the
-// window height to include this — keep in sync with PetWindow.SizeDimensions).
-const BUBBLE_BAND = 28;
+// window height to include this — keep in sync with PetWindow.SizeDimensions). Tall
+// enough for a two-line bubble: the data-rich macOS-parity quips (top model, 30-day
+// total, etc.) are longer than today's single line, and this layered window clips
+// content at its edges (unlike macOS, where the bubble can overflow the frame), so the
+// bubble wraps to a second line here instead of being truncated.
+const BUBBLE_BAND = 46;
 
 // Hover lean (macOS parity): while the cursor is over the pet, Clawd leans toward it
 // (ClawdCompanionView shifts the body ±1.2px and the eyes a touch more, ≈7% of width).
@@ -69,6 +78,27 @@ function readPetUsage() {
   };
 }
 
+// The full stats object the host pushes (window.__ttPetStats) — today + rolling 7d/30d
+// + heatmap + top models + conversations. Read fresh at tap time so the quip pool always
+// reflects the latest poll. Falls back to today-only numbers if the host hasn't pushed yet.
+function readPetStats() {
+  const s = typeof window !== "undefined" ? window.__ttPetStats : null;
+  const today = readPetUsage();
+  const num = (v, fallback = 0) => (Number.isFinite(Number(v)) ? Number(v) : fallback);
+  return {
+    todayTokens: num(s?.todayTokens, today.tokens),
+    todayCostUsd: num(s?.todayCostUsd, today.costUsd),
+    conversations: num(s?.conversations),
+    last7dTokens: num(s?.last7dTokens),
+    last7dActiveDays: num(s?.last7dActiveDays),
+    last30dTokens: num(s?.last30dTokens),
+    last30dAvgPerDay: num(s?.last30dAvgPerDay),
+    streakDays: num(s?.streakDays),
+    activeDaysAllTime: num(s?.activeDaysAllTime),
+    topModels: Array.isArray(s?.topModels) ? s.topModels : [],
+  };
+}
+
 function readPetConnected() {
   // Default to connected until the host says otherwise.
   return window.__ttPetConnected !== false;
@@ -85,15 +115,6 @@ function readPetCurrency() {
 
 function readPetLocale() {
   return normalizePetLocale(typeof window !== "undefined" ? window.__ttPetLocale : null);
-}
-
-// Matches the tray's UsagePoller.FormatTokens exactly (always 1 decimal) so the
-// pet bubble and the tray "今日" line read identically for the same number.
-function formatTokens(n) {
-  if (n >= 1_000_000_000) return (n / 1_000_000_000).toFixed(1) + "B";
-  if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + "M";
-  if (n >= 1_000) return (n / 1_000).toFixed(1) + "K";
-  return String(n);
 }
 
 function post(type) {
@@ -227,7 +248,9 @@ function PetClawd({ state, size, leanX }) {
   );
 }
 
-/** Compact translucent pill shown in the top band (usage on hover, or a tap quip). */
+/** Compact translucent pill shown in the top band (usage on hover, or a tap quip).
+    Wraps to at most two lines (clamped with an ellipsis) so the longer data-rich quips
+    show in full within this fixed, content-clipping window instead of truncating. */
 function Bubble({ text }) {
   return (
     <div
@@ -235,9 +258,12 @@ function Bubble({ text }) {
         maxWidth: "98%",
         padding: "3px 9px",
         borderRadius: 10,
-        whiteSpace: "nowrap",
+        display: "-webkit-box",
+        WebkitBoxOrient: "vertical",
+        WebkitLineClamp: 2,
         overflow: "hidden",
-        textOverflow: "ellipsis",
+        wordBreak: "break-word",
+        textAlign: "center",
         fontSize: 11,
         fontWeight: 600,
         lineHeight: 1.3,
@@ -269,6 +295,7 @@ function Pet() {
   const [size, setSize] = useState(sizeFor);
   const dragRef = useRef(null);
   const tapIndexRef = useRef(0);
+  const quipIndexRef = useRef(0); // rotates through the quip pool on each tap (macOS quipIndex)
   const tapTimer = useRef(0);
   const idleTimer = useRef(0);
 
@@ -383,22 +410,28 @@ function Pet() {
     const anim = TAP_ANIMATIONS[tapIndexRef.current % TAP_ANIMATIONS.length];
     tapIndexRef.current += 1;
     setTapState(anim);
-    // Feed the quip the SAME formatted figures the hover bubble shows, so a tap can
-    // bake in today's real token count + cost (macOS parity) instead of staying generic.
-    const costValue = today.costUsd * currency.rate;
-    setSpeech(pickQuip(locale, {
-      tokens: today.tokens,
-      tokensText: formatTokens(today.tokens),
+    // Build the full data-rich pool from the host's latest stats and rotate through it
+    // by index (macOS parity), so each tap surfaces a different real figure — today's
+    // tokens/cost, 7d/30d rolling, streak, top model, conversations — with personality
+    // lines as a natural minority.
+    const s = readPetStats();
+    const costValue = s.todayCostUsd * currency.rate;
+    const pool = buildQuipPool(locale, {
+      ...s,
+      tokens: s.todayTokens,
+      tokensText: formatTokens(s.todayTokens),
       costText: `${currency.symbol}${costValue.toFixed(2)}`,
       costValue,
       isSyncing,
-    }));
+    });
+    setSpeech(pool[quipIndexRef.current % pool.length] || null);
+    quipIndexRef.current += 1;
     clearTimeout(tapTimer.current);
     tapTimer.current = window.setTimeout(() => {
       setTapState(null);
       setSpeech(null);
     }, TAP_HOLD_MS);
-  }, [locale, today.tokens, today.costUsd, currency.symbol, currency.rate, isSyncing]);
+  }, [locale, currency.symbol, currency.rate, isSyncing]);
 
   // Distinguish a tap (→ cycle animation) from a drag (→ native window move):
   // only hand the move to the OS once the pointer travels past a small threshold.


### PR DESCRIPTION
## Summary

A follow-up to the Windows desktop pet (#128) that brings its speech bubble to full parity with the macOS companion and fixes a currency edge case.

### 1. Full macOS quip-pool parity

The pet's tap bubble previously only knew today's tokens + cost. It now reproduces the macOS companion's complete `quipPool` (`ClawdCompanionView.swift`), 1:1 and in the same order:

- today tokens / cost / usage tier
- **7-day & 30-day rolling totals + per-active-day average**
- **active days this week, perfect-week streak, current streak, all-time active days**
- **top model & runner-up share, model count, multi-tool setup**
- **today's conversation count + "busy talker"**

Taps now rotate through the pool by index (like macOS `quipIndex`) instead of the old random 25% personality weighting — because the data-rich lines outnumber the few personality lines, most taps surface real numbers and personality stays a natural minority. All 13 new string categories are localized across the 5 supported languages (en / zh-CN / zh-TW / ja / ko), ported from `Strings.swift`.

**Data sources (kept efficient):** the 7d/30d/average/active-days/conversation figures ride along in the `usage-summary` response the tray already fetches (it returns a `rolling` block that was previously discarded) — zero extra calls. Only the heatmap (all-time active days) and model breakdown (top models) need their own requests, and those are gated behind pet visibility, so nothing extra is fetched while the pet is hidden.

### 2. Two-line bubble

This is a fixed-size, content-clipping layered window (unlike macOS, where the bubble can overflow the frame), so the longer data-rich quips were truncating with an ellipsis. The bubble now wraps to two lines and the window grows to fit, while the sprite keeps the exact same visual size as before.

### 3. Currency persists across a cold launch

The pet's currency was read only from the dashboard WebView's `localStorage`. On a cold launch with just the pet on screen (no dashboard window yet), it fell back to USD even though the app last ran in, say, CNY. The chosen symbol + rate are now cached natively in `native-settings.json` — exactly how locale and theme are already persisted — so the cold-launched pet matches the app's last-used unit. (Locale/text was already correct via the existing native cache; only currency was missing one.)

## Demo

https://github.com/user-attachments/assets/2183500f-d278-4b40-b1f6-a96f67eb5afe



## Safety / isolation

The pet entry stays gated behind `TOKENTRACKER_BUILD_PET=1`, so the **default macOS/web bundle is byte-identical** (`main-DT0Mq89f.js`, no pet entry). `pet-quips.js` is imported only by `pet.jsx`. The CLI (`src/`) is untouched. C# builds clean; `ui-hardcode` + architecture guardrails pass.

## Notes

- The local server returns `streak_days: 0` (it's server-computed), so the current-streak quip stays dormant against the local backend — same as the macOS pet reads it. The string is ported faithfully and will light up if the backend ever returns a real streak.
- Model breakdown uses a fixed 30-day window (the Windows tray has no period switcher).
- No version bumps — release is the maintainer's call.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich usage statistics: 7-day and 30-day rolling stats, streak tracking, and top models breakdown.
  * Persisted currency preferences; pet quips now contextually generated from live usage data.
  * Enhanced bubble layout to accommodate longer quip text without truncation.

* **Bug Fixes**
  * Eliminated USD default flash on initial launch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->