### PR TITLE
fix(windows): bypass system/env proxy for the local server health check

### DIFF
--- a/TokenTrackerWin/ServerManager.cs
+++ b/TokenTrackerWin/ServerManager.cs
@@ -42,7 +42,12 @@ internal sealed class ServerManager : IDisposable
     private readonly object _syncLock = new();
     private readonly JobObject _job = new();
     private CancellationTokenSource? _healthCts;
-    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(3) };
+    // The local server is always on 127.0.0.1, so this client must NEVER honour a system /
+    // env (HTTP_PROXY) proxy: a VPN/proxy user with no loopback bypass would otherwise have
+    // the health check routed through the proxy, which can't reach the local server — the
+    // app then thinks startup failed even though the server is up. UseProxy=false = direct.
+    private static readonly HttpClient Http =
+        new(new HttpClientHandler { UseProxy = false }) { Timeout = TimeSpan.FromSeconds(3) };
     private static readonly string LogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
         "TokenTracker",

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -34,7 +34,10 @@ internal sealed class UsagePoller : IDisposable
         int ActiveDaysAllTime,
         IReadOnlyList<TopModelStat> TopModels);
 
-    private static readonly HttpClient Http = new() { Timeout = TimeSpan.FromSeconds(6) };
+    // Local server only (127.0.0.1) — never route through a system/env proxy, or a
+    // VPN/proxy user without a loopback bypass can't reach it (see ServerManager.Http).
+    private static readonly HttpClient Http =
+        new(new HttpClientHandler { UseProxy = false }) { Timeout = TimeSpan.FromSeconds(6) };
     private static readonly IReadOnlyList<TopModelStat> NoModels = Array.Empty<TopModelStat>();
     private readonly Func<string> _baseUrl;
     private CancellationTokenSource? _cts;


### PR DESCRIPTION
## Problem

On Windows, a user running a VPN/proxy that exports `HTTP_PROXY` / `HTTPS_PROXY` (very common — e.g. `HTTP_PROXY=http://127.0.0.1:10808` from v2rayN/clash) **cannot start the app** when they have no loopback `NO_PROXY` bypass.

The tray host's two `HttpClient`s — the server **health check** (`ServerManager`) and the **usage poller** (`UsagePoller`) — were plain `new HttpClient()`. On .NET 8 that honours `HTTP_PROXY`/`HTTPS_PROXY`, so the startup health check to `http://127.0.0.1:<port>/` was routed **through the proxy**, which can't reach the machine-local server. The check times out:

```
Fail: Server did not respond on http://127.0.0.1:17680 within 20s.
```

…and the app reports the server as down and never shows the dashboard/pet — even though the bundled server **is** up and listening on `127.0.0.1` (confirmed: `netstat` shows it LISTENING, and a direct request returns HTTP 200).

WinINET system-proxy users are usually fine (their bypass list includes `127.*` / `<local>`), but the **environment-variable** proxy that .NET reads has no such bypass unless `NO_PROXY` is set — which most users never set.

## Fix

Both clients only ever talk to the bundled local server on `127.0.0.1`, so construct them with `HttpClientHandler { UseProxy = false }` — loopback always connects directly, regardless of any system/env proxy. The host makes **no** external HTTP calls through these clients (GitHub opens in the browser; dashboard traffic goes through WebView2/WinINET), so disabling the proxy here is safe.

## Verification

Reproduced + fixed on the same machine. With `HTTP_PROXY=http://127.0.0.1:10808` set and **no** `NO_PROXY`:

- **Before:** health check fails (`Server did not respond … within 20s`), UI never appears.
- **After (this change):** server is reached directly, status goes Running, background sync proceeds (`sync --auto` → `exited code=0`), UI appears. No `NO_PROXY` needed.

No version bump (release is the maintainer's call). Windows-only change; macOS/web untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where health checks and usage monitoring could fail when system proxies or VPN connections were configured on the network. Background services now explicitly bypass proxy routing, ensuring direct and reliable connectivity to local services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->