### PR TITLE
fix(edge): per-model breakdown in cloud account-* aggregators

### DIFF
--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -409,6 +409,10 @@ export default async function (req: Request): Promise<Response> {
     cache_creation_input_tokens: number;
     reasoning_output_tokens: number;
     conversation_count: number;
+    // Per-model token totals for the day, so the dashboard Usage Trend can stack
+    // by MODEL in cloud (account) mode — mirrors src/lib/local-api.js daily output.
+    // Without this the trend falls back to a token-type breakdown in cloud mode.
+    models: Record<string, number>;
   }>();
   for (const row of rows) {
     if (!row.hour_start) continue;
@@ -427,6 +431,7 @@ export default async function (req: Request): Promise<Response> {
         cache_creation_input_tokens: 0,
         reasoning_output_tokens: 0,
         conversation_count: 0,
+        models: {},
       };
       byDay.set(day, a);
     }
@@ -440,6 +445,8 @@ export default async function (req: Request): Promise<Response> {
     a.cache_creation_input_tokens += Number(row.cache_creation_input_tokens) || 0;
     a.reasoning_output_tokens += Number(row.reasoning_output_tokens) || 0;
     a.conversation_count += Number(row.conversations) || 0;
+    const mdl = String(row.model || "unknown");
+    a.models[mdl] = (a.models[mdl] || 0) + tt;
   }
 
   const data = Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));

--- a/dashboard/edge-patches/tokentracker-account-heatmap.ts
+++ b/dashboard/edge-patches/tokentracker-account-heatmap.ts
@@ -197,19 +197,23 @@ export default async function (req: Request): Promise<Response> {
 
   const rows = rawRows;
 
-  const byDay = new Map<string, { total_tokens: number; billable_total_tokens: number }>();
+  const byDay = new Map<string, { total_tokens: number; billable_total_tokens: number; models: Record<string, number> }>();
   for (const row of rows) {
     if (!row.hour_start) continue;
     const day = zonedDayKey(String(row.hour_start), tz, tzOffsetMinutes);
     if (day < from || day > to) continue;
     let a = byDay.get(day);
     if (!a) {
-      a = { total_tokens: 0, billable_total_tokens: 0 };
+      a = { total_tokens: 0, billable_total_tokens: 0, models: {} };
       byDay.set(day, a);
     }
     const tt = Number(row.total_tokens) || 0;
     a.total_tokens += tt;
     a.billable_total_tokens += tt;
+    // Per-model totals so the activity-heatmap tooltip can show MODEL breakdown
+    // in cloud mode — mirrors src/lib/local-api.js heatmap cells.
+    const mdl = String(row.model || "unknown");
+    a.models[mdl] = (a.models[mdl] || 0) + tt;
   }
 
   const allValues = Array.from(byDay.values())
@@ -226,7 +230,7 @@ export default async function (req: Request): Promise<Response> {
     return 4;
   };
 
-  const cells: { day: string; total_tokens: number; billable_total_tokens: number; level: number }[] = [];
+  const cells: { day: string; total_tokens: number; billable_total_tokens: number; level: number; models: Record<string, number> | null }[] = [];
   const cursor = new Date(start);
   while (cursor <= end) {
     const day = cursor.toISOString().slice(0, 10);
@@ -237,6 +241,7 @@ export default async function (req: Request): Promise<Response> {
       total_tokens: data?.total_tokens || 0,
       billable_total_tokens: billable,
       level: calcLevel(billable),
+      models: data?.models || null,
     });
     cursor.setUTCDate(cursor.getUTCDate() + 1);
   }

--- a/dashboard/edge-patches/tokentracker-account-hourly.ts
+++ b/dashboard/edge-patches/tokentracker-account-hourly.ts
@@ -244,6 +244,9 @@ export default async function (req: Request): Promise<Response> {
     cache_creation_input_tokens: number;
     reasoning_output_tokens: number;
     conversation_count: number;
+    // Per-model totals so the Usage Trend (day/hourly mode) can stack by MODEL
+    // in cloud mode — mirrors src/lib/local-api.js aggregateHourlyByDay output.
+    models: Record<string, number>;
   }>();
   for (const row of rows) {
     if (!row.hour_start) continue;
@@ -263,6 +266,7 @@ export default async function (req: Request): Promise<Response> {
         cache_creation_input_tokens: 0,
         reasoning_output_tokens: 0,
         conversation_count: 0,
+        models: {},
       };
       byHour.set(hourKey, bucket);
     }
@@ -275,6 +279,8 @@ export default async function (req: Request): Promise<Response> {
     bucket.cache_creation_input_tokens += Number(row.cache_creation_input_tokens) || 0;
     bucket.reasoning_output_tokens += Number(row.reasoning_output_tokens) || 0;
     bucket.conversation_count += Number(row.conversations) || 0;
+    const mdl = String(row.model || "unknown");
+    bucket.models[mdl] = (bucket.models[mdl] || 0) + tt;
   }
 
   const data = Array.from(byHour.values()).sort((a, b) => a.hour.localeCompare(b.hour));

--- a/dashboard/edge-patches/tokentracker-account-monthly.ts
+++ b/dashboard/edge-patches/tokentracker-account-monthly.ts
@@ -177,6 +177,9 @@ export default async function (req: Request): Promise<Response> {
     cache_creation_input_tokens: number;
     reasoning_output_tokens: number;
     conversation_count: number;
+    // Per-model totals so the Usage Trend (total/monthly mode) can stack by
+    // MODEL in cloud mode — mirrors src/lib/local-api.js monthly output.
+    models: Record<string, number>;
   }>();
 
   for (const row of rows) {
@@ -196,6 +199,7 @@ export default async function (req: Request): Promise<Response> {
         cache_creation_input_tokens: 0,
         reasoning_output_tokens: 0,
         conversation_count: 0,
+        models: {},
       };
       byMonth.set(month, a);
     }
@@ -208,6 +212,8 @@ export default async function (req: Request): Promise<Response> {
     a.cache_creation_input_tokens += Number(row.cache_creation_input_tokens) || 0;
     a.reasoning_output_tokens += Number(row.reasoning_output_tokens) || 0;
     a.conversation_count += Number(row.conversations) || 0;
+    const mdl = String(row.model || "unknown");
+    a.models[mdl] = (a.models[mdl] || 0) + tt;
   }
 
   const data = Array.from(byMonth.values()).sort((a, b) => a.month.localeCompare(b.month));


### PR DESCRIPTION
Cloud Usage Trend + heatmap now stack by **model** (not token-type) in account view: account-daily/-monthly/-hourly/-heatmap emit a per-bucket `models` map mirroring local-api. Fixes the regression reported after v0.42.0 where the cloud trend tooltip showed only Cached/Input/Output/Reasoning. Already deployed to InsForge edge; this records it in source. Edge-only, no version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

- Token usage analytics now display per-model breakdowns in daily, hourly, and monthly aggregated views, enabling better visibility into which models consume the most tokens
- Heatmap visualizations now include model-specific token totals for enhanced insight into usage patterns across different time periods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->