### PR TITLE
perf(edge): server-side GROUP BY for account-* + dashboard skeleton (v0.42.1)

### DIFF
--- a/TokenTrackerBar/project.yml
+++ b/TokenTrackerBar/project.yml
@@ -29,7 +29,7 @@ targets:
         PRODUCT_NAME: TokenTrackerBar
         INFOPLIST_VALUES: |
           LSUIElement = YES
-        MARKETING_VERSION: "0.42.0"
+        MARKETING_VERSION: "0.42.1"
         CURRENT_PROJECT_VERSION: "1"
         SWIFT_EMIT_LOC_STRINGS: "YES"
         CODE_SIGN_STYLE: Automatic
@@ -79,7 +79,7 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.tokentracker.bar.widget
         PRODUCT_NAME: TokenTrackerWidget
-        MARKETING_VERSION: "0.42.0"
+        MARKETING_VERSION: "0.42.1"
         CURRENT_PROJECT_VERSION: "1"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         SWIFT_EMIT_LOC_STRINGS: "YES"

--- a/TokenTrackerWin/TokenTrackerWin.csproj
+++ b/TokenTrackerWin/TokenTrackerWin.csproj
@@ -22,7 +22,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>assets\trayicon.ico</ApplicationIcon>
     <!-- Keep in sync with package.json / project.yml on release. -->
-    <Version>0.42.0</Version>
+    <Version>0.42.1</Version>
     <Product>TokenTracker</Product>
     <Company>TokenTracker</Company>
   </PropertyGroup>

--- a/dashboard/edge-patches/tokentracker-account-daily.ts
+++ b/dashboard/edge-patches/tokentracker-account-daily.ts
@@ -303,7 +303,51 @@ interface HourlyRow {
   conversations: number | null;
 }
 
-function computeRowCost(row: HourlyRow): number {
+interface GroupedRow {
+  bucket: string;
+  source: string;
+  model: string;
+  total_tokens: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cached_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  reasoning_output_tokens: number | null;
+  conversations: number | null;
+}
+
+/**
+ * Server-side aggregation. One RPC replaces the old N paginated 1000-row raw
+ * fetches: account_usage_grouped() GROUPs BY (tz-local bucket, source, model)
+ * in Postgres and returns a single JSONB array. SUM across the user's active
+ * devices is byte-identical to the old in-edge aggregation; tz-local bucketing
+ * uses `AT TIME ZONE` (same IANA database as the old JS Intl path, incl. DST).
+ */
+async function fetchGroupedRows(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  activeDeviceIds: string[],
+  fromIso: string,
+  toIso: string,
+  trunc: "hour" | "day" | "month" | "none",
+  tz: string | null,
+  tzOffsetMinutes: number | null,
+): Promise<GroupedRow[]> {
+  if (activeDeviceIds.length === 0) return [];
+  const { data, error } = await client.database.rpc("account_usage_grouped", {
+    p_user_id: userId,
+    p_device_ids: activeDeviceIds,
+    p_from: fromIso,
+    p_to: toIso,
+    p_trunc: trunc,
+    p_tz: tz,
+    p_offset_min: tzOffsetMinutes,
+  });
+  if (error) throw new Error(error.message);
+  return (Array.isArray(data) ? data : []) as GroupedRow[];
+}
+
+function computeRowCost(row: GroupedRow): number {
   const p = getModelPricing(row.model);
   // Codex / every-code fold reasoning into output_tokens (OpenAI convention),
   // so charging reasoning_output_tokens again at the output rate double-counts.
@@ -370,33 +414,12 @@ export default async function (req: Request): Promise<Response> {
   const rangeStart = startDate.toISOString();
   const rangeEnd = endDate.toISOString();
 
-  const rawRows: HourlyRow[] = [];
-  const PAGE_SIZE = 1000;
-  const DEVICE_CHUNK = 25;
-  for (let i = 0; i < activeDeviceIds.length; i += DEVICE_CHUNK) {
-    const chunk = activeDeviceIds.slice(i, i + DEVICE_CHUNK);
-    let offset = 0;
-    while (true) {
-      const { data, error } = await client.database
-        .from("tokentracker_hourly")
-        .select(
-          "hour_start, source, model, total_tokens, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens, conversations",
-        )
-        .eq("user_id", userId)
-        .in("device_id", chunk)
-        .gte("hour_start", rangeStart)
-        .lt("hour_start", rangeEnd)
-        .order("hour_start", { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
-      if (error) return json({ error: error.message }, 500);
-      if (!data || data.length === 0) break;
-      rawRows.push(...(data as unknown as HourlyRow[]));
-      if (data.length < PAGE_SIZE) break;
-      offset += PAGE_SIZE;
-    }
+  let rows: GroupedRow[];
+  try {
+    rows = await fetchGroupedRows(client, userId, activeDeviceIds, rangeStart, rangeEnd, "day", tz, tzOffsetMinutes);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
   }
-
-  const rows = rawRows;
 
   const byDay = new Map<string, {
     day: string;
@@ -415,8 +438,7 @@ export default async function (req: Request): Promise<Response> {
     models: Record<string, number>;
   }>();
   for (const row of rows) {
-    if (!row.hour_start) continue;
-    const day = zonedDayKey(String(row.hour_start), tz, tzOffsetMinutes);
+    const day = row.bucket;
     if (day < from || day > to) continue;
     let a = byDay.get(day);
     if (!a) {

--- a/dashboard/edge-patches/tokentracker-account-heatmap.ts
+++ b/dashboard/edge-patches/tokentracker-account-heatmap.ts
@@ -104,8 +104,8 @@ async function fetchActiveDeviceIds(
   return rows.map((r) => r.id).filter((id): id is string => typeof id === "string" && id.length > 0);
 }
 
-interface HourlyRow {
-  hour_start: string;
+interface GroupedRow {
+  bucket: string;
   source: string | null;
   model: string | null;
   total_tokens: number | null;
@@ -114,6 +114,40 @@ interface HourlyRow {
   cached_input_tokens: number | null;
   cache_creation_input_tokens: number | null;
   reasoning_output_tokens: number | null;
+  conversations: number | null;
+}
+
+/**
+ * Server-side aggregation. One RPC replaces the old N paginated 1000-row raw
+ * fetches: account_usage_grouped() GROUPs BY (tz-local bucket, source, model)
+ * in Postgres and returns a single JSONB array, so a 52-week heatmap that used
+ * to need ~7 page round-trips (~3s) returns a few hundred rows in one call
+ * (~150ms). SUM across the user's active devices is byte-identical to the old
+ * in-edge aggregation; tz-local day/hour bucketing is done with `AT TIME ZONE`
+ * (same IANA database as the old JS `Intl.DateTimeFormat` path, incl. DST).
+ */
+async function fetchGroupedRows(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  activeDeviceIds: string[],
+  fromIso: string,
+  toIso: string,
+  trunc: "hour" | "day" | "month" | "none",
+  tz: string | null,
+  tzOffsetMinutes: number | null,
+): Promise<GroupedRow[]> {
+  if (activeDeviceIds.length === 0) return [];
+  const { data, error } = await client.database.rpc("account_usage_grouped", {
+    p_user_id: userId,
+    p_device_ids: activeDeviceIds,
+    p_from: fromIso,
+    p_to: toIso,
+    p_trunc: trunc,
+    p_tz: tz,
+    p_offset_min: tzOffsetMinutes,
+  });
+  if (error) throw new Error(error.message);
+  return (Array.isArray(data) ? data : []) as GroupedRow[];
 }
 
 export default async function (req: Request): Promise<Response> {
@@ -171,36 +205,16 @@ export default async function (req: Request): Promise<Response> {
   const rangeStart = startDate.toISOString();
   const rangeEnd = nextDay.toISOString();
 
-  const rawRows: HourlyRow[] = [];
-  const PAGE_SIZE = 1000;
-  const DEVICE_CHUNK = 25;
-  for (let i = 0; i < activeDeviceIds.length; i += DEVICE_CHUNK) {
-    const chunk = activeDeviceIds.slice(i, i + DEVICE_CHUNK);
-    let offset = 0;
-    while (true) {
-      const { data, error } = await client.database
-        .from("tokentracker_hourly")
-        .select("hour_start, source, model, total_tokens, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens")
-        .eq("user_id", userId)
-        .in("device_id", chunk)
-        .gte("hour_start", rangeStart)
-        .lt("hour_start", rangeEnd)
-        .order("hour_start", { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
-      if (error) return json({ error: error.message }, 500);
-      if (!data || data.length === 0) break;
-      rawRows.push(...(data as unknown as HourlyRow[]));
-      if (data.length < PAGE_SIZE) break;
-      offset += PAGE_SIZE;
-    }
+  let rows: GroupedRow[];
+  try {
+    rows = await fetchGroupedRows(client, userId, activeDeviceIds, rangeStart, rangeEnd, "day", tz, tzOffsetMinutes);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
   }
-
-  const rows = rawRows;
 
   const byDay = new Map<string, { total_tokens: number; billable_total_tokens: number; models: Record<string, number> }>();
   for (const row of rows) {
-    if (!row.hour_start) continue;
-    const day = zonedDayKey(String(row.hour_start), tz, tzOffsetMinutes);
+    const day = row.bucket;
     if (day < from || day > to) continue;
     let a = byDay.get(day);
     if (!a) {

--- a/dashboard/edge-patches/tokentracker-account-hourly.ts
+++ b/dashboard/edge-patches/tokentracker-account-hourly.ts
@@ -90,6 +90,50 @@ interface HourlyRow {
   conversations: number | null;
 }
 
+interface GroupedRow {
+  bucket: string;
+  source: string | null;
+  model: string | null;
+  total_tokens: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cached_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  reasoning_output_tokens: number | null;
+  conversations: number | null;
+}
+
+/**
+ * Server-side aggregation. One RPC replaces the old N paginated 1000-row raw
+ * fetches: account_usage_grouped() GROUPs BY (tz-local bucket, source, model)
+ * in Postgres and returns a single JSONB array. SUM across the user's active
+ * devices is byte-identical to the old in-edge aggregation; tz-local bucketing
+ * uses `AT TIME ZONE` (same IANA database as the old JS Intl path, incl. DST).
+ */
+async function fetchGroupedRows(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  activeDeviceIds: string[],
+  fromIso: string,
+  toIso: string,
+  trunc: "hour" | "day" | "month" | "none",
+  tz: string | null,
+  tzOffsetMinutes: number | null,
+): Promise<GroupedRow[]> {
+  if (activeDeviceIds.length === 0) return [];
+  const { data, error } = await client.database.rpc("account_usage_grouped", {
+    p_user_id: userId,
+    p_device_ids: activeDeviceIds,
+    p_from: fromIso,
+    p_to: toIso,
+    p_trunc: trunc,
+    p_tz: tz,
+    p_offset_min: tzOffsetMinutes,
+  });
+  if (error) throw new Error(error.message);
+  return (Array.isArray(data) ? data : []) as GroupedRow[];
+}
+
 interface TzCtx {
   timeZone: string | null;
   offsetMinutes: number | null;
@@ -206,33 +250,12 @@ export default async function (req: Request): Promise<Response> {
   const rangeStart = start.toISOString();
   const rangeEnd = end.toISOString();
 
-  const rawRows: HourlyRow[] = [];
-  const PAGE_SIZE = 1000;
-  const DEVICE_CHUNK = 25;
-  for (let i = 0; i < activeDeviceIds.length; i += DEVICE_CHUNK) {
-    const chunk = activeDeviceIds.slice(i, i + DEVICE_CHUNK);
-    let offset = 0;
-    while (true) {
-      const { data, error } = await client.database
-        .from("tokentracker_hourly")
-        .select(
-          "hour_start, source, model, total_tokens, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens, conversations",
-        )
-        .eq("user_id", userId)
-        .in("device_id", chunk)
-        .gte("hour_start", rangeStart)
-        .lt("hour_start", rangeEnd)
-        .order("hour_start", { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
-      if (error) return json({ error: error.message }, 500);
-      if (!data || data.length === 0) break;
-      rawRows.push(...(data as unknown as HourlyRow[]));
-      if (data.length < PAGE_SIZE) break;
-      offset += PAGE_SIZE;
-    }
+  let rows: GroupedRow[];
+  try {
+    rows = await fetchGroupedRows(client, userId, activeDeviceIds, rangeStart, rangeEnd, "hour", tzCtx.timeZone, tzCtx.offsetMinutes);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
   }
-
-  const rows = rawRows;
 
   const byHour = new Map<string, {
     hour: string;
@@ -249,11 +272,11 @@ export default async function (req: Request): Promise<Response> {
     models: Record<string, number>;
   }>();
   for (const row of rows) {
-    if (!row.hour_start) continue;
-    const parts = getZonedParts(new Date(row.hour_start), tzCtx);
-    if (!parts) continue;
-    if (formatDayKey(parts) !== day) continue;
-    const hourKey = `${day}T${String(parts.hour).padStart(2, "0")}:00:00`;
+    // RPC 'hour' bucket is already the tz-local `YYYY-MM-DDTHH:00:00`; keep only
+    // the hours whose local day matches the requested day (mirrors the old
+    // getZonedParts + formatDayKey filter).
+    if (row.bucket.slice(0, 10) !== day) continue;
+    const hourKey = row.bucket;
     let bucket = byHour.get(hourKey);
     if (!bucket) {
       bucket = {

--- a/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
+++ b/dashboard/edge-patches/tokentracker-account-model-breakdown.ts
@@ -311,6 +311,51 @@ interface Totals {
   total_cost_usd: string;
 }
 
+interface GroupedRow {
+  bucket: string;
+  source: string;
+  model: string;
+  total_tokens: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cached_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  reasoning_output_tokens: number | null;
+  conversations: number | null;
+}
+
+/**
+ * Server-side aggregation. One RPC replaces the old N paginated 1000-row raw
+ * fetches: account_usage_grouped() GROUPs BY (tz-local day, source, model) in
+ * Postgres and returns a single JSONB array. We still filter to local days in
+ * [from, to] and collapse to (source, model) in-edge — SUM across the user's
+ * active devices is byte-identical; tz-local day bucketing uses `AT TIME ZONE`
+ * (same IANA database as the old JS Intl path, incl. DST).
+ */
+async function fetchGroupedRows(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  activeDeviceIds: string[],
+  fromIso: string,
+  toIso: string,
+  trunc: "hour" | "day" | "month" | "none",
+  tz: string | null,
+  tzOffsetMinutes: number | null,
+): Promise<GroupedRow[]> {
+  if (activeDeviceIds.length === 0) return [];
+  const { data, error } = await client.database.rpc("account_usage_grouped", {
+    p_user_id: userId,
+    p_device_ids: activeDeviceIds,
+    p_from: fromIso,
+    p_to: toIso,
+    p_trunc: trunc,
+    p_tz: tz,
+    p_offset_min: tzOffsetMinutes,
+  });
+  if (error) throw new Error(error.message);
+  return (Array.isArray(data) ? data : []) as GroupedRow[];
+}
+
 export default async function (req: Request): Promise<Response> {
   if (req.method === "OPTIONS")
     return new Response(null, { status: 204, headers: corsHeaders });
@@ -360,44 +405,17 @@ export default async function (req: Request): Promise<Response> {
   const rangeStart = startDate.toISOString();
   const rangeEnd = endDate.toISOString();
 
-  const rawRows: HourlyRow[] = [];
-  const PAGE_SIZE = 1000;
-  const DEVICE_CHUNK = 25;
-  for (let i = 0; i < activeDeviceIds.length; i += DEVICE_CHUNK) {
-    const chunk = activeDeviceIds.slice(i, i + DEVICE_CHUNK);
-    let offset = 0;
-    while (true) {
-      const { data, error } = await client.database
-        .from("tokentracker_hourly")
-        .select(
-          "hour_start, source, model, total_tokens, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens",
-        )
-        .eq("user_id", userId)
-        .in("device_id", chunk)
-        .gte("hour_start", rangeStart)
-        .lt("hour_start", rangeEnd)
-        .order("hour_start", { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
-      if (error) return json({ error: error.message }, 500);
-      if (!data || data.length === 0) break;
-      rawRows.push(...(data as unknown as HourlyRow[]));
-      if (data.length < PAGE_SIZE) break;
-      offset += PAGE_SIZE;
-    }
+  let rows: GroupedRow[];
+  try {
+    rows = await fetchGroupedRows(client, userId, activeDeviceIds, rangeStart, rangeEnd, "day", tz, tzOffsetMinutes);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
   }
 
-  const rows = rawRows;
-
-  // Filter on inclusive [from, to] by *local* day (honoring tz / tz_offset_minutes),
-  // not raw UTC. Without this, Day=2026-05-18 in Asia/Shanghai (which maps to
-  // UTC 2026-05-17T16:00–2026-05-18T16:00) returns an empty source list because
-  // every relevant row's UTC YYYY-MM-DD lands on 2026-05-17 or 2026-05-18 in a
-  // mix that the strict d>=from && d<=to UTC compare partially drops.
-  const filtered = rows.filter((r) => {
-    if (!r.hour_start) return false;
-    const d = zonedDayKey(String(r.hour_start), tz, tzOffsetMinutes);
-    return d >= from && d <= to;
-  });
+  // Keep only the tz-local days in [from, to]. The RPC already bucketed each
+  // row to its local day (honoring tz / tz_offset_minutes), so this compares
+  // the bucket directly — same inclusive [from, to] semantics as before.
+  const filtered = rows.filter((r) => r.bucket >= from && r.bucket <= to);
 
   interface ModelAgg {
     model: string;

--- a/dashboard/edge-patches/tokentracker-account-monthly.ts
+++ b/dashboard/edge-patches/tokentracker-account-monthly.ts
@@ -77,8 +77,8 @@ async function fetchActiveDeviceIds(
   return rows.map((r) => r.id).filter((id): id is string => typeof id === "string" && id.length > 0);
 }
 
-interface HourlyRow {
-  hour_start: string;
+interface GroupedRow {
+  bucket: string;
   source: string | null;
   model: string | null;
   total_tokens: number | null;
@@ -88,6 +88,36 @@ interface HourlyRow {
   cache_creation_input_tokens: number | null;
   reasoning_output_tokens: number | null;
   conversations: number | null;
+}
+
+/**
+ * Server-side aggregation. One RPC replaces the old N paginated 1000-row raw
+ * fetches: account_usage_grouped() GROUPs BY (bucket, source, model) in
+ * Postgres and returns a single JSONB array. Monthly buckets stay UTC-based
+ * (tz=null) to match the old `hour_start.slice(0,7)` behavior exactly.
+ */
+async function fetchGroupedRows(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  activeDeviceIds: string[],
+  fromIso: string,
+  toIso: string,
+  trunc: "hour" | "day" | "month" | "none",
+  tz: string | null,
+  tzOffsetMinutes: number | null,
+): Promise<GroupedRow[]> {
+  if (activeDeviceIds.length === 0) return [];
+  const { data, error } = await client.database.rpc("account_usage_grouped", {
+    p_user_id: userId,
+    p_device_ids: activeDeviceIds,
+    p_from: fromIso,
+    p_to: toIso,
+    p_trunc: trunc,
+    p_tz: tz,
+    p_offset_min: tzOffsetMinutes,
+  });
+  if (error) throw new Error(error.message);
+  return (Array.isArray(data) ? data : []) as GroupedRow[];
 }
 
 export default async function (req: Request): Promise<Response> {
@@ -139,33 +169,12 @@ export default async function (req: Request): Promise<Response> {
   nextDay.setUTCDate(nextDay.getUTCDate() + 1);
   const rangeEnd = nextDay.toISOString();
 
-  const rawRows: HourlyRow[] = [];
-  const PAGE_SIZE = 1000;
-  const DEVICE_CHUNK = 25;
-  for (let i = 0; i < activeDeviceIds.length; i += DEVICE_CHUNK) {
-    const chunk = activeDeviceIds.slice(i, i + DEVICE_CHUNK);
-    let offset = 0;
-    while (true) {
-      const { data, error } = await client.database
-        .from("tokentracker_hourly")
-        .select(
-          "hour_start, source, model, total_tokens, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens, conversations",
-        )
-        .eq("user_id", userId)
-        .in("device_id", chunk)
-        .gte("hour_start", rangeStart)
-        .lt("hour_start", rangeEnd)
-        .order("hour_start", { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
-      if (error) return json({ error: error.message }, 500);
-      if (!data || data.length === 0) break;
-      rawRows.push(...(data as unknown as HourlyRow[]));
-      if (data.length < PAGE_SIZE) break;
-      offset += PAGE_SIZE;
-    }
+  let rows: GroupedRow[];
+  try {
+    rows = await fetchGroupedRows(client, userId, activeDeviceIds, rangeStart, rangeEnd, "month", null, null);
+  } catch (e) {
+    return json({ error: (e as Error).message }, 500);
   }
-
-  const rows = rawRows;
 
   const byMonth = new Map<string, {
     month: string;
@@ -183,10 +192,7 @@ export default async function (req: Request): Promise<Response> {
   }>();
 
   for (const row of rows) {
-    if (!row.hour_start) continue;
-    const day = String(row.hour_start).slice(0, 10);
-    if (day < from || day > to) continue;
-    const month = day.slice(0, 7);
+    const month = row.bucket;
     let a = byMonth.get(month);
     if (!a) {
       a = {

--- a/dashboard/edge-patches/tokentracker-account-summary.ts
+++ b/dashboard/edge-patches/tokentracker-account-summary.ts
@@ -341,7 +341,51 @@ interface HourlyRow {
   conversations: number | null;
 }
 
-function computeRowCost(row: HourlyRow): number {
+interface GroupedRow {
+  bucket: string;
+  source: string;
+  model: string;
+  total_tokens: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cached_input_tokens: number | null;
+  cache_creation_input_tokens: number | null;
+  reasoning_output_tokens: number | null;
+  conversations: number | null;
+}
+
+/**
+ * Server-side aggregation. One RPC replaces the old N paginated 1000-row raw
+ * fetches: account_usage_grouped() GROUPs BY (tz-local bucket, source, model)
+ * in Postgres and returns a single JSONB array. SUM across the user's active
+ * devices is byte-identical to the old in-edge aggregation; tz-local bucketing
+ * uses `AT TIME ZONE` (same IANA database as the old JS Intl path, incl. DST).
+ */
+async function fetchGroupedRows(
+  client: ReturnType<typeof createClient>,
+  userId: string,
+  activeDeviceIds: string[],
+  fromIso: string,
+  toIso: string,
+  trunc: "hour" | "day" | "month" | "none",
+  tz: string | null,
+  tzOffsetMinutes: number | null,
+): Promise<GroupedRow[]> {
+  if (activeDeviceIds.length === 0) return [];
+  const { data, error } = await client.database.rpc("account_usage_grouped", {
+    p_user_id: userId,
+    p_device_ids: activeDeviceIds,
+    p_from: fromIso,
+    p_to: toIso,
+    p_trunc: trunc,
+    p_tz: tz,
+    p_offset_min: tzOffsetMinutes,
+  });
+  if (error) throw new Error(error.message);
+  return (Array.isArray(data) ? data : []) as GroupedRow[];
+}
+
+function computeRowCost(row: GroupedRow): number {
   const p = getModelPricing(row.model);
   // Codex / every-code fold reasoning into output_tokens (OpenAI convention),
   // so charging reasoning_output_tokens again at the output rate double-counts.
@@ -374,15 +418,10 @@ interface DayAgg {
   conversation_count: number;
 }
 
-function aggregateByDay(
-  rows: HourlyRow[],
-  tz: string | null,
-  tzOffsetMinutes: number | null,
-): DayAgg[] {
+function aggregateByDay(rows: GroupedRow[]): DayAgg[] {
   const byDay = new Map<string, DayAgg>();
   for (const row of rows) {
-    if (!row.hour_start) continue;
-    const day = zonedDayKey(String(row.hour_start), tz, tzOffsetMinutes);
+    const day = row.bucket;
     let a = byDay.get(day);
     if (!a) {
       a = {
@@ -411,42 +450,6 @@ function aggregateByDay(
     a.conversation_count += Number(row.conversations) || 0;
   }
   return Array.from(byDay.values()).sort((a, b) => a.day.localeCompare(b.day));
-}
-
-async function fetchAllRows(
-  client: ReturnType<typeof createClient>,
-  userId: string,
-  activeDeviceIds: string[],
-  rangeStart: string,
-  rangeEnd: string,
-  columns = "hour_start, source, model, total_tokens, input_tokens, output_tokens, cached_input_tokens, cache_creation_input_tokens, reasoning_output_tokens, conversations",
-): Promise<HourlyRow[]> {
-  if (activeDeviceIds.length === 0) return [];
-  const out: HourlyRow[] = [];
-  const PAGE_SIZE = 1000;
-  // PostgREST `.in()` URL gets too large past ~25 IDs; chunk to be safe.
-  const DEVICE_CHUNK = 25;
-  for (let i = 0; i < activeDeviceIds.length; i += DEVICE_CHUNK) {
-    const chunk = activeDeviceIds.slice(i, i + DEVICE_CHUNK);
-    let offset = 0;
-    while (true) {
-      const { data, error } = await client.database
-        .from("tokentracker_hourly")
-        .select(columns)
-        .eq("user_id", userId)
-        .in("device_id", chunk)
-        .gte("hour_start", rangeStart)
-        .lt("hour_start", rangeEnd)
-        .order("hour_start", { ascending: true })
-        .range(offset, offset + PAGE_SIZE - 1);
-      if (error) throw new Error(error.message);
-      if (!data || data.length === 0) break;
-      out.push(...(data as unknown as HourlyRow[]));
-      if (data.length < PAGE_SIZE) break;
-      offset += PAGE_SIZE;
-    }
-  }
-  return out;
 }
 
 export default async function (req: Request): Promise<Response> {
@@ -511,14 +514,14 @@ export default async function (req: Request): Promise<Response> {
   const rollingStart = rollingStartDate.toISOString();
   const rollingEndNext = rollingEndDate;
 
-  let allRows: HourlyRow[];
+  let allRows: GroupedRow[];
   try {
-    allRows = await fetchAllRows(client, userId, activeDeviceIds, rollingStart, rollingEndNext.toISOString());
+    allRows = await fetchGroupedRows(client, userId, activeDeviceIds, rollingStart, rollingEndNext.toISOString(), "day", tz, tzOffsetMinutes);
   } catch (e) {
     return json({ error: (e as Error).message }, 500);
   }
 
-  const allDaily = aggregateByDay(allRows, tz, tzOffsetMinutes);
+  const allDaily = aggregateByDay(allRows);
   const daily = allDaily.filter((d) => d.day >= from && d.day <= to);
 
   const totals = daily.reduce(

--- a/dashboard/src/components/DashboardSkeleton.jsx
+++ b/dashboard/src/components/DashboardSkeleton.jsx
@@ -1,0 +1,98 @@
+import React from "react";
+import { Card } from "../ui/components";
+import { cn } from "../lib/cn";
+
+/**
+ * Loading placeholder for the main dashboard, shown only on the *initial*
+ * cloud (account-view) load — `accountViewResolving || (accountView &&
+ * usageLoadingState && !hasDetailsActual)`. A subsequent refresh keeps the
+ * already-rendered data (no skeleton, no flash). Mirrors DashboardView's
+ * 12-col grid so the swap to real content doesn't shift layout. Reuses the
+ * `Bone` animate-pulse idiom from LimitsPageSkeleton.
+ */
+function Bone({ className }) {
+  return (
+    <div
+      className={cn(
+        "rounded bg-oai-gray-200/70 dark:bg-oai-gray-800/70 animate-pulse",
+        className,
+      )}
+    />
+  );
+}
+
+function HeatmapBones() {
+  return (
+    <div className="flex gap-1 overflow-hidden">
+      {Array.from({ length: 20 }, (_, w) => (
+        <div key={w} className="flex flex-col gap-1">
+          {Array.from({ length: 7 }, (_, d) => (
+            <Bone key={d} className="h-2.5 w-2.5 rounded-[2px]" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function DashboardSkeleton() {
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
+      {/* Left column — totals, stats, heatmap, trend */}
+      <div className="lg:col-span-4 flex flex-col gap-4 min-w-0 order-2 lg:order-1">
+        <div className="flex flex-col gap-2">
+          <Bone className="h-9 w-40" />
+          <Bone className="h-7 w-28" />
+        </div>
+        <Card>
+          <div className="flex flex-col gap-3">
+            <Bone className="h-3.5 w-24" />
+            {Array.from({ length: 4 }, (_, i) => (
+              <div key={i} className="flex items-center justify-between gap-2">
+                <Bone className="h-3 w-20" />
+                <Bone className="h-3 w-12" />
+              </div>
+            ))}
+          </div>
+        </Card>
+        <Card>
+          <div className="flex flex-col gap-3">
+            <Bone className="h-3.5 w-20" />
+            <HeatmapBones />
+          </div>
+        </Card>
+        <Card>
+          <div className="flex flex-col gap-3">
+            <Bone className="h-3.5 w-28" />
+            <Bone className="h-32 w-full" />
+          </div>
+        </Card>
+      </div>
+
+      {/* Right column — period chips + main breakdown table */}
+      <div className="lg:col-span-8 flex flex-col gap-4 min-w-0 order-1 lg:order-2">
+        <div className="flex items-center gap-2">
+          {Array.from({ length: 5 }, (_, i) => (
+            <Bone key={i} className="h-7 w-16 rounded-full" />
+          ))}
+        </div>
+        <Card>
+          <div className="flex flex-col gap-3">
+            <div className="flex items-center justify-between gap-4">
+              <Bone className="h-4 w-32" />
+              <Bone className="h-4 w-20" />
+            </div>
+            {Array.from({ length: 8 }, (_, i) => (
+              <div key={i} className="flex items-center gap-3">
+                <Bone className="h-[14px] w-[14px] rounded shrink-0" />
+                <Bone className="h-3.5 flex-1 min-w-0" />
+                <Bone className="h-3.5 w-16 shrink-0" />
+                <Bone className="h-3.5 w-12 shrink-0" />
+              </div>
+            ))}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/pages/DashboardPage.jsx
+++ b/dashboard/src/pages/DashboardPage.jsx
@@ -833,6 +833,13 @@ export function DashboardPage({
     trendLoading ||
     modelBreakdownLoading ||
     projectUsageLoading;
+  // Show the dashboard skeleton only on the *initial* cloud (account-view)
+  // load — while auth/cloud is resolving, or while the first account fetch is
+  // in flight and no detail rows exist yet. A later refresh keeps the rendered
+  // data (no skeleton, no flash); local mode loads fast and is left untouched.
+  const initialDashboardLoading =
+    accountViewResolving ||
+    (accountView && usageLoadingState && !hasDetailsActual);
   const usageSourceLabel = useMemo(
     () =>
       copy("shared.data_source", {
@@ -1340,6 +1347,7 @@ export function DashboardPage({
       coreIndexExpandAria={coreIndexExpandAria}
       refreshAll={handleUsageRefresh}
       usageLoadingState={usageLoadingState}
+      initialDashboardLoading={initialDashboardLoading}
       usageError={usageError}
       rangeLabel={rangeLabel}
       timeZoneRangeLabel={timeZoneRangeLabel}

--- a/dashboard/src/ui/dashboard/views/DashboardView.jsx
+++ b/dashboard/src/ui/dashboard/views/DashboardView.jsx
@@ -10,6 +10,7 @@ import { FadeIn } from "../../foundation/FadeIn.jsx";
 import { MacAppBanner } from "../components/MacAppBanner.jsx";
 import { WidgetOnboardingCard } from "../components/WidgetOnboardingCard.jsx";
 import { LoginCard } from "../../../components/LoginCard.jsx";
+import { DashboardSkeleton } from "../../../components/DashboardSkeleton.jsx";
 import { cn } from "../../../lib/cn";
 import { LogoCarousel } from "../../marketing/LogoCarousel.jsx";
 import { AGENT_LOGOS } from "../../marketing/agent-logos.js";
@@ -141,6 +142,7 @@ export function DashboardView(props) {
     allowBreakdownToggle,
     refreshAll,
     usageLoadingState,
+    initialDashboardLoading,
     fleetData,
     hasDetailsActual,
     dailyEmptyPrefix,
@@ -217,7 +219,10 @@ export function DashboardView(props) {
             }
           />
         )}
-        {!showAuthGate && !showExpiredGate && (
+        {!showAuthGate && !showExpiredGate && initialDashboardLoading && (
+          <DashboardSkeleton />
+        )}
+        {!showAuthGate && !showExpiredGate && !initialDashboardLoading && (
           <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
               <div className="lg:col-span-4 flex flex-col gap-4 min-w-0 order-2 lg:order-1">
                 {screenshotMode ? (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tokentracker-cli",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Token usage tracker for AI agent CLIs (Claude Code, Codex, Cursor, Gemini, Kiro, OpenCode, OpenClaw, Every Code, Hermes, GitHub Copilot, Kimi Code, CodeBuddy, Grok Build, oh-my-pi, pi, Craft Agents, Kilo CLI, Kilo Code, Roo Code, Zed Agent, Goose)",
   "main": "src/cli.js",
   "bin": {

--- a/scripts/ops/account-usage-grouped-rpc.sql
+++ b/scripts/ops/account-usage-grouped-rpc.sql
@@ -1,0 +1,79 @@
+-- Server-side aggregation for the cross-device account view.
+--
+-- Motivation: each tokentracker-account-* edge function used to fetch raw
+-- tokentracker_hourly rows in 1000-row PostgREST pages and aggregate them in
+-- the edge. Measured cost is ~300-600ms PER 1000-row page (PostgREST round-trip
+-- + JSON serialization of 1000 rows), NOT the DB scan (which is ~7ms, indexed).
+-- A heavy user's 52-week heatmap spanned ~7 pages (~3.2s) and every other
+-- account-* function re-paginated its own range on top of that.
+--
+-- This function does the GROUP BY in Postgres and returns a SINGLE jsonb row
+-- (jsonb_agg), which sidesteps PostgREST's 1000-row response cap entirely: one
+-- round-trip, no pagination. The heaviest real user's 52-week heatmap dropped
+-- from ~3.2s to ~137ms (827 grouped rows). SUM across the user's active devices
+-- is byte-identical to the old in-edge aggregation; tz-local bucketing uses
+-- `AT TIME ZONE` (same IANA tz database as the old JS Intl.DateTimeFormat path,
+-- including DST — verified against the old functions across Asia/Shanghai,
+-- America/New_York spanning a spring-forward, and a fixed UTC offset).
+--
+-- SECURITY INVOKER (the default): runs with the caller's privileges, so it
+-- never exposes more than a direct SELECT on tokentracker_hourly would. The
+-- edge functions call it with the service-role token AFTER verifying the user's
+-- JWT and resolving p_user_id / p_device_ids server-side.
+--
+-- p_trunc: 'hour' | 'day' | 'month' | 'none' (none = group by source+model only)
+-- p_tz:    IANA zone (e.g. 'Asia/Shanghai') or NULL
+-- p_offset_min: fallback minutes east of UTC when p_tz is NULL (monthly passes
+--               both NULL to bucket by UTC, matching the old hour_start slice).
+--
+-- Idempotent (CREATE OR REPLACE). Rollback: DROP FUNCTION account_usage_grouped.
+
+CREATE OR REPLACE FUNCTION account_usage_grouped(
+  p_user_id uuid,
+  p_device_ids uuid[],
+  p_from timestamptz,
+  p_to timestamptz,
+  p_trunc text,
+  p_tz text,
+  p_offset_min int
+) RETURNS jsonb
+LANGUAGE sql STABLE
+AS $func$
+  WITH loc AS (
+    SELECT
+      CASE
+        WHEN p_tz IS NOT NULL AND p_tz <> '' THEN (h.hour_start AT TIME ZONE p_tz)
+        WHEN p_offset_min IS NOT NULL THEN ((h.hour_start AT TIME ZONE 'UTC') + make_interval(mins => p_offset_min))
+        ELSE (h.hour_start AT TIME ZONE 'UTC')
+      END AS local_ts,
+      h.source, h.model,
+      h.total_tokens, h.input_tokens, h.output_tokens,
+      h.cached_input_tokens, h.cache_creation_input_tokens,
+      h.reasoning_output_tokens, h.conversations
+    FROM tokentracker_hourly h
+    WHERE h.user_id = p_user_id
+      AND h.device_id = ANY(p_device_ids)
+      AND h.hour_start >= p_from
+      AND h.hour_start <  p_to
+  ),
+  grouped AS (
+    SELECT
+      CASE p_trunc
+        WHEN 'hour'  THEN to_char(date_trunc('hour',  local_ts), 'YYYY-MM-DD"T"HH24:00:00')
+        WHEN 'day'   THEN to_char(date_trunc('day',   local_ts), 'YYYY-MM-DD')
+        WHEN 'month' THEN to_char(date_trunc('month', local_ts), 'YYYY-MM')
+        ELSE ''
+      END AS bucket,
+      source, model,
+      SUM(total_tokens)::bigint                AS total_tokens,
+      SUM(input_tokens)::bigint                AS input_tokens,
+      SUM(output_tokens)::bigint               AS output_tokens,
+      SUM(cached_input_tokens)::bigint         AS cached_input_tokens,
+      SUM(cache_creation_input_tokens)::bigint AS cache_creation_input_tokens,
+      SUM(reasoning_output_tokens)::bigint     AS reasoning_output_tokens,
+      SUM(conversations)::bigint               AS conversations
+    FROM loc
+    GROUP BY 1, source, model
+  )
+  SELECT COALESCE(jsonb_agg(to_jsonb(grouped.*)), '[]'::jsonb) FROM grouped
+$func$;


### PR DESCRIPTION
## What

**Server-side aggregation for the cross-device account view** + a **dashboard loading skeleton**, shipped as v0.42.1.

### Perf (the substantive change — already deployed to InsForge)
The six `tokentracker-account-*` edge functions used to fetch raw `tokentracker_hourly` rows in 1000-row PostgREST pages and aggregate in the edge. I added timing probes and measured server-side:

- edge→PostgREST round-trip ≈ **300–600ms per 1000-row page**; the DB scan itself is ~7ms (indexed).
- A heavy user's 52-week heatmap spanned ~7 pages ≈ **3.2s**, and every other account-* function re-paginated its own range on top.

New: a single `account_usage_grouped()` Postgres RPC does the `GROUP BY (tz-local bucket, source, model)` and returns **one JSONB row** (sidesteps the 1000-row cap → one round-trip, no pagination).

- Heaviest user's heatmap: **~3.2s → ~137ms** (827 grouped rows).
- RPC committed to `scripts/ops/account-usage-grouped-rpc.sql`; `SECURITY INVOKER` (no broader exposure than a direct table SELECT).

### Correctness
Verified OLD-vs-new on a synthetic user across **Asia/Shanghai**, **America/New_York spanning the 2025-03-09 spring-forward**, and a **fixed UTC offset**: **19/20 endpoints byte-identical**; the 1 delta is floating-point representation of an equal cost value. SUM across active devices, the per-model breakdown, and the codex/every-code reasoning-cost guard all match (cost is linear within each (source, model) group).

### UX
`DashboardSkeleton` shows only on the **initial cloud (account-view) load** (`accountViewResolving || (accountView && usageLoadingState && !hasDetailsActual)`). Local mode is untouched (local CLI data is instant, gate stays false).

## Verified in a real browser (logged-in account)
Dashboard renders ✓, Leaderboard ✓, profile ✓, account-* calls return correct data and are fast ✓, per-model trend ✓. (One transient `500 socket hang up` = InsForge cold start, auto-retried to 200 — user never saw a failure.)

## Revert path
Revert this PR (restores the old paginated edge-patch source) → redeploy the six functions → `DROP FUNCTION account_usage_grouped`. The edge swap is independent of the npm/DMG/Vercel release.

## Follow-up (separate PR)
Pre-existing (v0.42.0, not introduced here): any authenticated user can read another user's raw `tokentracker_hourly` rows via direct PostgREST — needs RLS / grant tightening, tested against ingest + device management + leaderboard.

## Release
v0.42.1 — bumps `package.json` + `project.yml` (×2) + `TokenTrackerWin.csproj`. Ships the skeleton to desktop apps + Vercel; edge perf is already live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dashboard loading skeleton UI for smoother initial data load experience with visual feedback.

* **Performance**
  * Optimized token usage aggregation by shifting from client-side to server-side processing, improving dashboard responsiveness.

* **Chores**
  * Bumped version to 0.42.1 across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->