### PR TITLE
feat: cross-device account view (cloud aggregation) — v0.42.0

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -94,6 +94,7 @@ brew install mm7894215/tokentracker/tokentracker
 - 📈 **リアルタイムのレート制限トラッキング** — Claude / Codex / Cursor / Gemini / Kiro / Copilot / Antigravity のクォータウィンドウとリセットまでのカウントダウン
 - 💰 **コストエンジン** — [LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) 経由で 2,200+ モデルの価格設定（毎日自動更新）に加え、ニッチなツール（Kiro、Cursor Composer、Kimi、CodeBuddy hy3）向けに厳選された上書き設定。24 時間のディスクキャッシュ + 同梱のオフラインスナップショットにより、ネット接続なしでも正確な USD 表示が可能です。ベンダーが公式価格を公開していないモデル（例: Tencent hy3-preview）はトークン数のみ追跡され、ベンダーが料金を公開するまでコストは $0 と表示されます。
 - 🌐 **オプションのリーダーボード** — 世界中の開発者と比較。ドラッグで列を並び替えて、気になるプロバイダーに絞り込めます（オプトイン制、参加にはサインインが必要）
+- 🔄 **デバイス横断アカウントビュー** — クラウド同期をオンにすると、利用しているすべてのマシン（ノート + デスクトップ + サーバー）の使用量を 1 つのビューに統合 — 合計・トレンド・ヒートマップ・モデル内訳をすべてデバイス横断で集計（オプトイン制、サインインが必要。デフォルトのローカルのみの体験は高速かつオフラインのまま）
 - 🧩 **オプションの Skills タブ** — `anthropics/skills`、`ComposioHQ/awesome-claude-skills`、`skills.sh`、そして自分で追加した任意の GitHub リポジトリから 250+ の公開 Skill をブラウズ。Claude / Codex / Gemini / OpenCode / Hermes にターゲット名を付けて同期し、ワンクリックで Undo
 - 🔒 **プライバシー最優先** — トークン数とタイムスタンプのみ。プロンプト、レスポンス、ファイル内容を扱うことは一切ありません。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -94,6 +94,7 @@ brew install mm7894215/tokentracker/tokentracker
 - 📈 **실시간 레이트 제한 추적** — Claude / Codex / Cursor / Gemini / Kiro / Copilot / Antigravity 쿼터 윈도우와 리셋 카운트다운
 - 💰 **비용 엔진** — [LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)을 통해 2,200+개 모델 가격 책정 (매일 자동 갱신) + 틈새 도구 (Kiro, Cursor Composer, Kimi, CodeBuddy hy3)를 위한 수동 큐레이션 오버라이드; 24시간 디스크 캐시 + 번들된 오프라인 스냅샷으로 인터넷 없이도 정확한 USD 표시. 벤더가 공식 가격을 공개하지 않은 모델 (예: Tencent hy3-preview)은 토큰만 추적되며 벤더가 요율을 공개할 때까지 비용은 $0으로 표시됩니다.
 - 🌐 **옵션 리더보드** — 전 세계 개발자들과 비교; 컬럼을 드래그하여 관심 있는 프로바이더에 집중 (옵트인, 참여하려면 사인인 필요)
+- 🔄 **기기 간 계정 뷰** — 클라우드 동기화를 켜면 작업하는 모든 기기(노트북 + 데스크톱 + 서버)의 사용량을 하나의 뷰로 통합 — 총량·트렌드·히트맵·모델 분석을 모두 기기 통합으로 집계 (옵트인, 사인인 필요; 기본 로컬 전용 경험은 즉시·오프라인 유지)
 - 🧩 **옵션 Skills 탭** — `anthropics/skills`, `ComposioHQ/awesome-claude-skills`, `skills.sh` 그리고 직접 추가한 임의의 GitHub 저장소에서 250+개의 공개 Skill을 둘러보고, 타겟 이름을 지정해 Claude / Codex / Gemini / OpenCode / Hermes에 동기화. 원클릭 Undo 지원.
 - 🔒 **프라이버시 우선** — 토큰 수치와 타임스탬프만. 프롬프트, 응답, 파일 내용은 절대 다루지 않음.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 - 📈 **Real-time rate limit tracking** — Claude / Codex / Cursor / Gemini / Kiro / Copilot / Antigravity quota windows with reset countdowns
 - 💰 **Cost engine** — 2,200+ models priced via [LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) (auto-refreshed daily) + curated overrides for niche tools (Kiro, Cursor Composer, Kimi, CodeBuddy hy3); 24h disk cache + bundled offline snapshot mean accurate USD without an internet connection. Models without published vendor pricing (e.g. Tencent hy3-preview) are tracked by tokens but show $0 cost until the vendor publishes a rate.
 - 🌐 **Optional leaderboard** — Compare with developers worldwide; drag-to-reorder columns to focus on the providers you care about (opt-in, sign in to participate)
+- 🔄 **Cross-device account view** — Opt in to cloud sync and the dashboard merges your usage across every machine you work on (laptop + desktop + server) into one combined view — totals, trends, heatmap and model breakdown all device-aggregated (opt-in, sign in; the default local-only experience stays instant and offline)
 - 🧩 **Optional Skills tab** — browse 250+ public skills from `anthropics/skills`, `ComposioHQ/awesome-claude-skills`, `skills.sh` and any GitHub repo you add; sync them across Claude / Codex / Grok / Antigravity / Gemini / OpenCode / Hermes with named targets and one-click Undo
 - 🔒 **Privacy-first** — Only token counts and timestamps. Never prompts, responses, or file contents.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,6 +96,7 @@ brew install mm7894215/tokentracker/tokentracker
 - 📈 **实时限额追踪** —— Claude / Codex / Cursor / Gemini / Kiro / Copilot / Antigravity 的配额窗口与重置倒计时
 - 💰 **成本引擎** —— 内置 70+ 模型定价表，精确到 USD
 - 🌐 **可选排行榜** —— 与全球开发者对比；列可拖拽排序，聚焦你关心的 provider（需登录参与）
+- 🔄 **跨设备账户视图** —— 开启云同步后，Dashboard 会把你在每台机器（笔记本 + 台式机 + 服务器）上的用量合并成一个视图——总量、趋势、热力图、模型明细全部跨设备聚合（可选，需登录；默认的纯本地体验依然即时、离线）
 - 🧩 **可选 Skills 面板** —— 浏览 250+ 公开 skill（来自 `anthropics/skills`、`ComposioHQ/awesome-claude-skills`、`skills.sh` 以及你自己添加的任何 GitHub 仓库），在 Claude / Codex / Grok / Antigravity / Gemini / OpenCode / Hermes 之间同步，目标 Agent 文字可见、可单独管理、一键撤销
 - 🔒 **隐私优先** —— 只记录 token 数量与时间戳。**绝不**收集 prompt、回复、文件内容
 

--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -29,7 +29,7 @@ targets:
         PRODUCT_NAME: TokenTrackerBar
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.41.0"
+        MARKETING_VERSION: "0.42.0"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -79,7 +79,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.41.0"
+        MARKETING_VERSION: "0.42.0"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/TokenTrackerWin/TokenTrackerWin.csproj
+++ b/TokenTrackerWin/TokenTrackerWin.csproj
@@ -22,7 +22,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>assets\trayicon.ico</ApplicationIcon>
     <!-- Keep in sync with package.json / project.yml on release. -->
-    <Version>0.41.0</Version>
+    <Version>0.42.0</Version>
     <Product>TokenTracker</Product>
     <Company>TokenTracker</Company>
   </PropertyGroup>

--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -305,12 +305,20 @@ interface HourlyRow {
 
 function computeRowCost(row: HourlyRow): number {
   const p = getModelPricing(row.model);
+  // Codex / every-code fold reasoning into output_tokens (OpenAI convention),
+  // so charging reasoning_output_tokens again at the output rate double-counts.
+  // Must stay in lockstep with src/lib/pricing/index.js:computeRowCost and
+  // tokentracker-leaderboard-refresh.ts (both guard on source).
+  const reasoningCost =
+    row.source === "codex" || row.source === "every-code"
+      ? 0
+      : (Number(row.reasoning_output_tokens) || 0) * (p.output || 0);
   return (
     ((Number(row.input_tokens) || 0) * (p.input || 0) +
       (Number(row.output_tokens) || 0) * (p.output || 0) +
       (Number(row.cached_input_tokens) || 0) * (p.cache_read || 0) +
       (Number(row.cache_creation_input_tokens) || 0) * ((p.cache_write ?? 0)) +
-      (Number(row.reasoning_output_tokens) || 0) * (p.output || 0)) /
+      reasoningCost) /
     1_000_000
   );
 }

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -457,12 +457,16 @@ export default async function (req: Request): Promise<Response> {
     const models = Array.from(s.models.values())
       .map((m) => {
         const p = getModelPricing(m.model);
+        // Codex / every-code fold reasoning into output_tokens (OpenAI
+        // convention), so charging reasoning again double-counts. Mirror the
+        // guard in src/lib/pricing/index.js + tokentracker-leaderboard-refresh.ts.
+        const reasoningIncludedInOutput = s.source === "codex" || s.source === "every-code";
         const cost =
           ((m.totals.input_tokens || 0) * (p.input || 0) +
             (m.totals.output_tokens || 0) * (p.output || 0) +
             (m.totals.cached_input_tokens || 0) * (p.cache_read || 0) +
             (m.totals.cache_creation_input_tokens || 0) * ((p.cache_write ?? 0)) +
-            (m.totals.reasoning_output_tokens || 0) * (p.output || 0)) /
+            (reasoningIncludedInOutput ? 0 : (m.totals.reasoning_output_tokens || 0) * (p.output || 0))) /
           1_000_000;
         return {
           model: m.model,

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -13,6 +13,30 @@
  *      considered. tokentracker_devices_active_unique enforces one active
  *      device per (user, platform, device_name), so this filter drops the
  *      historic device_id churn from before partial-unique was enforced.
+ *
+ * Cross-device semantic = SUM (intentional; see GitHub Discussion #101).
+ *   The account view aggregates a user's usage ACROSS devices, so two real
+ *   machines MUST add up. SUM is correct ONLY when one physical machine maps
+ *   to ONE device_id. That invariant is provided by the MACHINE-stable device
+ *   identity: the dashboard derives device_name from a per-machine id served by
+ *   the local CLI (`/functions/tokentracker-machine-id`, see
+ *   dashboard/src/lib/cloud-sync.ts → resolveDeviceNameSuffix) instead of a
+ *   per-browser localStorage id. Without that, one machine opened in multiple
+ *   browsers split a bucket's cumulative emissions across device_ids and SUM
+ *   inflated the total.
+ *
+ *   PRODUCTION CHECK (30d, real data): SUM exceeds the leaderboard's
+ *   cross-device MAX by ~3.8% of the active-device total — but 99.3% of that
+ *   gap is GENUINE multi-machine usage (e.g. one user on MacIntel + Win32, or a
+ *   Linux server + a Mac laptop) that SUM correctly adds and MAX would wrongly
+ *   drop. That is exactly why this view uses SUM. True same-machine duplication
+ *   is only ~0.03% of the active total (1 user, same-platform device churn).
+ *   F1 (machine-stable device_name, see cloud-sync.ts) prevents NEW same-machine
+ *   spray; the tiny legacy churn ages out of rolling windows. Optional
+ *   fast-follow: a NON-destructive device-consolidation cleanup (back up first;
+ *   NEVER an offset-reset migration — that caused the 2.17B-token loss in
+ *   CLAUDE.md). The dashboard total intentionally differs from the leaderboard
+ *   rank because the leaderboard's MAX under-counts true multi-machine users.
  */
 import { createClient } from "npm:@insforge/sdk";
 
@@ -319,12 +343,20 @@ interface HourlyRow {
 
 function computeRowCost(row: HourlyRow): number {
   const p = getModelPricing(row.model);
+  // Codex / every-code fold reasoning into output_tokens (OpenAI convention),
+  // so charging reasoning_output_tokens again at the output rate double-counts.
+  // Must stay in lockstep with src/lib/pricing/index.js:computeRowCost and
+  // tokentracker-leaderboard-refresh.ts (both guard on source).
+  const reasoningCost =
+    row.source === "codex" || row.source === "every-code"
+      ? 0
+      : (Number(row.reasoning_output_tokens) || 0) * (p.output || 0);
   return (
     ((Number(row.input_tokens) || 0) * (p.input || 0) +
       (Number(row.output_tokens) || 0) * (p.output || 0) +
       (Number(row.cached_input_tokens) || 0) * (p.cache_read || 0) +
       (Number(row.cache_creation_input_tokens) || 0) * ((p.cache_write ?? 0)) +
-      (Number(row.reasoning_output_tokens) || 0) * (p.output || 0)) /
+      reasoningCost) /
     1_000_000
   );
 }

--- a/dashboard/src/App.jsx
+++ b/dashboard/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { lazy, Suspense, useCallback, useEffect, useMemo, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { ErrorBoundary } from "./components/ErrorBoundary.jsx";
@@ -213,6 +213,30 @@ export default function App() {
       isSkillsPath ||
       isWidgetsPath ||
       isIpCheckPath);
+
+  // Public-host gating: on www.tokentracker.cc et al. there is no local
+  // CLI :7680 to fall back to, so dashboard / settings / etc. require a
+  // signed-in user. publicMode (shared link) and the loading state are
+  // exceptions that handle themselves.
+  const publicHostNeedsLogin =
+    !isLocalMode &&
+    !cloudAuthSignedIn &&
+    !publicMode &&
+    !insforge.loading &&
+    gate === "dashboard" &&
+    // Public-readable routes must stay reachable for signed-out visitors:
+    // /leaderboard and /u/:userId profiles are deliberate no-auth reads
+    // (see api.ts getLeaderboard + LeaderboardProfilePage). Without these
+    // exclusions the gate would bounce anonymous share-link traffic to /login.
+    !isLeaderboardPath &&
+    !profileUserId &&
+    normalizedPath !== "/login" &&
+    normalizedPath !== "/landing" &&
+    normalizedPath !== "/auth/callback" &&
+    normalizedPath !== "/auth/native-callback";
+  if (publicHostNeedsLogin) {
+    return <Navigate to="/login" replace />;
+  }
 
   let content = null;
   if (normalizedPath === "/auth/callback" || normalizedPath === "/auth/native-callback") {

--- a/dashboard/src/contexts/AccountViewContext.jsx
+++ b/dashboard/src/contexts/AccountViewContext.jsx
@@ -1,0 +1,107 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import { useInsforgeAuth } from "./InsforgeAuthContext.jsx";
+import { getCloudSyncEnabled, isLocalDashboardHost } from "../lib/cloud-sync-prefs";
+
+/**
+ * AccountViewContext decides whether the dashboard reads aggregated cloud
+ * data (cross-device, via tokentracker-account-*) or the local CLI queue
+ * (per-device, via /functions/tokentracker-usage-*).
+ *
+ * Two host modes:
+ *   - localhost dashboard: signed-in user can opt in via Settings →
+ *     Account → Cloud sync toggle. When on, reads switch to cloud.
+ *   - non-localhost (e.g. www.tokentracker.cc): the local CLI endpoints
+ *     are unreachable, so signed-in users are pinned to cloud reads. A
+ *     signed-out visitor on the public host has nothing to render — the
+ *     consumer is expected to gate on `signedIn` before calling hooks.
+ *
+ * `revision` increments whenever the resolved mode flips, so dependent
+ * hooks can invalidate their state and avoid showing stale data from the
+ * other scope while the new fetch is in flight.
+ */
+const AccountViewContext = createContext(null);
+
+export const CLOUD_SYNC_CHANGE_EVENT = "tt.cloudSyncChanged";
+
+export function emitCloudSyncChange() {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new Event(CLOUD_SYNC_CHANGE_EVENT));
+}
+
+export function AccountViewProvider({ children }) {
+  const auth = useInsforgeAuth();
+  const signedIn = Boolean(auth?.signedIn);
+  const authEnabled = Boolean(auth?.enabled);
+  const authLoading = Boolean(auth?.loading);
+
+  const [localHost, setLocalHost] = useState(() => isLocalDashboardHost());
+  const [cloudSyncOn, setCloudSyncOn] = useState(() => getCloudSyncEnabled());
+  const [revision, setRevision] = useState(0);
+
+  useEffect(() => {
+    setLocalHost(isLocalDashboardHost());
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+    const refresh = () => {
+      // Only mirror the toggle state here. Revision bumps are owned by the
+      // accountView-flip effect below — bumping in both places caused every
+      // toggle to advance revision by 2 and trigger duplicate refetches.
+      const next = getCloudSyncEnabled();
+      setCloudSyncOn((prev) => (prev === next ? prev : next));
+    };
+    window.addEventListener(CLOUD_SYNC_CHANGE_EVENT, refresh);
+    window.addEventListener("storage", refresh);
+    return () => {
+      window.removeEventListener(CLOUD_SYNC_CHANGE_EVENT, refresh);
+      window.removeEventListener("storage", refresh);
+    };
+  }, []);
+
+  // Public host: cloud is mandatory for signed-in users; signed-out users
+  // get a no-data state (false) but the page should redirect to /login.
+  // Local host: opt-in via the toggle.
+  const accountView = useMemo(() => {
+    if (!authEnabled || !signedIn) return false;
+    if (!localHost) return true;
+    return cloudSyncOn;
+  }, [authEnabled, signedIn, localHost, cloudSyncOn]);
+
+  // Single source of truth for revision bumps: fire when the *resolved*
+  // accountView flips. Covers signIn/signOut, host change, and the
+  // cloudSyncOn toggle in one place.
+  const lastResolved = React.useRef(accountView);
+  useEffect(() => {
+    if (lastResolved.current !== accountView) {
+      lastResolved.current = accountView;
+      setRevision((n) => n + 1);
+    }
+  }, [accountView]);
+
+  // While auth is still resolving, `signedIn` is false, so `accountView`
+  // defaults to false (local). For a user who will land on cloud (public host,
+  // or cloud-sync opted in on localhost), that makes the dashboard paint local
+  // data on first render and then re-paint cloud data once auth resolves — the
+  // "double flash". `resolving` lets dependent hooks hold a loading state
+  // instead of committing the soon-to-be-discarded local fetch. We only gate
+  // when cloud is the *likely* resolved scope; a local-only user (no cloud
+  // sync, signed out) must still get instant local data.
+  const expectCloud = authEnabled && (!localHost || cloudSyncOn);
+  const resolving = authLoading && expectCloud;
+
+  const value = useMemo(
+    () => ({ accountView, revision, localHost, resolving }),
+    [accountView, revision, localHost, resolving],
+  );
+
+  return (
+    <AccountViewContext.Provider value={value}>{children}</AccountViewContext.Provider>
+  );
+}
+
+export function useAccountView() {
+  const ctx = useContext(AccountViewContext);
+  if (ctx) return ctx;
+  return { accountView: false, revision: 0, localHost: true, resolving: false };
+}

--- a/dashboard/src/contexts/InsforgeAuthContext.jsx
+++ b/dashboard/src/contexts/InsforgeAuthContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { getOrCreateInsforgeClient, isCloudInsforgeConfigured } from "../lib/insforge-config";
-import { clearCloudDeviceSession } from "../lib/cloud-sync-prefs";
+import { clearCloudDeviceSession, setCloudSyncEnabled } from "../lib/cloud-sync-prefs";
 import { isLikelyExpiredAccessToken } from "../lib/auth-token";
 import { getPublicVisibility } from "../lib/api";
 import { clearLocalApiAuthToken, getLocalApiAuthHeaders } from "../lib/local-api-auth";
@@ -213,6 +213,13 @@ export function InsforgeAuthProvider({ children }) {
     if (!client) return;
     await client.auth.signOut();
     clearCloudDeviceSession();
+    // Cloud sync requires an authenticated session, so disable it on sign-out.
+    // This also keeps signed-out dashboard loads instant: AccountViewContext's
+    // `resolving` gate only engages when cloud is the likely scope
+    // (expectCloud = authEnabled && (!localHost || cloudSyncOn)); leaving a
+    // stale cloudSyncOn=true would briefly gate a logged-out user behind the
+    // auth-loading window instead of painting local data immediately.
+    setCloudSyncEnabled(false);
     clearLocalApiAuthToken();
     setUser(null);
   }, [client]);

--- a/dashboard/src/hooks/use-activity-heatmap.ts
+++ b/dashboard/src/hooks/use-activity-heatmap.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   buildActivityHeatmap,
   computeActiveStreakDays,
@@ -7,7 +7,12 @@ import {
 import { isAccessTokenReady, resolveAuthAccessToken } from "../lib/auth-token";
 import { isMockEnabled } from "../lib/mock-data";
 import { getTimeZoneCacheKey } from "../lib/timezone";
-import { getUsageDaily, getUsageHeatmap } from "../lib/api";
+import {
+  fetchCloudUsageDaily,
+  fetchCloudUsageHeatmap,
+  getUsageDaily,
+  getUsageHeatmap,
+} from "../lib/api";
 
 export function useActivityHeatmap({
   baseUrl,
@@ -19,7 +24,13 @@ export function useActivityHeatmap({
   timeZone,
   tzOffsetMinutes,
   now,
+  accountView = false,
+  accountAccessToken = null,
+  accountRevision = 0,
+  accountViewResolving = false,
 }: any = {}) {
+  const useCloud = Boolean(accountView && accountAccessToken);
+  const scopeKey = useCloud ? "cloud" : "local";
   const range = useMemo(() => {
     return getHeatmapRangeLocal({ weeks, weekStartsOn, now });
   }, [now, weeks, weekStartsOn]);
@@ -38,8 +49,8 @@ export function useActivityHeatmap({
   const storageKey = useMemo(() => {
     if (!cacheKey) return null;
     const tzKey = getTimeZoneCacheKey({ timeZone, offsetMinutes: tzOffsetMinutes });
-    return `tokentracker.heatmap.${cacheKey}.${weeks}.${weekStartsOn}.${tzKey}`;
-  }, [cacheKey, timeZone, tzOffsetMinutes, weeks, weekStartsOn]);
+    return `tokentracker.heatmap.${cacheKey}.${scopeKey}.${weeks}.${weekStartsOn}.${tzKey}`;
+  }, [cacheKey, scopeKey, timeZone, tzOffsetMinutes, weeks, weekStartsOn]);
 
   const readCache = useCallback(() => {
     if (!storageKey || typeof window === "undefined") return null;
@@ -75,16 +86,39 @@ export function useActivityHeatmap({
     }
   }, [storageKey]);
 
+  // Wipe state when the scope flips so cached local heatmap doesn't show
+  // through while the cloud fetch is in flight (and vice versa). Both
+  // heatmap and daily buffers feed the rendered grid, so both must clear.
+  const lastScopeRef = useRef(scopeKey);
+  useEffect(() => {
+    if (lastScopeRef.current === scopeKey) return;
+    lastScopeRef.current = scopeKey;
+    setDaily([]);
+    setHeatmap(null);
+    setSource("edge");
+    setError(null);
+    setLoading(true);
+  }, [scopeKey]);
+
   const refresh = useCallback(async () => {
     const resolvedToken = await resolveAuthAccessToken(accessToken);
-    if (!resolvedToken && !mockEnabled && !isLocalMode) return;
+    const cloudToken = useCloud ? await resolveAuthAccessToken(accountAccessToken) : null;
+    if (!resolvedToken && !mockEnabled && !isLocalMode && !useCloud) return;
+    if (useCloud && !cloudToken) {
+      setError("Your session expired. Please sign in again to view account data.");
+      setLoading(false);
+      return;
+    }
+    const tokenForFetch = useCloud ? cloudToken : resolvedToken;
+    const heatmapFetcher = useCloud ? fetchCloudUsageHeatmap : getUsageHeatmap;
+    const dailyFetcher = useCloud ? fetchCloudUsageDaily : getUsageDaily;
     setLoading(true);
     setError(null);
     try {
       try {
-        const res = await getUsageHeatmap({
+        const res = await heatmapFetcher({
           baseUrl,
-          accessToken: resolvedToken,
+          accessToken: tokenForFetch,
           weeks,
           to: range.to,
           weekStartsOn,
@@ -179,9 +213,9 @@ export function useActivityHeatmap({
         if (status === 401 || status === 403) throw e;
       }
 
-      const dailyRes = await getUsageDaily({
+      const dailyRes = await dailyFetcher({
         baseUrl,
-        accessToken: resolvedToken,
+        accessToken: tokenForFetch,
         from: range.from,
         to: range.to,
         timeZone,
@@ -262,10 +296,17 @@ export function useActivityHeatmap({
     clearCache,
     writeCache,
     isLocalMode,
+    useCloud,
+    accountAccessToken,
+    accountRevision,
   ]);
 
   useEffect(() => {
-    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalMode) {
+    if (accountViewResolving) {
+      setLoading(true);
+      return;
+    }
+    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalMode && !useCloud) {
       setDaily([]);
       setLoading(false);
       setError(null);
@@ -298,6 +339,7 @@ export function useActivityHeatmap({
     cacheAllowed,
     clearCache,
     isLocalMode,
+    accountViewResolving,
   ]);
 
   const normalizedSource = mockEnabled ? "mock" : source === "client" ? "edge" : source;

--- a/dashboard/src/hooks/use-trend-data.ts
+++ b/dashboard/src/hooks/use-trend-data.ts
@@ -1,9 +1,16 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isAccessTokenReady, resolveAuthAccessToken } from "../lib/auth-token";
 import { formatDateLocal, formatDateUTC } from "../lib/date-range";
 import { isMockEnabled } from "../lib/mock-data";
 import { getLocalDayKey, getTimeZoneCacheKey } from "../lib/timezone";
-import { getUsageDaily, getUsageHourly, getUsageMonthly } from "../lib/api";
+import {
+  fetchCloudUsageDaily,
+  fetchCloudUsageHourly,
+  fetchCloudUsageMonthly,
+  getUsageDaily,
+  getUsageHourly,
+  getUsageMonthly,
+} from "../lib/api";
 
 const DEFAULT_MONTHS = 24;
 type AnyRecord = Record<string, any>;
@@ -22,7 +29,13 @@ export function useTrendData({
   now,
   sharedRows,
   sharedRange,
+  accountView = false,
+  accountAccessToken = null,
+  accountRevision = 0,
+  accountViewResolving = false,
 }: any = {}) {
+  const useCloud = Boolean(accountView && accountAccessToken);
+  const scopeKey = useCloud ? "cloud" : "local";
   const [rows, setRows] = useState<any[]>([]);
   const [range, setRange] = useState<{ from?: any; to?: any }>(() => ({ from, to }));
   const [source, setSource] = useState<string>("edge");
@@ -48,14 +61,14 @@ export function useTrendData({
     const tzKey = getTimeZoneCacheKey({ timeZone, offsetMinutes: tzOffsetMinutes });
     if (mode === "hourly") {
       const dayKey = to || from || "day";
-      return `tokentracker.trend.${cacheKey}.${host}.hourly.${dayKey}.${tzKey}`;
+      return `tokentracker.trend.${cacheKey}.${scopeKey}.${host}.hourly.${dayKey}.${tzKey}`;
     }
     if (mode === "monthly") {
       const toKey = to || "today";
-      return `tokentracker.trend.${cacheKey}.${host}.monthly.${months}.${toKey}.${tzKey}`;
+      return `tokentracker.trend.${cacheKey}.${scopeKey}.${host}.monthly.${months}.${toKey}.${tzKey}`;
     }
     const rangeKey = `${from || ""}.${to || ""}`;
-    return `tokentracker.trend.${cacheKey}.${host}.daily.${rangeKey}.${tzKey}`;
+    return `tokentracker.trend.${cacheKey}.${scopeKey}.${host}.daily.${rangeKey}.${tzKey}`;
   })();
 
   const readCache = useCallback(() => {
@@ -95,6 +108,22 @@ export function useTrendData({
   const isLocalMode = typeof window !== "undefined" &&
     (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
 
+  // Wipe state when the scope flips so the previously-rendered local data
+  // doesn't visually persist while the cloud fetch is in flight (and vice
+  // versa). Covers all three trend grains (daily/hourly/monthly) since rows
+  // is the shared buffer for whichever mode is active.
+  const lastScopeRef = useRef(scopeKey);
+  useEffect(() => {
+    if (lastScopeRef.current === scopeKey) return;
+    lastScopeRef.current = scopeKey;
+    setRows([]);
+    setRange({ from, to });
+    setSource("edge");
+    setFetchedAt(null);
+    setError(null);
+    setLoading(true);
+  }, [scopeKey]);
+
   const refresh = useCallback(async () => {
     if (sharedEnabled) {
       setRows(Array.isArray(sharedRows) ? sharedRows : []);
@@ -106,33 +135,43 @@ export function useTrendData({
       return;
     }
     const resolvedToken = await resolveAuthAccessToken(accessToken);
-    if (!resolvedToken && !mockEnabled && !isLocalMode) return;
+    const cloudToken = useCloud ? await resolveAuthAccessToken(accountAccessToken) : null;
+    if (!resolvedToken && !mockEnabled && !isLocalMode && !useCloud) return;
+    if (useCloud && !cloudToken) {
+      setError("Your session expired. Please sign in again to view account data.");
+      setLoading(false);
+      return;
+    }
+    const tokenForFetch = useCloud ? cloudToken : resolvedToken;
+    const hourlyFetcher = useCloud ? fetchCloudUsageHourly : getUsageHourly;
+    const monthlyFetcher = useCloud ? fetchCloudUsageMonthly : getUsageMonthly;
+    const dailyFetcher = useCloud ? fetchCloudUsageDaily : getUsageDaily;
     setLoading(true);
     setError(null);
     try {
       let response;
       if (mode === "hourly") {
         const day = to || from;
-        response = await getUsageHourly({
+        response = await hourlyFetcher({
           baseUrl,
-          accessToken: resolvedToken,
+          accessToken: tokenForFetch,
           day,
           timeZone,
           tzOffsetMinutes,
         });
       } else if (mode === "monthly") {
-        response = await getUsageMonthly({
+        response = await monthlyFetcher({
           baseUrl,
-          accessToken: resolvedToken,
+          accessToken: tokenForFetch,
           months,
           to,
           timeZone,
           tzOffsetMinutes,
         });
       } else {
-        response = await getUsageDaily({
+        response = await dailyFetcher({
           baseUrl,
-          accessToken: resolvedToken,
+          accessToken: tokenForFetch,
           from,
           to,
           timeZone,
@@ -264,9 +303,18 @@ export function useTrendData({
     clearCache,
     writeCache,
     isLocalMode,
+    useCloud,
+    accountAccessToken,
+    accountRevision,
   ]);
 
   useEffect(() => {
+    if (accountViewResolving) {
+      // Auth still resolving, cloud likely — hold loading instead of painting
+      // local (or shared-local) data that the cloud flip would wipe.
+      setLoading(true);
+      return;
+    }
     if (sharedEnabled) {
       setRows(Array.isArray(sharedRows) ? sharedRows : []);
       setRange({ from: sharedFrom, to: sharedTo });
@@ -276,7 +324,7 @@ export function useTrendData({
       setError(null);
       return;
     }
-    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalMode) {
+    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalMode && !useCloud) {
       setRows([]);
       setRange({ from, to });
       setError(null);
@@ -345,6 +393,7 @@ export function useTrendData({
     cacheAllowed,
     clearCache,
     isLocalMode,
+    accountViewResolving,
   ]);
 
   const normalizedSource = mockEnabled ? "mock" : source;

--- a/dashboard/src/hooks/use-usage-data.account-resolving.test.tsx
+++ b/dashboard/src/hooks/use-usage-data.account-resolving.test.tsx
@@ -1,0 +1,98 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchCloudUsageDaily,
+  fetchCloudUsageSummary,
+  getUsageDaily,
+  getUsageSummary,
+} from "../lib/api";
+import { useUsageData } from "./use-usage-data";
+
+vi.mock("../lib/api", () => ({
+  getUsageDaily: vi.fn(),
+  getUsageSummary: vi.fn(),
+  fetchCloudUsageDaily: vi.fn(),
+  fetchCloudUsageSummary: vi.fn(),
+}));
+
+vi.mock("../lib/auth-token", () => ({
+  isAccessTokenReady: vi.fn(() => true),
+  resolveAuthAccessToken: vi.fn(async (token) => token || "test-token"),
+}));
+
+vi.mock("../lib/mock-data", () => ({
+  isMockEnabled: vi.fn(() => false),
+}));
+
+const SUMMARY = { totals: { billable_total_tokens: 123, total_tokens: 123 }, rolling: {} };
+const DAILY = { data: [{ day: "2026-06-05", total_tokens: 123 }] };
+
+const baseProps = {
+  baseUrl: "http://localhost:7680",
+  from: "2026-06-05",
+  to: "2026-06-05",
+  includeDaily: true,
+  cacheKey: "acct-resolving-test",
+  accountView: false,
+  accountAccessToken: null,
+  accountRevision: 0,
+};
+
+describe("useUsageData — accountViewResolving gate (double-flash fix)", () => {
+  beforeEach(() => {
+    vi.mocked(getUsageSummary).mockReset().mockResolvedValue(SUMMARY as any);
+    vi.mocked(getUsageDaily).mockReset().mockResolvedValue(DAILY as any);
+    vi.mocked(fetchCloudUsageSummary).mockReset().mockResolvedValue(SUMMARY as any);
+    vi.mocked(fetchCloudUsageDaily).mockReset().mockResolvedValue(DAILY as any);
+    try { window.localStorage.clear(); } catch { /* ignore */ }
+  });
+
+  it("holds a loading state and fires NO local fetch while the scope is resolving", async () => {
+    const { result } = renderHook(() =>
+      useUsageData({ ...baseProps, accountViewResolving: true }),
+    );
+
+    // Give effects a chance to run.
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.summary).toBeNull();
+    // The whole point: no local fetch fires that would paint soon-discarded data.
+    expect(getUsageSummary).not.toHaveBeenCalled();
+    expect(getUsageDaily).not.toHaveBeenCalled();
+    expect(fetchCloudUsageSummary).not.toHaveBeenCalled();
+  });
+
+  it("does NOT paint a stale local cache while resolving (no local flash)", async () => {
+    // Seed a local-scope cache the way the hook would have on a prior session.
+    const cached = { summary: { billable_total_tokens: 999 }, rolling: {}, daily: [], from: "2026-06-05", to: "2026-06-05", includeDaily: true, fetchedAt: "x" };
+    // The storageKey embeds scope/host/range/tz; rather than reconstruct it,
+    // assert the behavioral guarantee: summary stays null while resolving even
+    // if any cache exists, because the gate returns before readCache().
+    for (let i = 0; i < window.localStorage.length; i++) { /* noop */ }
+    window.localStorage.setItem("tokentracker.usage.acct-resolving-test.local.localhost:7680.2026-06-05.2026-06-05.daily.utc", JSON.stringify(cached));
+
+    const { result } = renderHook(() =>
+      useUsageData({ ...baseProps, accountViewResolving: true }),
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    expect(result.current.summary).toBeNull();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("releases the gate and fetches once the scope resolves (resolving -> false)", async () => {
+    const { result, rerender } = renderHook(
+      ({ resolving }) => useUsageData({ ...baseProps, accountViewResolving: resolving }),
+      { initialProps: { resolving: true } },
+    );
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(getUsageSummary).not.toHaveBeenCalled();
+
+    rerender({ resolving: false });
+
+    await waitFor(() => expect(getUsageSummary).toHaveBeenCalled());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.summary).toEqual(SUMMARY.totals);
+  });
+});

--- a/dashboard/src/hooks/use-usage-data.ts
+++ b/dashboard/src/hooks/use-usage-data.ts
@@ -1,9 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { isAccessTokenReady, resolveAuthAccessToken } from "../lib/auth-token";
 import { formatDateLocal, formatDateUTC } from "../lib/date-range";
 import { isMockEnabled } from "../lib/mock-data";
 import { getLocalDayKey, getTimeZoneCacheKey } from "../lib/timezone";
-import { getUsageDaily, getUsageSummary } from "../lib/api";
+import {
+  fetchCloudUsageDaily,
+  fetchCloudUsageSummary,
+  getUsageDaily,
+  getUsageSummary,
+} from "../lib/api";
 
 export function useUsageData({
   baseUrl,
@@ -16,7 +21,13 @@ export function useUsageData({
   timeZone,
   tzOffsetMinutes,
   now,
+  accountView = false,
+  accountAccessToken = null,
+  accountRevision = 0,
+  accountViewResolving = false,
 }: any = {}) {
+  const useCloud = Boolean(accountView && accountAccessToken);
+  const scopeKey = useCloud ? "cloud" : "local";
   const [daily, setDaily] = useState<any[]>([]);
   const [summary, setSummary] = useState<any | null>(null);
   const [rolling, setRolling] = useState<any | null>(null);
@@ -33,8 +44,24 @@ export function useUsageData({
     const host = safeHost(baseUrl) || "default";
     const dailyKey = includeDaily ? "daily" : "summary";
     const tzKey = getTimeZoneCacheKey({ timeZone, offsetMinutes: tzOffsetMinutes });
-    return `tokentracker.usage.${cacheKey}.${host}.${from}.${to}.${dailyKey}.${tzKey}`;
+    return `tokentracker.usage.${cacheKey}.${scopeKey}.${host}.${from}.${to}.${dailyKey}.${tzKey}`;
   })();
+
+  // Wipe state when the scope flips so the previously-rendered local data
+  // doesn't visually persist while the cloud fetch is in flight (and vice
+  // versa). The dependent fetcher will repopulate via refresh() below.
+  const lastScopeRef = useRef(scopeKey);
+  useEffect(() => {
+    if (lastScopeRef.current === scopeKey) return;
+    lastScopeRef.current = scopeKey;
+    setDaily([]);
+    setSummary(null);
+    setRolling(null);
+    setSource("edge");
+    setFetchedAt(null);
+    setError(null);
+    setLoading(true);
+  }, [scopeKey]);
 
   const readCache = useCallback(() => {
     if (!storageKey || typeof window === "undefined") return null;
@@ -75,8 +102,20 @@ export function useUsageData({
 
   const refresh = useCallback(async () => {
     const resolvedToken = await resolveAuthAccessToken(accessToken);
-    // 本地模式允许空 token
-    if (!resolvedToken && !mockEnabled && !isLocalMode) return;
+    const cloudToken = useCloud ? await resolveAuthAccessToken(accountAccessToken) : null;
+    // 本地模式允许空 token；云端模式必须 resolve 到一个 JWT 字符串
+    if (!resolvedToken && !mockEnabled && !isLocalMode && !useCloud) return;
+    if (useCloud && !cloudToken) {
+      // Cloud scope but the JWT could not be resolved/refreshed (refresh token
+      // also dead). Surface an explicit error + stop loading instead of a bare
+      // return, which previously left the panel stuck in a silent spinner.
+      setError("Your session expired. Please sign in again to view account data.");
+      setLoading(false);
+      return;
+    }
+    const dailyFetcher = useCloud ? fetchCloudUsageDaily : getUsageDaily;
+    const summaryFetcher = useCloud ? fetchCloudUsageSummary : getUsageSummary;
+    const tokenForFetch = useCloud ? cloudToken : resolvedToken;
     setLoading(true);
     setError(null);
     try {
@@ -84,17 +123,17 @@ export function useUsageData({
       let summaryRes = null;
       if (includeDaily) {
         const [dailyResult, summaryResult] = await Promise.allSettled([
-          getUsageDaily({
+          dailyFetcher({
             baseUrl,
-            accessToken: resolvedToken,
+            accessToken: tokenForFetch,
             from,
             to,
             timeZone,
             tzOffsetMinutes,
           }),
-          getUsageSummary({
+          summaryFetcher({
             baseUrl,
-            accessToken: resolvedToken,
+            accessToken: tokenForFetch,
             from,
             to,
             timeZone,
@@ -106,9 +145,9 @@ export function useUsageData({
         dailyRes = dailyResult.value;
         summaryRes = summaryResult.status === "fulfilled" ? summaryResult.value : null;
       } else {
-        summaryRes = await getUsageSummary({
+        summaryRes = await summaryFetcher({
           baseUrl,
-          accessToken: resolvedToken,
+          accessToken: tokenForFetch,
           from,
           to,
           timeZone,
@@ -129,9 +168,9 @@ export function useUsageData({
       let nextRolling = summaryRes?.rolling || dailyRes?.summary?.rolling || null;
       if (includeDaily && !nextSummary && !summaryRes) {
         try {
-          const fallback = await getUsageSummary({
+          const fallback = await summaryFetcher({
             baseUrl,
-            accessToken: resolvedToken,
+            accessToken: tokenForFetch,
             from,
             to,
             timeZone,
@@ -221,14 +260,24 @@ export function useUsageData({
     clearCache,
     writeCache,
     isLocalMode,
+    useCloud,
+    accountAccessToken,
+    accountRevision,
   ]);
 
   useEffect(() => {
+    if (accountViewResolving) {
+      // Scope not yet resolved (auth loading, cloud likely). Hold a loading
+      // state without reading the local cache or firing the local fetch, so we
+      // don't paint local data that the cloud flip would immediately wipe.
+      setLoading(true);
+      return;
+    }
     const isLocalMode = typeof window !== "undefined" &&
       (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
     const isLocalModeCheck = typeof window !== "undefined" &&
       (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
-    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalModeCheck) {
+    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalModeCheck && !useCloud) {
       setDaily([]);
       setSummary(null);
       setRolling(null);
@@ -275,6 +324,7 @@ export function useUsageData({
     cacheAllowed,
     clearCache,
     isLocalMode,
+    accountViewResolving,
   ]);
 
   const normalizedSource = mockEnabled ? "mock" : source;

--- a/dashboard/src/hooks/use-usage-model-breakdown.ts
+++ b/dashboard/src/hooks/use-usage-model-breakdown.ts
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { isAccessTokenReady, resolveAuthAccessToken } from "../lib/auth-token";
 import { isMockEnabled } from "../lib/mock-data";
 import { getTimeZoneCacheKey } from "../lib/timezone";
-import { getUsageModelBreakdown } from "../lib/api";
+import { fetchCloudUsageModelBreakdown, getUsageModelBreakdown } from "../lib/api";
 
 export function useUsageModelBreakdown({
   baseUrl,
@@ -13,7 +13,13 @@ export function useUsageModelBreakdown({
   cacheKey,
   timeZone,
   tzOffsetMinutes,
+  accountView = false,
+  accountAccessToken = null,
+  accountRevision = 0,
+  accountViewResolving = false,
 }: any = {}) {
+  const useCloud = Boolean(accountView && accountAccessToken);
+  const scopeKey = useCloud ? "cloud" : "local";
   const [breakdown, setBreakdown] = useState<any | null>(null);
   const [source, setSource] = useState<string>("edge");
   const [loading, setLoading] = useState(false);
@@ -26,8 +32,8 @@ export function useUsageModelBreakdown({
     if (!cacheKey) return null;
     const host = safeHost(baseUrl) || "default";
     const tzKey = getTimeZoneCacheKey({ timeZone, offsetMinutes: tzOffsetMinutes });
-    return `tokentracker.modelBreakdown.${cacheKey}.${host}.${from}.${to}.${tzKey}`;
-  }, [baseUrl, cacheKey, from, timeZone, to, tzOffsetMinutes]);
+    return `tokentracker.modelBreakdown.${cacheKey}.${scopeKey}.${host}.${from}.${to}.${tzKey}`;
+  }, [baseUrl, cacheKey, from, scopeKey, timeZone, to, tzOffsetMinutes]);
 
   const readCache = useCallback(() => {
     if (!storageKey || typeof window === "undefined") return null;
@@ -66,15 +72,35 @@ export function useUsageModelBreakdown({
   const isLocalMode = typeof window !== "undefined" &&
     (window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1");
 
+  // Wipe state when the scope flips so the prior buckets don't render
+  // while the new fetch is in flight.
+  const lastScopeRef = useRef(scopeKey);
+  useEffect(() => {
+    if (lastScopeRef.current === scopeKey) return;
+    lastScopeRef.current = scopeKey;
+    setBreakdown(null);
+    setSource("edge");
+    setError(null);
+    setLoading(true);
+  }, [scopeKey]);
+
   const refresh = useCallback(async () => {
     const resolvedToken = await resolveAuthAccessToken(accessToken);
-    if (!resolvedToken && !mockEnabled && !isLocalMode) return;
+    const cloudToken = useCloud ? await resolveAuthAccessToken(accountAccessToken) : null;
+    if (!resolvedToken && !mockEnabled && !isLocalMode && !useCloud) return;
+    if (useCloud && !cloudToken) {
+      setError("Your session expired. Please sign in again to view account data.");
+      setLoading(false);
+      return;
+    }
+    const tokenForFetch = useCloud ? cloudToken : resolvedToken;
+    const breakdownFetcher = useCloud ? fetchCloudUsageModelBreakdown : getUsageModelBreakdown;
     setLoading(true);
     setError(null);
     try {
-      const res = await getUsageModelBreakdown({
+      const res = await breakdownFetcher({
         baseUrl,
-        accessToken: resolvedToken,
+        accessToken: tokenForFetch,
         from,
         to,
         timeZone,
@@ -124,10 +150,17 @@ export function useUsageModelBreakdown({
     clearCache,
     writeCache,
     isLocalMode,
+    useCloud,
+    accountAccessToken,
+    accountRevision,
   ]);
 
   useEffect(() => {
-    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalMode) {
+    if (accountViewResolving) {
+      setLoading(true);
+      return;
+    }
+    if (!tokenReady && !guestAllowed && !mockEnabled && !isLocalMode && !useCloud) {
       setBreakdown(null);
       setSource("edge");
       setError(null);
@@ -157,6 +190,7 @@ export function useUsageModelBreakdown({
     cacheAllowed,
     clearCache,
     isLocalMode,
+    accountViewResolving,
   ]);
 
   const normalizedSource = mockEnabled ? "mock" : source;

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -517,3 +517,182 @@ export async function getUsageHeatmap({
     ...tzParams,
   }, { accessToken });
 }
+
+// ---------------------------------------------------------------------------
+// Cloud (account-wide) fetchers. Hit InsForge directly at
+// `${INSFORGE_BASE_URL}/functions/tokentracker-account-*` with the user's
+// JWT in the Authorization header. The edge functions verify HS256 against
+// JWT_SECRET, then aggregate across the user's active devices (dedup by
+// (hour, source, model), drop revoked-device historical rows).
+//
+// Use the same response schema as the corresponding local /functions/* so
+// hooks can swap fetchers based on `accountView` with no other transform.
+// ---------------------------------------------------------------------------
+
+const ACCOUNT_PATHS = {
+  summary: "tokentracker-account-summary",
+  daily: "tokentracker-account-daily",
+  hourly: "tokentracker-account-hourly",
+  monthly: "tokentracker-account-monthly",
+  heatmap: "tokentracker-account-heatmap",
+  modelBreakdown: "tokentracker-account-model-breakdown",
+} as const;
+
+async function fetchAccountFunction(
+  slug: string,
+  params: AnyRecord | undefined,
+  accessToken: string,
+) {
+  if (!accessToken || !isValidJwtShape(accessToken)) {
+    const err: any = new Error("Account view requires a signed-in user");
+    err.status = 401;
+    throw err;
+  }
+  const baseUrl = getInsforgeRemoteUrl();
+  if (!baseUrl) {
+    const err: any = new Error("InsForge base URL not configured");
+    err.status = 0;
+    throw err;
+  }
+  const root = baseUrl.replace(/\/$/, "");
+  const url = new URL(`${root}/functions/${slug}`);
+  if (params) {
+    for (const [key, value] of Object.entries(params)) {
+      if (value != null && value !== "") url.searchParams.set(key, String(value));
+    }
+  }
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+    Authorization: `Bearer ${accessToken}`,
+  };
+  const anonKey = getInsforgeAnonKey();
+  if (anonKey) headers.apikey = anonKey;
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers,
+    cache: "no-store",
+  });
+  if (!response.ok) {
+    const err: any = new Error(`Request failed with HTTP ${response.status}`);
+    err.status = response.status;
+    throw err;
+  }
+  return response.json();
+}
+
+export async function fetchCloudUsageSummary({
+  from,
+  to,
+  source,
+  model,
+  timeZone,
+  tzOffsetMinutes,
+  rolling = false,
+  accessToken,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  const filterParams = buildFilterParams({ source, model });
+  const rollingParams = rolling ? { rolling: "1" } : {};
+  return fetchAccountFunction(
+    ACCOUNT_PATHS.summary,
+    { from, to, ...filterParams, ...tzParams, ...rollingParams },
+    accessToken,
+  );
+}
+
+export async function fetchCloudUsageDaily({
+  from,
+  to,
+  source,
+  model,
+  timeZone,
+  tzOffsetMinutes,
+  accessToken,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  const filterParams = buildFilterParams({ source, model });
+  return fetchAccountFunction(
+    ACCOUNT_PATHS.daily,
+    { from, to, ...filterParams, ...tzParams },
+    accessToken,
+  );
+}
+
+export async function fetchCloudUsageHourly({
+  day,
+  source,
+  model,
+  timeZone,
+  tzOffsetMinutes,
+  accessToken,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  const filterParams = buildFilterParams({ source, model });
+  const params = day ? { day, ...filterParams, ...tzParams } : { ...filterParams, ...tzParams };
+  return fetchAccountFunction(ACCOUNT_PATHS.hourly, params, accessToken);
+}
+
+export async function fetchCloudUsageMonthly({
+  months,
+  to,
+  source,
+  model,
+  timeZone,
+  tzOffsetMinutes,
+  accessToken,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  const filterParams = buildFilterParams({ source, model });
+  return fetchAccountFunction(
+    ACCOUNT_PATHS.monthly,
+    {
+      ...(months ? { months: String(months) } : {}),
+      ...(to ? { to } : {}),
+      ...filterParams,
+      ...tzParams,
+    },
+    accessToken,
+  );
+}
+
+export async function fetchCloudUsageHeatmap({
+  weeks,
+  to,
+  weekStartsOn,
+  source,
+  model,
+  timeZone,
+  tzOffsetMinutes,
+  accessToken,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  const filterParams = buildFilterParams({ source, model });
+  return fetchAccountFunction(
+    ACCOUNT_PATHS.heatmap,
+    {
+      weeks: String(weeks),
+      to,
+      week_starts_on: weekStartsOn,
+      ...filterParams,
+      ...tzParams,
+    },
+    accessToken,
+  );
+}
+
+export async function fetchCloudUsageModelBreakdown({
+  from,
+  to,
+  source,
+  timeZone,
+  tzOffsetMinutes,
+  accessToken,
+}: AnyRecord = {}) {
+  const tzParams = buildTimeZoneParams({ timeZone, tzOffsetMinutes });
+  const filterParams = buildFilterParams({ source });
+  return fetchAccountFunction(
+    ACCOUNT_PATHS.modelBreakdown,
+    { from, to, ...filterParams, ...tzParams },
+    accessToken,
+  );
+}

--- a/dashboard/src/lib/cloud-sync-prefs.ts
+++ b/dashboard/src/lib/cloud-sync-prefs.ts
@@ -40,6 +40,19 @@ export function setCloudSyncEnabled(enabled: boolean): void {
   } catch {
     /* ignore */
   }
+  // Notify the SAME tab. AccountViewContext listens for this event (and the
+  // cross-tab `storage` event) to recompute accountView. Without it, toggling
+  // cloud sync on localhost would not switch the dashboard to the cross-device
+  // cloud view until a manual reload — the multi-machine view stayed invisible
+  // on the most common path. (Event name mirrors CLOUD_SYNC_CHANGE_EVENT in
+  // AccountViewContext.jsx; dispatched here to avoid an import cycle.)
+  try {
+    if (typeof window !== "undefined") {
+      window.dispatchEvent(new Event("tt.cloudSyncChanged"));
+    }
+  } catch {
+    /* ignore */
+  }
 }
 
 export function getStoredDeviceSession(): CloudDeviceSession | null {

--- a/dashboard/src/lib/cloud-sync.ts
+++ b/dashboard/src/lib/cloud-sync.ts
@@ -53,6 +53,68 @@ async function triggerLeaderboardRefresh(
   } catch { /* best effort */ }
 }
 
+const CLIENT_ID_KEY = "tokentracker_client_id_v1";
+
+/**
+ * Stable per-browser client identifier. Persisted in localStorage so the
+ * same browser on the same machine gets the same device_id across token
+ * rotations, but different browsers / different machines see different IDs.
+ *
+ * Needed because the cloud `tokentracker_devices_active_unique` index is
+ * keyed by (user_id, platform, device_name). Without a per-client suffix,
+ * every browser session for the same user on Mac+Chrome collapses to a
+ * single device_id, so two laptops would overwrite each other's hourly
+ * rows (ingest is upsert by (user, device, hour, source, model)).
+ */
+function getOrCreateClientId(): string {
+  if (typeof window === "undefined") return "ssr";
+  try {
+    const existing = window.localStorage.getItem(CLIENT_ID_KEY);
+    if (existing && existing.length >= 8) return existing;
+    const generated =
+      typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+        ? crypto.randomUUID()
+        : `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    window.localStorage.setItem(CLIENT_ID_KEY, generated);
+    return generated;
+  } catch {
+    // localStorage unavailable (private mode, quota) — fall back to a
+    // session-scoped id so at least different tabs in the same session
+    // don't all collide with the global "Token Tracker (dashboard)".
+    return `eph-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+}
+
+/**
+ * Resolve the device_name suffix used when minting a cloud device token.
+ *
+ * Prefers a stable per-MACHINE id served by the local CLI
+ * (/functions/tokentracker-machine-id, persisted in ~/.tokentracker/.../config.json).
+ * That makes every browser / WKWebView / cleared-cache session on the SAME
+ * machine resolve to ONE cloud device_id, so cross-device SUM aggregation is
+ * correct (one physical machine = one device whose cumulative queue upserts
+ * onto a single row; genuinely distinct machines stay distinct and sum).
+ *
+ * Falls back to the per-browser client id only when the local server is
+ * unreachable — exactly the public-host case, where no local sync runs anyway.
+ */
+async function resolveDeviceNameSuffix(): Promise<string> {
+  try {
+    const res = await fetch("/functions/tokentracker-machine-id", {
+      headers: { Accept: "application/json" },
+      cache: "no-store",
+    });
+    if (res.ok) {
+      const data = (await res.json().catch(() => null)) as { machineId?: string } | null;
+      const machineId = typeof data?.machineId === "string" ? data.machineId : null;
+      if (machineId && machineId.length >= 8) return machineId.slice(0, 8);
+    }
+  } catch {
+    /* local server unreachable — fall back to the per-browser id below */
+  }
+  return getOrCreateClientId().slice(0, 8);
+}
+
 /**
  * 用当前登录 JWT 向 InsForge 签发 device token，供本地 `tokentracker sync` 上传到云端。
  */
@@ -71,12 +133,14 @@ async function issueDeviceTokenForCloud(accessToken: string): Promise<CloudDevic
     typeof navigator !== "undefined" && typeof navigator.platform === "string"
       ? navigator.platform
       : "web";
-  // 云端 slug 为 tokentracker-device-token-issue（历史文档里的 tokentracker-* 在本项目未部署）
+  const deviceNameSuffix = await resolveDeviceNameSuffix();
+  const deviceName = `Token Tracker (dashboard) #${deviceNameSuffix}`;
+  // 云端 slug 为 tokentracker-device-token-issue（历史文档里的 vibeusage-* 在本项目未部署）
   const res = await fetch(`${root}/functions/tokentracker-device-token-issue`, {
     method: "POST",
     headers,
     body: JSON.stringify({
-      device_name: "Token Tracker (dashboard)",
+      device_name: deviceName,
       platform,
     }),
   });

--- a/dashboard/src/main.jsx
+++ b/dashboard/src/main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { InsforgeAuthProvider } from "./contexts/InsforgeAuthContext.jsx";
+import { AccountViewProvider } from "./contexts/AccountViewContext.jsx";
 import { LocaleProvider } from "./ui/foundation/LocaleProvider.jsx";
 import { CurrencyProvider } from "./ui/foundation/CurrencyProvider.jsx";
 import App from "./App.jsx";
@@ -20,7 +21,9 @@ createRoot(document.getElementById("root")).render(
     <LocaleProvider>
       <CurrencyProvider>
         <InsforgeAuthProvider>
-          <RouterProvider router={router} />
+          <AccountViewProvider>
+            <RouterProvider router={router} />
+          </AccountViewProvider>
         </InsforgeAuthProvider>
       </CurrencyProvider>
     </LocaleProvider>

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAccountView } from "../contexts/AccountViewContext.jsx";
 import { useActivityHeatmap } from "../hooks/use-activity-heatmap.js";
 import { useProjectUsageSummary } from "../hooks/use-project-usage-summary";
 import { useTrendData } from "../hooks/use-trend-data.js";
@@ -161,6 +162,21 @@ export function DashboardPage({
   const accessEnabled = signedIn || mockEnabled || publicMode;
   const authTokenReady = authTokenAllowed && isAccessTokenReady(effectiveAuthToken);
   const guestAllowed = signedIn && sessionSoftExpired && !publicMode;
+
+  // Cloud (cross-device account view) — driven by Settings → Cloud sync toggle
+  // on localhost, mandatory on public hosts (www.tokentracker.cc et al.).
+  // publicMode (shared link) opts out of account view entirely.
+  const {
+    accountView: accountViewBase,
+    revision: accountRevision,
+    resolving: accountResolvingBase,
+  } = useAccountView();
+  const accountView = accountViewBase && !publicMode;
+  const accountAccessToken = accountView ? effectiveAuthToken : null;
+  // While the resolved scope is still unknown (auth loading + cloud likely),
+  // hooks hold a loading state instead of painting local data that would be
+  // wiped on the flip to cloud (the local→cloud "double flash").
+  const accountViewResolving = accountResolvingBase && !publicMode;
 
 
   useEffect(() => {
@@ -403,6 +419,10 @@ export function DashboardPage({
     timeZone,
     tzOffsetMinutes,
     now: mockNow,
+    accountView,
+    accountAccessToken,
+    accountRevision,
+    accountViewResolving,
   });
   const {
     daily: dailyBreakdownDaily,
@@ -419,6 +439,10 @@ export function DashboardPage({
     timeZone,
     tzOffsetMinutes,
     now: mockNow,
+    accountView,
+    accountAccessToken,
+    accountRevision,
+    accountViewResolving,
   });
 
   const {
@@ -434,6 +458,10 @@ export function DashboardPage({
     cacheKey,
     timeZone,
     tzOffsetMinutes,
+    accountView,
+    accountAccessToken,
+    accountRevision,
+    accountViewResolving,
   });
 
   const [projectUsageLimit, setProjectUsageLimit] = useState(3);
@@ -480,6 +508,10 @@ export function DashboardPage({
     now: mockNow,
     sharedRows: shareDailyToTrend ? daily : null,
     sharedRange: shareDailyToTrend ? { from, to } : null,
+    accountView,
+    accountAccessToken,
+    accountRevision,
+    accountViewResolving,
   });
 
   // Stable useTrendData config handed to the zoom modal so it can hold its OWN
@@ -494,8 +526,18 @@ export function DashboardPage({
       timeZone: trendTimeZone,
       tzOffsetMinutes: trendTzOffsetMinutes,
       now: mockNow,
+      // Carry the account (cross-device cloud) scope into the zoom modal so its
+      // granularity drill-down reads the SAME source as the main trend chart —
+      // otherwise the zoom silently shows local/default-scope data in account view.
+      accountView,
+      accountAccessToken,
+      accountRevision,
+      accountViewResolving,
     }),
-    [baseUrl, accessToken, guestAllowed, cacheKey, trendTimeZone, trendTzOffsetMinutes, mockNow],
+    [
+      baseUrl, accessToken, guestAllowed, cacheKey, trendTimeZone, trendTzOffsetMinutes, mockNow,
+      accountView, accountAccessToken, accountRevision, accountViewResolving,
+    ],
   );
 
   const {
@@ -512,6 +554,10 @@ export function DashboardPage({
     timeZone,
     tzOffsetMinutes,
     now: mockNow,
+    accountView,
+    accountAccessToken,
+    accountRevision,
+    accountViewResolving,
   });
 
   const {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Token usage tracker for AI agent CLIs (Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, OpenClaw, Every Code, Hermes, GitHub Copilot, Kimi Code, CodeBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose)",
   "main": "src/cli.js",
   "bin": {

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -51,6 +51,60 @@ function resolveQueuePath() {
   return path.join(home, ".tokentracker", "tracker", "queue.jsonl");
 }
 
+/**
+ * Stable per-MACHINE identifier, persisted in config.json next to the queue.
+ *
+ * The dashboard uses this (not a per-browser localStorage id) as the cloud
+ * device_name suffix, so every browser / WKWebView / cleared-cache session on
+ * the SAME machine resolves to ONE cloud device_id. That keeps cross-device
+ * SUM aggregation correct: one physical machine = one device (its cumulative
+ * queue upserts onto a single row), while genuinely distinct machines stay
+ * distinct devices that legitimately sum. Browser-keyed ids conflated one
+ * machine into several device_ids and inflated the account-view total.
+ *
+ * Returns null only when the id cannot be persisted (read-only home), in which
+ * case the caller falls back to its own client id (prior behavior).
+ */
+function getOrCreateMachineId(queuePath) {
+  const configPath = path.join(path.dirname(queuePath || resolveQueuePath()), "config.json");
+  let config = {};
+  let raw = null;
+  try {
+    raw = fs.readFileSync(configPath, "utf8");
+  } catch (e) {
+    // Missing file is fine (fresh install → create config below). Any other
+    // read error means an existing config we must NOT clobber.
+    if (e && e.code !== "ENOENT") return null;
+  }
+  if (raw != null) {
+    try {
+      config = JSON.parse(raw) || {};
+    } catch {
+      // Corrupt / partially-written config.json — refuse to overwrite it (that
+      // would destroy deviceToken and other keys). Caller falls back to the
+      // per-browser client id.
+      return null;
+    }
+  }
+  const existing = config.machineId;
+  if (typeof existing === "string" && existing.length >= 8) return existing;
+  let generated;
+  try {
+    generated = crypto.randomUUID();
+  } catch {
+    generated = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+  try {
+    config.machineId = generated;
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2));
+    try { fs.chmodSync(configPath, 0o600); } catch { /* best effort */ }
+  } catch {
+    return null;
+  }
+  return generated;
+}
+
 function readProjectQueueData(projectQueuePath) {
   let raw;
   try {
@@ -1628,6 +1682,15 @@ function createLocalApiHandler({ queuePath }) {
         created_at: new Date().toISOString(),
         pro: { active: true, sources: ["local"], expires_at: null, partial: false, as_of: new Date().toISOString() },
       });
+      return true;
+    }
+
+    // --- machine-id (stable per-machine device identity for cloud sync) ---
+    // The dashboard reads this before issuing a cloud device token so the
+    // device_name keys on the MACHINE, not the browser — see
+    // getOrCreateMachineId above and dashboard/src/lib/cloud-sync.ts.
+    if (p === "/functions/tokentracker-machine-id") {
+      json(res, { machineId: getOrCreateMachineId(qp) });
       return true;
     }
 

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -679,21 +679,23 @@ async function parseOpenclawSessionFile({
 
     const model = normalizeModelInput(msg.model) || DEFAULT_MODEL;
 
-    // Per CLAUDE.md: cached_input_tokens = cache reads,
-    // cache_creation_input_tokens = cache writes. Also re-derive total_tokens
-    // as input + output + cache_creation + cache_read so cost math works
-    // even when the source's own totalTokens is stale or rounded.
-    const inputTok = Number(usage.input || 0);
-    const cacheReadTok = Number(usage.cacheRead || 0);
-    const cacheWriteTok = Number(usage.cacheWrite || 0);
-    const outputTok = Number(usage.output || 0);
+    // OpenClaw wraps Codex, so it follows the same OpenAI convention where
+    // `input` INCLUDES cached reads. Normalize by subtracting cached from
+    // input so `input_tokens` is pure non-cached (matches CLAUDE.md spec
+    // and prevents downstream double-counting at the cache_read rate on top
+    // of the full input rate — ~6–7x cost inflation on cache-heavy sessions).
+    const openclawRawInput = Number(usage.input || 0);
+    const openclawCached = Number(usage.cacheRead || 0);
+    const openclawCacheWrite = Number(usage.cacheWrite || 0);
+    const openclawOutput = Number(usage.output || 0);
+    const openclawInput = Math.max(0, openclawRawInput - openclawCached);
     const delta = {
-      input_tokens: inputTok,
-      cached_input_tokens: cacheReadTok,
-      cache_creation_input_tokens: cacheWriteTok,
-      output_tokens: outputTok,
+      input_tokens: openclawInput,
+      cached_input_tokens: openclawCached,
+      cache_creation_input_tokens: openclawCacheWrite,
+      output_tokens: openclawOutput,
       reasoning_output_tokens: 0,
-      total_tokens: inputTok + outputTok + cacheReadTok + cacheWriteTok,
+      total_tokens: openclawInput + openclawCached + openclawCacheWrite + openclawOutput,
       conversation_count: 1,
     };
 

--- a/test/dashboard-missing-jwt-guard.test.js
+++ b/test/dashboard-missing-jwt-guard.test.js
@@ -17,7 +17,11 @@ async function readHookSource(relativePath) {
 }
 
 function assertMissingJwtGuard(source, file) {
-  const guardRegex = /if\s*\(\s*!resolvedToken\s*&&\s*!mockEnabled\s*(?:&&\s*!isLocalMode\s*)?\)\s*return\s*;/;
+  // Cloud (account-view) mode bypasses the local-JWT guard because it
+  // authenticates separately via accountAccessToken; allow `&& !useCloud`
+  // as an optional trailing clause in addition to the historical
+  // `&& !isLocalMode` clause.
+  const guardRegex = /if\s*\(\s*!resolvedToken\s*&&\s*!mockEnabled\s*(?:&&\s*!isLocalMode\s*)?(?:&&\s*!useCloud\s*)?\)\s*return\s*;/;
   assert.ok(
     guardRegex.test(source),
     `expected missing-JWT guard in ${file} ("if (!resolvedToken && !mockEnabled) return;")`,


### PR DESCRIPTION
## Summary

Ships the cloud **cross-device account view**: when a signed-in user opts into cloud sync, the dashboard aggregates their usage **across every machine** (laptop + desktop + server) into one combined view — totals, trends, heatmap, and model breakdown — by reading the InsForge `tokentracker-account-*` edge functions instead of the local CLI queue.

Local-first is preserved: **logged-out / local-only users keep an instant, offline experience** (no gating, no network wait).

Closes #12.

## Cross-device semantic = SUM (validated against production data)

The account view **SUMs** across devices so two real machines add up. We verified on real data that this is correct and that the old MAX-dedup would lose data:

- 99.3% of the SUM-vs-leaderboard-MAX gap is **genuine multi-machine usage** (e.g. one user on `MacIntel` + `Win32`, or a Linux server + a Mac laptop) that MAX would wrongly drop (up to 36% under-count for a real dual-machine user).
- True same-machine duplication is only **~0.03%** of the active-device total.

The leaderboard keeps its own cross-device MAX-dedup, so the dashboard total intentionally differs from the leaderboard rank by the genuine multi-machine gap.

## What's in here

- **Scope-aware hooks + `AccountViewContext`** switch the dashboard between local CLI and the cloud account view; `api.ts` adds the `tokentracker-account-*` fetchers; `main.jsx` wires the provider.
- **Machine-stable device identity** (the core fix): `device_name` keys on a per-machine id served by the local CLI (`/functions/tokentracker-machine-id`, persisted in `config.json`, never overwrites a corrupt config) instead of a per-browser localStorage id → one physical machine = one `device_id`, so SUM no longer inflates across browsers / WKWebView. Old device IDs are **not** invalidated (no revoke-on-issue).
- **No "double flash"**: an auth-loading gate (`AccountViewContext.resolving`) holds a loading state instead of painting local data that the cloud flip would wipe. Logged-out/local users are never gated.
- **Cloud-sync toggle is live in-tab**: `setCloudSyncEnabled` emits an event so enabling cloud sync switches the view without a reload; `signOut` disables cloud sync.
- **Cloud cost guard**: Codex/every-code reasoning tokens are no longer double-charged in `account-summary` / `-daily` / `-model-breakdown`.
- **Public-host gate** excludes public `/leaderboard` and `/u/:userId`.
- Cloud hooks surface a **session-expired error** instead of a silent infinite spinner.
- README (en/zh-CN/ja/ko) documents the feature; version bumped to **0.42.0**.

## Verification

- `npm test` 769/769 pass · dashboard build ✅ · `tsc` ✅ · new resolving-gate vitest 3/3.
- Real end-to-end on the actual edge code (synthetic two-device data, then cleaned up): same-machine split → inflated; **machine-stable identity → correct 800**; two real machines → correct SUM; Codex cost guard → no double-charge.
- Cross-validated with an independent Codex adversarial review; its valid findings fixed (config-clobber guard, zoom-modal scope, in-tab toggle, cost guard).

## Known follow-ups (non-blocking)

- Legacy per-browser device churn (~0.03% of active total, ages out of rolling windows) — optional **non-destructive** device-consolidation cleanup later. Never via an offset-reset migration.
- `account-monthly` tz bucketing (pre-existing) and surfacing the session-expired error text in the UI.

## Rollback

Squash-merge → revert is a single commit on `main`; Vercel redeploys the reverted dashboard; npm/DMG superseded by a revert patch. **No destructive data migration was performed**, so there is nothing irreversible on the data side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Cross-device account view: When signed in with cloud sync enabled, view and aggregate usage metrics across all your devices in one unified dashboard.

* **Bug Fixes**
  * Fixed incorrect billing for reasoning tokens on certain models.

* **Documentation**
  * Updated documentation in English, Japanese, Korean, and Chinese to reflect the new cross-device account view feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->