### PR TITLE
Support nested local skill directories

### DIFF
--- a/dashboard/src/pages/SkillsPage.jsx
+++ b/dashboard/src/pages/SkillsPage.jsx
@@ -64,6 +64,37 @@ function getSkillKey(skill) {
   return `${skill.repoOwner || "local"}/${skill.repoName || "local"}:${skill.directory}`;
 }
 
+function normalizedDirectory(value) {
+  return String(value || "").replace(/\\/g, "/").trim().toLowerCase();
+}
+
+function directoryLeaf(value) {
+  const directory = normalizedDirectory(value);
+  return directory.split("/").filter(Boolean).pop() || "";
+}
+
+function installedDirectoryFallbackKey(skill) {
+  if (skill.repoOwner || skill.repoName) return "";
+  const directory = normalizedDirectory(skill.directory);
+  if (!directory || directory.includes("/")) return "";
+  return `dir:${directory}`;
+}
+
+function browseDirectoryFallbackKey(skill) {
+  const leaf = directoryLeaf(skill.directory);
+  return leaf ? `dir:${leaf}` : "";
+}
+
+function installedSkillKeys(skill) {
+  const keys = new Set([getSkillKey(skill).toLowerCase()]);
+  if (skill.repoOwner && skill.repoName) {
+    keys.add(`${skill.repoOwner}/${skill.repoName}:${skill.sourceDirectory || skill.directory}`.toLowerCase());
+  }
+  const fallback = installedDirectoryFallbackKey(skill);
+  if (fallback) keys.add(fallback);
+  return keys;
+}
+
 function installBusyKey(skill) {
   return `install:${getSkillKey(skill)}`;
 }
@@ -731,15 +762,7 @@ export function SkillsPage() {
   const installedKeys = useMemo(() => {
     const keys = new Set();
     for (const skill of installedData.skills || []) {
-      keys.add(getSkillKey(skill).toLowerCase());
-      if (skill.repoOwner && skill.repoName) {
-        keys.add(`${skill.repoOwner}/${skill.repoName}:${skill.sourceDirectory || skill.directory}`.toLowerCase());
-      }
-      // Directory-name fallback so unmanaged installs (no repoOwner recorded
-      // — e.g. CLI-installed skills physically placed under ~/.claude/skills/)
-      // still match browse entries from skills.sh or GitHub by skill folder name.
-      const tail = String(skill.directory || "").split(/[\\/]/).pop().toLowerCase();
-      if (tail) keys.add(`dir:${tail}`);
+      for (const key of installedSkillKeys(skill)) keys.add(key);
     }
     return keys;
   }, [installedData.skills]);
@@ -1177,9 +1200,13 @@ export function SkillsPage() {
   // in place (sync targets, usage, remove) without leaving the current tab.
   const handleManage = useCallback(
     (browseSkill) => {
-      const tail = String(browseSkill.directory || "").split(/[\\/]/).pop().toLowerCase();
+      const fullKey = getSkillKey(browseSkill).toLowerCase();
+      const fallbackKey = browseDirectoryFallbackKey(browseSkill);
       const match = (installedData.skills || []).find(
-        (s) => String(s.directory || "").toLowerCase() === tail,
+        (skill) => {
+          const keys = installedSkillKeys(skill);
+          return keys.has(fullKey) || (fallbackKey && keys.has(fallbackKey));
+        },
       );
       if (match) setSelectedSkillId(match.id || match.directory);
     },
@@ -1213,8 +1240,7 @@ export function SkillsPage() {
           (skill.description || "").toLowerCase().includes(q));
     return matched.map((skill) => {
       const fullKey = getSkillKey(skill).toLowerCase();
-      const tail = String(skill.directory || "").split(/[\\/]/).pop().toLowerCase();
-      const dirKey = tail ? `dir:${tail}` : "";
+      const dirKey = browseDirectoryFallbackKey(skill);
       return {
         ...skill,
         installed: installedKeys.has(fullKey) || (dirKey && installedKeys.has(dirKey)),

--- a/dashboard/src/pages/SkillsPage.test.jsx
+++ b/dashboard/src/pages/SkillsPage.test.jsx
@@ -107,7 +107,7 @@ describe("SkillsPage", () => {
     expect(searchSkills).not.toHaveBeenCalled();
   });
 
-  it("clears My tab search when clear filters is clicked", async () => {
+  it("clears My tab search when clear search is clicked", async () => {
     const user = userEvent.setup();
     render(<SkillsPage />);
 
@@ -122,11 +122,56 @@ describe("SkillsPage", () => {
       expect(screen.queryByText("Beta Skill")).not.toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: copy("skills.filter.clear") }));
+    await user.click(screen.getByRole("button", { name: copy("skills.action.search_clear") }));
 
     await waitFor(() => {
       expect(screen.getByText("Beta Skill")).toBeInTheDocument();
       expect(searchInput).toHaveValue("");
     });
+  });
+
+  it("does not mark an unrelated browse skill installed when only the nested local leaf matches", async () => {
+    const user = userEvent.setup();
+    vi.mocked(getInstalledSkills).mockResolvedValue({
+      targets: [
+        { id: "claude", label: "Claude" },
+        { id: "codex", label: "Codex" },
+      ],
+      skills: [
+        {
+          id: "local:apple/apple-notes",
+          name: "Local Apple Notes",
+          directory: "apple/apple-notes",
+          description: "Nested local skill.",
+          targets: ["claude"],
+          managed: true,
+        },
+      ],
+    });
+    vi.mocked(getSkillRepos).mockResolvedValue({
+      repos: [{ owner: "someone", name: "unrelated-skills", branch: "main", enabled: true }],
+    });
+    vi.mocked(discoverSkills).mockResolvedValue({
+      skills: [
+        {
+          key: "someone/unrelated-skills:apple-notes",
+          name: "Remote Apple Notes",
+          directory: "apple-notes",
+          description: "Different remote skill with the same leaf name.",
+          repoOwner: "someone",
+          repoName: "unrelated-skills",
+          repoBranch: "main",
+        },
+      ],
+    });
+
+    render(<SkillsPage />);
+
+    expect(await screen.findByText("Local Apple Notes")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: copy("skills.tab.browse") }));
+
+    expect(await screen.findByText("Remote Apple Notes")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: copy("skills.action.install") })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: copy("skills.card.manage") })).not.toBeInTheDocument();
   });
 });

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1818,8 +1818,8 @@ function createLocalApiHandler({ queuePath }) {
               if (!norm) return null;
               if (installedByDirectory.has(norm)) return installedByDirectory.get(norm);
               if (installedByLeaf.has(norm)) return installedByLeaf.get(norm);
-              if (leafCounts.get(norm) > 1) return null;
               if (nameCounts.get(norm) === 1) return installedByName.get(norm);
+              if (leafCounts.get(norm) > 1) return null;
               return null;
             };
             const usedSkillIds = new Set();

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1791,19 +1791,45 @@ function createLocalApiHandler({ queuePath }) {
             // Claude Code built-in tools (bash/agent/…), which dominate the logs
             // and are NOT uninstallable. Cost is priced per-model (source=claude).
             const installed = skills.listInstalledSkills();
+            const skillDirectoryLeaf = (value) =>
+              String(value || "").replace(/\\/g, "/").split("/").filter(Boolean).pop()?.trim().toLowerCase() || "";
+            const leafCounts = new Map();
+            for (const s of installed) {
+              const leaf = skillDirectoryLeaf(s.directory);
+              if (leaf) leafCounts.set(leaf, (leafCounts.get(leaf) || 0) + 1);
+            }
+            const installedByDirectory = new Map();
+            const installedByLeaf = new Map();
+            const nameCounts = new Map();
             const installedByName = new Map();
             for (const s of installed) {
-              for (const key of [s.directory, s.name]) {
-                const norm = String(key || "").trim().toLowerCase();
-                if (norm) installedByName.set(norm, s);
+              const dir = String(s.directory || "").trim().toLowerCase();
+              if (dir) installedByDirectory.set(dir, s);
+              const leaf = skillDirectoryLeaf(s.directory);
+              if (leaf && leafCounts.get(leaf) === 1) installedByLeaf.set(leaf, s);
+              const name = String(s.name || "").trim().toLowerCase();
+              if (name) {
+                nameCounts.set(name, (nameCounts.get(name) || 0) + 1);
+                if (!installedByName.has(name)) installedByName.set(name, s);
               }
             }
+            const findInstalledSkill = (value) => {
+              const norm = String(value || "").trim().toLowerCase();
+              if (!norm) return null;
+              if (installedByDirectory.has(norm)) return installedByDirectory.get(norm);
+              if (installedByLeaf.has(norm)) return installedByLeaf.get(norm);
+              if (leafCounts.get(norm) > 1) return null;
+              if (nameCounts.get(norm) === 1) return installedByName.get(norm);
+              return null;
+            };
+            const usedSkillIds = new Set();
             const priced = usage.skills.map((entry) => {
               let cost = 0;
               for (const [model, tokens] of Object.entries(entry.models || {})) {
                 cost += computeRowCost({ ...tokens, model, source: "claude" });
               }
-              const match = installedByName.get(String(entry.skill || "").trim().toLowerCase());
+              const match = findInstalledSkill(entry.skill);
+              if (match?.id) usedSkillIds.add(match.id);
               return {
                 skill: entry.skill,
                 invocations: entry.invocations,
@@ -1816,13 +1842,8 @@ function createLocalApiHandler({ queuePath }) {
               };
             });
             // Installed skills with zero invocations = dead-weight candidates.
-            const usedNames = new Set(usage.skills.map((s) => String(s.skill || "").trim().toLowerCase()));
             const unusedInstalled = installed
-              .filter((s) => {
-                const dir = String(s.directory || "").trim().toLowerCase();
-                const name = String(s.name || "").trim().toLowerCase();
-                return !usedNames.has(dir) && !usedNames.has(name);
-              })
+              .filter((s) => !usedSkillIds.has(s.id))
               .map((s) => ({ skillId: s.id, directory: s.directory, name: s.name }));
             json(res, {
               generatedAt: usage.generatedAt,

--- a/src/lib/skills-manager.js
+++ b/src/lib/skills-manager.js
@@ -570,6 +570,28 @@ function isSymlink(targetPath) {
   }
 }
 
+function targetSkillPath(baseDir, directory) {
+  const safe = sanitizeRelativePath(directory);
+  if (!safe) return null;
+  const root = path.resolve(baseDir);
+  const targetPath = path.resolve(root, safe);
+  if (!pathStrictlyWithin(root, targetPath)) return null;
+  const parts = safe.split("/");
+  let current = root;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    current = path.join(current, parts[i]);
+    let stat;
+    try {
+      stat = fs.lstatSync(current);
+    } catch (e) {
+      if (e?.code === "ENOENT") continue;
+      return null;
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) return null;
+  }
+  return targetPath;
+}
+
 function copyDir(source, dest) {
   assertNotNested(source, dest);
   removePath(dest);
@@ -595,7 +617,8 @@ function syncSkillToTarget(directory, targetId) {
   const source = path.join(ssotDir(), directory);
   if (!fs.existsSync(source)) throw new Error(`Managed skill not found: ${directory}`);
   for (const baseDir of targetDirs(target)) {
-    const dest = path.join(baseDir, directory);
+    const dest = targetSkillPath(baseDir, directory);
+    if (!dest) throw new Error(`Invalid skill directory: ${directory}`);
     assertNotNested(source, dest);
     ensureDir(path.dirname(dest));
     removePath(dest);
@@ -611,7 +634,8 @@ function removeSkillFromTarget(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) return;
   for (const baseDir of targetDirs(target)) {
-    const targetPath = path.join(baseDir, directory);
+    const targetPath = targetSkillPath(baseDir, directory);
+    if (!targetPath) continue;
     removePath(targetPath);
     removeEmptyAncestors(path.dirname(targetPath), baseDir);
   }
@@ -621,7 +645,8 @@ function scanTargetSkill(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) return false;
   for (const baseDir of targetDirs(target)) {
-    const candidate = path.join(baseDir, directory);
+    const candidate = targetSkillPath(baseDir, directory);
+    if (!candidate) continue;
     if (fs.existsSync(candidate) || isSymlink(candidate)) return true;
   }
   return false;
@@ -636,7 +661,8 @@ function classifyTargetSkill(directory, targetId) {
   if (!target) return "off";
   let state = "off";
   for (const baseDir of targetDirs(target)) {
-    const candidate = path.join(baseDir, directory);
+    const candidate = targetSkillPath(baseDir, directory);
+    if (!candidate) continue;
     if (fs.existsSync(candidate)) return "synced";
     if (isSymlink(candidate)) state = "orphan";
   }
@@ -895,7 +921,8 @@ function findLocalSkillSource(directory) {
   if (!sourceDir) return null;
   for (const target of Object.values(TARGETS)) {
     for (const baseDir of targetDirs(target)) {
-      const skillPath = path.join(baseDir, sourceDir);
+      const skillPath = targetSkillPath(baseDir, sourceDir);
+      if (!skillPath) continue;
       if (findSkillMarker(skillPath)) {
         return { path: skillPath, targetId: target.id };
       }

--- a/src/lib/skills-manager.js
+++ b/src/lib/skills-manager.js
@@ -174,11 +174,20 @@ function sanitizePathSegment(value) {
 }
 
 function sanitizeRelativePath(value) {
-  const raw = String(value || "").replace(/\\/g, "/").trim();
-  if (!raw || raw.startsWith("/") || raw.includes("\0")) return null;
+  const input = String(value || "").trim();
+  const raw = input.replace(/\\/g, "/");
+  if (!raw || raw.includes("\0")) return null;
+  if (path.posix.isAbsolute(raw) || path.win32.isAbsolute(input) || path.win32.isAbsolute(raw)) return null;
   const parts = raw.split("/").filter(Boolean);
-  if (!parts.length || parts.some((part) => part === "." || part === "..")) return null;
+  if (!parts.length || parts.some((part) => part === "." || part === ".." || part.includes(":"))) return null;
   return parts.join("/");
+}
+
+function sanitizeLocalSkillPath(value) {
+  const safe = sanitizeRelativePath(value);
+  if (!safe) return null;
+  if (safe.split("/").some((part) => part.startsWith("."))) return null;
+  return safe;
 }
 
 function installNameFromDirectory(directory) {
@@ -254,6 +263,36 @@ function findSkillMarker(dir) {
     }
   }
   return null;
+}
+
+const MAX_LOCAL_SKILL_SCAN_DEPTH = 3;
+
+function scanSkillDirectories(rootDir) {
+  const found = [];
+  const walk = (dir, relDir = "", depth = 0) => {
+    let entries = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch (_e) {
+      return;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      if (!entry.name || entry.name.startsWith(".")) continue;
+      const rel = relDir ? `${relDir}/${entry.name}` : entry.name;
+      const full = path.join(dir, entry.name);
+      if (findSkillMarker(full)) {
+        found.push(rel);
+        continue;
+      }
+      // Direct symlinked skills are accepted above, but symlinked group folders
+      // are not traversed so the scan stays within the target skills tree.
+      if (entry.isDirectory() && depth + 1 < MAX_LOCAL_SKILL_SCAN_DEPTH) walk(full, rel, depth + 1);
+    }
+  };
+  walk(rootDir);
+  return found;
 }
 
 const HASH_IGNORE = new Set([".git", ".DS_Store", "Thumbs.db", ".gitignore"]);
@@ -537,6 +576,19 @@ function copyDir(source, dest) {
   fs.cpSync(source, dest, { recursive: true, force: true });
 }
 
+function removeEmptyAncestors(startDir, stopDir) {
+  let current = path.resolve(startDir);
+  const stop = path.resolve(stopDir);
+  while (pathStrictlyWithin(stop, current)) {
+    try {
+      fs.rmdirSync(current);
+    } catch (_e) {
+      return;
+    }
+    current = path.dirname(current);
+  }
+}
+
 function syncSkillToTarget(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) throw new Error(`Unsupported target: ${targetId}`);
@@ -559,7 +611,9 @@ function removeSkillFromTarget(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) return;
   for (const baseDir of targetDirs(target)) {
-    removePath(path.join(baseDir, directory));
+    const targetPath = path.join(baseDir, directory);
+    removePath(targetPath);
+    removeEmptyAncestors(path.dirname(targetPath), baseDir);
   }
 }
 
@@ -612,19 +666,11 @@ function listInstalledSkills() {
   const unmanaged = new Map();
   for (const target of Object.values(TARGETS)) {
     for (const dir of targetDirs(target)) {
-      let entries = [];
-      try {
-        entries = fs.readdirSync(dir, { withFileTypes: true });
-      } catch (_e) {
-        continue;
-      }
-      for (const entry of entries) {
-        if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
-        const directory = entry.name;
-        if (!directory || directory.startsWith(".") || managedDirs.has(directory.toLowerCase())) continue;
+      for (const directory of scanSkillDirectories(dir)) {
+        if (!directory || managedDirs.has(directory.toLowerCase())) continue;
         const skillPath = findSkillMarker(path.join(dir, directory));
         if (!skillPath) continue;
-        const metadata = readSkillMetadata(fs.readFileSync(skillPath, "utf8"), directory);
+        const metadata = readSkillMetadata(fs.readFileSync(skillPath, "utf8"), installNameFromDirectory(directory) || directory);
         const key = directory.toLowerCase();
         if (!unmanaged.has(key)) {
           unmanaged.set(key, {
@@ -670,6 +716,8 @@ async function installSkill(skillInput, targetIds = ["claude", "codex"]) {
   };
   if (!skill.repoOwner || !skill.repoName) throw new Error("Missing GitHub repository information");
   const sourceDir = sanitizeRelativePath(skill.directory);
+  // GitHub-sourced skills keep the historical flat install name even when
+  // sourceDirectory is nested; local nested-skill support uses importLocalSkill().
   const installName = installNameFromDirectory(sourceDir);
   if (!sourceDir || !installName) throw new Error("Invalid skill directory");
 
@@ -758,9 +806,11 @@ function uninstallSkill(id) {
   if (fs.existsSync(ssotPath)) {
     ensureDir(trashDir());
     const stamp = Date.now();
-    const trashPath = path.join(trashDir(), `${skill.directory}-${stamp}`);
+    const trashName = `${Buffer.from(String(skill.directory || ""), "utf8").toString("base64url")}-${stamp}`;
+    const trashPath = path.join(trashDir(), trashName);
     try {
       fs.renameSync(ssotPath, trashPath);
+      removeEmptyAncestors(path.dirname(ssotPath), ssotDir());
       skill.trashedAt = stamp;
       skill.trashedDirectory = path.basename(trashPath);
       skill.previousTargets = skill.targets || [];
@@ -773,6 +823,7 @@ function uninstallSkill(id) {
       return { ok: true, trashed: true, restoreId: skill.id, ttlMs: TRASH_TTL_MS };
     } catch (_e) {
       removePath(ssotPath);
+      removeEmptyAncestors(path.dirname(ssotPath), ssotDir());
     }
   }
   registry.skills = registry.skills.filter((entry) => entry.id !== skill.id);
@@ -840,11 +891,11 @@ function setSkillTargets(id, targetIds) {
 }
 
 function findLocalSkillSource(directory) {
-  const installName = sanitizePathSegment(directory);
-  if (!installName) return null;
+  const sourceDir = sanitizeLocalSkillPath(directory);
+  if (!sourceDir) return null;
   for (const target of Object.values(TARGETS)) {
     for (const baseDir of targetDirs(target)) {
-      const skillPath = path.join(baseDir, installName);
+      const skillPath = path.join(baseDir, sourceDir);
       if (findSkillMarker(skillPath)) {
         return { path: skillPath, targetId: target.id };
       }
@@ -854,10 +905,10 @@ function findLocalSkillSource(directory) {
 }
 
 function importLocalSkill(directory, targetIds = []) {
-  const installName = sanitizePathSegment(directory);
-  if (!installName) throw new Error("Invalid skill directory");
+  const sourceDir = sanitizeLocalSkillPath(directory);
+  if (!sourceDir) throw new Error("Invalid skill directory");
   const registry = readRegistry();
-  const existing = registry.skills.find((entry) => entry.directory.toLowerCase() === installName.toLowerCase());
+  const existing = registry.skills.find((entry) => entry.directory.toLowerCase() === sourceDir.toLowerCase());
   if (existing) {
     if (!targetIds || !targetIds.length) {
       return { ...existing, managed: true, targets: existing.targets || [] };
@@ -865,22 +916,22 @@ function importLocalSkill(directory, targetIds = []) {
     return setSkillTargets(existing.id, targetIds);
   }
 
-  const source = findLocalSkillSource(installName);
+  const source = findLocalSkillSource(sourceDir);
   if (!source) throw new Error("Local skill not found");
 
-  const dest = path.join(ssotDir(), installName);
+  const dest = path.join(ssotDir(), sourceDir);
   copyDir(source.path, dest);
   const skillMarker = findSkillMarker(dest);
-  const metadata = readSkillMetadata(skillMarker ? fs.readFileSync(skillMarker, "utf8") : "", installName);
-  const discoveredTargets = Object.keys(TARGETS).filter((targetId) => scanTargetSkill(installName, targetId));
+  const metadata = readSkillMetadata(skillMarker ? fs.readFileSync(skillMarker, "utf8") : "", installNameFromDirectory(sourceDir));
+  const discoveredTargets = Object.keys(TARGETS).filter((targetId) => scanTargetSkill(sourceDir, targetId));
   const selectedTargets = (targetIds.length ? targetIds : discoveredTargets).filter((targetId) => TARGETS[targetId]);
   const skill = {
-    id: `local:${installName}`,
-    key: `local:${installName}`,
+    id: `local:${sourceDir}`,
+    key: `local:${sourceDir}`,
     name: metadata.name,
     description: metadata.description,
-    directory: installName,
-    sourceDirectory: installName,
+    directory: sourceDir,
+    sourceDirectory: sourceDir,
     readmeUrl: null,
     repoOwner: null,
     repoName: null,
@@ -893,15 +944,15 @@ function importLocalSkill(directory, targetIds = []) {
   registry.skills.push(skill);
   saveRegistry(registry);
   for (const targetId of Object.keys(TARGETS)) {
-    if (selectedTargets.includes(targetId)) syncSkillToTarget(installName, targetId);
-    else removeSkillFromTarget(installName, targetId);
+    if (selectedTargets.includes(targetId)) syncSkillToTarget(sourceDir, targetId);
+    else removeSkillFromTarget(sourceDir, targetId);
   }
-  appendActivity({ action: "import", name: skill.name, directory: installName, targets: selectedTargets });
+  appendActivity({ action: "import", name: skill.name, directory: sourceDir, targets: selectedTargets });
   return { ...skill, managed: true, targets: selectedTargets };
 }
 
 function deleteLocalSkill(directory, targetIds = []) {
-  const installName = sanitizePathSegment(directory);
+  const installName = sanitizeLocalSkillPath(directory);
   if (!installName) throw new Error("Invalid skill directory");
   const selectedTargets = targetIds.length ? targetIds : Object.keys(TARGETS);
   for (const targetId of selectedTargets) removeSkillFromTarget(installName, targetId);

--- a/src/lib/skills-manager.js
+++ b/src/lib/skills-manager.js
@@ -576,6 +576,12 @@ function targetSkillPath(baseDir, directory) {
   const root = path.resolve(baseDir);
   const targetPath = path.resolve(root, safe);
   if (!pathStrictlyWithin(root, targetPath)) return null;
+  try {
+    const rootStat = fs.lstatSync(root);
+    if (rootStat.isSymbolicLink() || !rootStat.isDirectory()) return null;
+  } catch (e) {
+    if (e?.code !== "ENOENT") return null;
+  }
   const parts = safe.split("/");
   let current = root;
   for (let i = 0; i < parts.length - 1; i += 1) {
@@ -590,6 +596,12 @@ function targetSkillPath(baseDir, directory) {
     if (stat.isSymbolicLink() || !stat.isDirectory()) return null;
   }
   return targetPath;
+}
+
+function managedSkillPath(directory) {
+  const skillPath = targetSkillPath(ssotDir(), directory);
+  if (!skillPath) throw new Error(`Invalid skill directory: ${directory}`);
+  return skillPath;
 }
 
 function copyDir(source, dest) {
@@ -614,7 +626,7 @@ function removeEmptyAncestors(startDir, stopDir) {
 function syncSkillToTarget(directory, targetId) {
   const target = TARGETS[targetId];
   if (!target) throw new Error(`Unsupported target: ${targetId}`);
-  const source = path.join(ssotDir(), directory);
+  const source = managedSkillPath(directory);
   if (!fs.existsSync(source)) throw new Error(`Managed skill not found: ${directory}`);
   for (const baseDir of targetDirs(target)) {
     const dest = targetSkillPath(baseDir, directory);
@@ -769,7 +781,7 @@ async function installSkill(skillInput, targetIds = ["claude", "codex"]) {
   );
   if (!files.some((entry) => /(^|\/)SKILL\.md$/i.test(entry.path))) throw new Error("SKILL.md not found in selected directory");
 
-  const dest = path.join(ssotDir(), installName);
+  const dest = managedSkillPath(installName);
   const temp = path.join(dataDir(), "tmp", `${installName}-${Date.now()}`);
   removePath(temp);
   ensureDir(temp);
@@ -825,10 +837,10 @@ function uninstallSkill(id) {
   const registry = readRegistry();
   const skill = registry.skills.find((entry) => entry.id === id || entry.key === id);
   if (!skill) throw new Error("Managed skill not found");
+  const ssotPath = managedSkillPath(skill.directory);
   for (const targetId of Object.keys(TARGETS)) removeSkillFromTarget(skill.directory, targetId);
   // Move SSOT copy into a trash bucket so it can be restored briefly. The
   // registry entry is retained but flagged so restoreSkill can re-link it.
-  const ssotPath = path.join(ssotDir(), skill.directory);
   if (fs.existsSync(ssotPath)) {
     ensureDir(trashDir());
     const stamp = Date.now();
@@ -885,7 +897,7 @@ function restoreSkill(id) {
     throw new Error("Restore window expired");
   }
   const trashPath = path.join(trashDir(), skill.trashedDirectory || "");
-  const ssotPath = path.join(ssotDir(), skill.directory);
+  const ssotPath = managedSkillPath(skill.directory);
   if (!fs.existsSync(trashPath)) throw new Error("Trashed copy is missing");
   ensureDir(path.dirname(ssotPath));
   removePath(ssotPath);
@@ -935,8 +947,11 @@ function importLocalSkill(directory, targetIds = []) {
   const sourceDir = sanitizeLocalSkillPath(directory);
   if (!sourceDir) throw new Error("Invalid skill directory");
   const registry = readRegistry();
-  const existing = registry.skills.find((entry) => entry.directory.toLowerCase() === sourceDir.toLowerCase());
+  const existing = registry.skills.find((entry) => String(entry.directory || "").toLowerCase() === sourceDir.toLowerCase());
   if (existing) {
+    if (!String(existing.id || existing.key || "").startsWith("local:")) {
+      throw new Error(`Skill directory "${sourceDir}" is already managed by another installed skill`);
+    }
     if (!targetIds || !targetIds.length) {
       return { ...existing, managed: true, targets: existing.targets || [] };
     }
@@ -946,7 +961,7 @@ function importLocalSkill(directory, targetIds = []) {
   const source = findLocalSkillSource(sourceDir);
   if (!source) throw new Error("Local skill not found");
 
-  const dest = path.join(ssotDir(), sourceDir);
+  const dest = managedSkillPath(sourceDir);
   copyDir(source.path, dest);
   const skillMarker = findSkillMarker(dest);
   const metadata = readSkillMetadata(skillMarker ? fs.readFileSync(skillMarker, "utf8") : "", installNameFromDirectory(sourceDir));

--- a/test/local-api-skills.test.js
+++ b/test/local-api-skills.test.js
@@ -18,6 +18,41 @@ const queuePath = path.join(sandboxHome, "queue.jsonl");
 fs.writeFileSync(queuePath, "");
 const handler = createLocalApiHandler({ queuePath });
 
+function writeLocalSkill(targetDir, directory, body = "---\nname: Local Skill\ndescription: Test skill\n---\n") {
+  const dir = path.join(sandboxHome, targetDir, directory);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "SKILL.md"), body);
+  return dir;
+}
+
+function writeSkillUsageTranscript(skillName) {
+  const projDir = path.join(sandboxHome, ".claude", "projects", "proj");
+  fs.mkdirSync(projDir, { recursive: true });
+  const line = JSON.stringify({
+    type: "assistant",
+    timestamp: "2026-05-01T00:00:00.000Z",
+    message: {
+      id: `msg-${skillName}`,
+      model: "claude-opus-4-6",
+      usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      content: [
+        {
+          type: "tool_use",
+          id: `block-${skillName}`,
+          name: "Skill",
+          input: { skill: skillName },
+        },
+      ],
+    },
+  });
+  fs.writeFileSync(path.join(projDir, `${skillName}.jsonl`), `${line}\n`);
+}
+
 function makeReq({ method = "GET", pathname = "/functions/tokentracker-skills", search = "", headers = {}, body }) {
   const url = new URL(`http://localhost${pathname}${search}`);
   let listeners = {};
@@ -168,6 +203,39 @@ describe("/functions/tokentracker-skills auth + input", () => {
     assert.ok(Array.isArray(body.skills));
     assert.ok(Array.isArray(body.unusedInstalled));
     assert.ok(Number.isFinite(body.totalInvocations));
+  });
+
+  it("GET mode=skill_usage joins nested installed skills by leaf name", async () => {
+    writeLocalSkill(".hermes/skills", "apple/apple-notes", "---\nname: Apple Notes\ndescription: Nested\n---\n");
+    writeSkillUsageTranscript("apple-notes");
+
+    const { status, body } = await call({ method: "GET", search: "?mode=skill_usage&force=1" });
+
+    assert.equal(status, 200);
+    const usage = body.skills.find((entry) => entry.skill === "apple-notes");
+    assert.ok(usage);
+    assert.equal(usage.installed, true);
+    assert.equal(usage.directory, "apple/apple-notes");
+    assert.equal(body.unusedInstalled.some((entry) => entry.directory === "apple/apple-notes"), false);
+  });
+
+  it("GET mode=skill_usage does not join ambiguous nested leaf names", async () => {
+    writeLocalSkill(".hermes/skills", "alpha/shared-note", "---\ndescription: first\n---\n");
+    writeLocalSkill(".codex/skills", "beta/shared-note", "---\ndescription: second\n---\n");
+    writeSkillUsageTranscript("shared-note");
+
+    const { status, body } = await call({ method: "GET", search: "?mode=skill_usage&force=1" });
+
+    assert.equal(status, 200);
+    const usage = body.skills.find((entry) => entry.skill === "shared-note");
+    assert.ok(usage);
+    assert.equal(usage.installed, false);
+    assert.equal(usage.directory, null);
+    const unused = body.unusedInstalled
+      .filter((entry) => entry.directory.endsWith("/shared-note"))
+      .map((entry) => entry.directory)
+      .sort();
+    assert.deepEqual(unused, ["alpha/shared-note", "beta/shared-note"]);
   });
 
   it("GET mode=popular returns install-sorted skills (stubbed fetch)", async () => {

--- a/test/local-api-skills.test.js
+++ b/test/local-api-skills.test.js
@@ -238,6 +238,22 @@ describe("/functions/tokentracker-skills auth + input", () => {
     assert.deepEqual(unused, ["alpha/shared-note", "beta/shared-note"]);
   });
 
+  it("GET mode=skill_usage still joins a unique skill name when leaf names are ambiguous", async () => {
+    writeLocalSkill(".hermes/skills", "alpha/name-leaf-collision", "---\nname: name-leaf-collision\n---\n");
+    writeLocalSkill(".codex/skills", "beta/name-leaf-collision", "---\nname: Different Name\n---\n");
+    writeSkillUsageTranscript("name-leaf-collision");
+
+    const { status, body } = await call({ method: "GET", search: "?mode=skill_usage&force=1" });
+
+    assert.equal(status, 200);
+    const usage = body.skills.find((entry) => entry.skill === "name-leaf-collision");
+    assert.ok(usage);
+    assert.equal(usage.installed, true);
+    assert.equal(usage.directory, "alpha/name-leaf-collision");
+    assert.equal(body.unusedInstalled.some((entry) => entry.directory === "alpha/name-leaf-collision"), false);
+    assert.equal(body.unusedInstalled.some((entry) => entry.directory === "beta/name-leaf-collision"), true);
+  });
+
   it("GET mode=popular returns install-sorted skills (stubbed fetch)", async () => {
     const realFetch = global.fetch;
     global.fetch = async () => ({

--- a/test/skills-manager.test.js
+++ b/test/skills-manager.test.js
@@ -71,12 +71,120 @@ describe("skills-manager addRepo validation", () => {
 describe("skills-manager importLocalSkill sanitization", () => {
   it("rejects invalid directory names", () => {
     assert.throws(() => skills.importLocalSkill("..", []), /Invalid skill directory/);
-    assert.throws(() => skills.importLocalSkill("foo/bar", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("../foo", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("foo/../bar", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("/tmp/foo", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("C:/foo", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("C:\\foo", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("\\\\server\\share\\foo", []), /Invalid skill directory/);
+    assert.throws(() => skills.importLocalSkill("foo:bar", []), /Invalid skill directory/);
     assert.throws(() => skills.importLocalSkill("", []), /Invalid skill directory/);
+    assert.throws(() => skills.deleteLocalSkill("C:/foo", ["hermes"]), /Invalid skill directory/);
+    assert.throws(() => skills.deleteLocalSkill("\\\\server\\share\\foo", ["hermes"]), /Invalid skill directory/);
   });
 
   it("throws when skill is not present in any target folder", () => {
     assert.throws(() => skills.importLocalSkill("not-there", ["claude"]), /Local skill not found/);
+  });
+});
+
+describe("skills-manager nested local skill folders", () => {
+  const nestedSkill = "apple/apple-notes";
+  const archivedSkill = ".archive/old-skill";
+
+  before(() => {
+    writeLocalSkill(".hermes/skills", nestedSkill, "---\nname: Apple Notes\ndescription: Nested Hermes skill\n---\n");
+    writeLocalSkill(".hermes/skills", archivedSkill, "---\nname: Archived Skill\ndescription: Should stay hidden\n---\n");
+  });
+
+  it("lists nested skills below target skill folders while skipping hidden groups", () => {
+    const installed = skills.listInstalledSkills();
+    const nested = installed.find((s) => s.directory === nestedSkill);
+    assert.ok(nested, "nested Hermes skill should be discovered");
+    assert.equal(nested.name, "Apple Notes");
+    assert.deepEqual(nested.targets, ["hermes"]);
+    assert.equal(nested.targetStates.hermes, "synced");
+    assert.equal(installed.some((s) => s.directory === archivedSkill), false);
+  });
+
+  it("rejects direct local imports and deletes from hidden skill groups", () => {
+    assert.throws(() => skills.importLocalSkill(archivedSkill, ["hermes"]), /Invalid skill directory/);
+    assert.throws(() => skills.deleteLocalSkill(archivedSkill, ["hermes"]), /Invalid skill directory/);
+  });
+
+  it("can promote a nested unmanaged skill without flattening its target path", () => {
+    const imported = skills.importLocalSkill(nestedSkill, ["hermes", "codex"]);
+    assert.equal(imported.managed, true);
+    assert.equal(imported.directory, nestedSkill);
+    assert.deepEqual(new Set(imported.targets), new Set(["hermes", "codex"]));
+    assert.ok(fs.existsSync(path.join(sandboxHome, ".hermes/skills", nestedSkill, "SKILL.md")));
+    assert.ok(fs.existsSync(path.join(sandboxHome, ".codex/skills", nestedSkill, "SKILL.md")));
+
+    skills.uninstallSkill(imported.id);
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".hermes/skills", nestedSkill)));
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".codex/skills", nestedSkill)));
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".hermes/skills/apple")));
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".codex/skills/apple")));
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".tokentracker/skills/managed/apple")));
+  });
+
+  it("keeps non-empty parent folders when removing one nested managed skill", () => {
+    writeLocalSkill(".hermes/skills", "shared-parent/remove-one", "---\nname: Remove One\n---\n");
+    writeLocalSkill(".hermes/skills", "shared-parent/keep-one", "---\nname: Keep One\n---\n");
+    const removed = skills.importLocalSkill("shared-parent/remove-one", ["hermes"]);
+    const kept = skills.importLocalSkill("shared-parent/keep-one", ["hermes"]);
+
+    skills.uninstallSkill(removed.id);
+
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".tokentracker/skills/managed/shared-parent/remove-one")));
+    assert.ok(fs.existsSync(path.join(sandboxHome, ".tokentracker/skills/managed/shared-parent/keep-one/SKILL.md")));
+    assert.ok(fs.existsSync(path.join(sandboxHome, ".hermes/skills/shared-parent/keep-one/SKILL.md")));
+    assert.ok(fs.existsSync(path.join(sandboxHome, ".tokentracker/skills/managed/shared-parent")));
+    assert.ok(fs.existsSync(path.join(sandboxHome, ".hermes/skills/shared-parent")));
+
+    skills.uninstallSkill(kept.id);
+  });
+
+  it("uses the leaf folder name as fallback display name for nested unmanaged skills", () => {
+    writeLocalSkill(".hermes/skills", "fallback/no-name", "---\ndescription: Missing explicit name\n---\n");
+    const entry = skills.listInstalledSkills().find((s) => s.directory === "fallback/no-name");
+    assert.ok(entry);
+    assert.equal(entry.name, "no-name");
+  });
+
+  it("does not scan arbitrarily deep local skill directory trees", () => {
+    writeLocalSkill(".hermes/skills", "too/deep/for/scan/nested", "---\nname: Too Deep\n---\n");
+    const installed = skills.listInstalledSkills();
+    assert.equal(installed.some((s) => s.directory === "too/deep/for/scan/nested"), false);
+  });
+
+  it("keeps undo restore available for nested skills whose flattened names collide", () => {
+    writeLocalSkill(".hermes/skills", "collision/a-b", "---\nname: Collision Nested\ndescription: Nested\n---\n");
+    writeLocalSkill(".hermes/skills", "collision__a-b", "---\nname: Collision Flat\ndescription: Flat\n---\n");
+    const nested = skills.importLocalSkill("collision/a-b", ["hermes"]);
+    const flat = skills.importLocalSkill("collision__a-b", ["hermes"]);
+    const originalNow = Date.now;
+    Date.now = () => 1234567890;
+    try {
+      const nestedRemoved = skills.uninstallSkill(nested.id);
+      const flatRemoved = skills.uninstallSkill(flat.id);
+      assert.equal(nestedRemoved.trashed, true);
+      assert.equal(flatRemoved.trashed, true);
+      assert.notEqual(nestedRemoved.restoreId, flatRemoved.restoreId);
+      skills.restoreSkill(nested.id);
+      skills.restoreSkill(flat.id);
+      assert.ok(fs.existsSync(path.join(sandboxHome, ".hermes/skills/collision/a-b/SKILL.md")));
+      assert.ok(fs.existsSync(path.join(sandboxHome, ".hermes/skills/collision__a-b/SKILL.md")));
+    } finally {
+      Date.now = originalNow;
+      for (const id of [nested.id, flat.id]) {
+        try {
+          skills.uninstallSkill(id);
+        } catch (_e) {
+          // already cleaned up
+        }
+      }
+    }
   });
 });
 

--- a/test/skills-manager.test.js
+++ b/test/skills-manager.test.js
@@ -158,6 +158,41 @@ describe("skills-manager nested local skill folders", () => {
     assert.equal(installed.some((s) => s.directory === "too/deep/for/scan/nested"), false);
   });
 
+  it("does not delete through symlinked parent directories", (t) => {
+    const root = path.join(sandboxHome, ".hermes/skills");
+    const outside = path.join(sandboxHome, "outside-skill-delete");
+    const victim = path.join(outside, "victim");
+    fs.mkdirSync(victim, { recursive: true });
+    fs.writeFileSync(path.join(victim, "keep.txt"), "important");
+    fs.mkdirSync(root, { recursive: true });
+    try {
+      fs.symlinkSync(outside, path.join(root, "linked-delete"), "dir");
+    } catch (_e) {
+      t.skip("directory symlinks are not available on this platform");
+      return;
+    }
+
+    skills.deleteLocalSkill("linked-delete/victim", ["hermes"]);
+
+    assert.ok(fs.existsSync(path.join(victim, "keep.txt")));
+  });
+
+  it("does not import through symlinked parent directories", (t) => {
+    const root = path.join(sandboxHome, ".hermes/skills");
+    const outside = path.join(sandboxHome, "outside-skill-import");
+    writeLocalSkill("outside-skill-import", "external-skill", "---\nname: External Skill\n---\n");
+    fs.mkdirSync(root, { recursive: true });
+    try {
+      fs.symlinkSync(outside, path.join(root, "linked-import"), "dir");
+    } catch (_e) {
+      t.skip("directory symlinks are not available on this platform");
+      return;
+    }
+
+    assert.throws(() => skills.importLocalSkill("linked-import/external-skill", ["hermes"]), /Local skill not found/);
+    assert.ok(!fs.existsSync(path.join(sandboxHome, ".tokentracker/skills/managed/linked-import/external-skill")));
+  });
+
   it("keeps undo restore available for nested skills whose flattened names collide", () => {
     writeLocalSkill(".hermes/skills", "collision/a-b", "---\nname: Collision Nested\ndescription: Nested\n---\n");
     writeLocalSkill(".hermes/skills", "collision__a-b", "---\nname: Collision Flat\ndescription: Flat\n---\n");

--- a/test/skills-manager.test.js
+++ b/test/skills-manager.test.js
@@ -23,6 +23,19 @@ function writeLocalSkill(targetDir, directory, body = "---\nname: Local Skill\nd
   return dir;
 }
 
+function writeRegistry(registry) {
+  const file = path.join(sandboxHome, ".tokentracker", "skills", "registry.json");
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, `${JSON.stringify(registry, null, 2)}\n`);
+}
+
+function writeManagedSkill(directory, body = "---\nname: Managed Skill\n---\n") {
+  const dir = path.join(sandboxHome, ".tokentracker", "skills", "managed", directory);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "SKILL.md"), body);
+  return dir;
+}
+
 function restoreEnv(name, value) {
   if (value === undefined) delete process.env[name];
   else process.env[name] = value;
@@ -326,5 +339,129 @@ describe("skills-manager antigravity target", () => {
       if (prev === undefined) delete process.env.TOKENTRACKER_ANTIGRAVITY_HOME;
       else process.env.TOKENTRACKER_ANTIGRAVITY_HOME = prev;
     }
+  });
+});
+
+describe("skills-manager path hardening", () => {
+  it("does not delete through a symlinked target root", (t) => {
+    const targetParent = path.join(sandboxHome, ".agents");
+    const targetRoot = path.join(targetParent, "skills");
+    const outside = path.join(sandboxHome, "outside-target-root");
+    const victim = path.join(outside, "root-linked-victim");
+    fs.mkdirSync(targetParent, { recursive: true });
+    fs.mkdirSync(victim, { recursive: true });
+    fs.writeFileSync(path.join(victim, "keep.txt"), "important");
+    try {
+      fs.symlinkSync(outside, targetRoot, "dir");
+    } catch (_e) {
+      t.skip("directory symlinks are not available on this platform");
+      return;
+    }
+
+    skills.deleteLocalSkill("root-linked-victim", ["agents"]);
+
+    assert.ok(fs.existsSync(path.join(victim, "keep.txt")));
+  });
+
+  it("does not import through a symlinked SSOT parent", (t) => {
+    const sourceDir = "ssot-linked/imported-skill";
+    const managedRoot = path.join(sandboxHome, ".tokentracker", "skills", "managed");
+    const outside = path.join(sandboxHome, "outside-ssot-import");
+    writeLocalSkill(".config/opencode/skills", sourceDir, "---\nname: Imported Skill\n---\n");
+    fs.mkdirSync(managedRoot, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+    try {
+      fs.symlinkSync(outside, path.join(managedRoot, "ssot-linked"), "dir");
+    } catch (_e) {
+      t.skip("directory symlinks are not available on this platform");
+      return;
+    }
+
+    assert.throws(() => skills.importLocalSkill(sourceDir, []), /Invalid skill directory/);
+    assert.ok(!fs.existsSync(path.join(outside, "imported-skill")));
+  });
+
+  it("does not uninstall through a symlinked SSOT parent", (t) => {
+    const directory = "ssot-uninstall/victim";
+    const managedRoot = path.join(sandboxHome, ".tokentracker", "skills", "managed");
+    const outside = path.join(sandboxHome, "outside-ssot-uninstall");
+    fs.mkdirSync(managedRoot, { recursive: true });
+    fs.mkdirSync(path.join(outside, "victim"), { recursive: true });
+    fs.writeFileSync(path.join(outside, "victim", "keep.txt"), "important");
+    try {
+      fs.symlinkSync(outside, path.join(managedRoot, "ssot-uninstall"), "dir");
+    } catch (_e) {
+      t.skip("directory symlinks are not available on this platform");
+      return;
+    }
+    writeRegistry({
+      repos: [],
+      skills: [{ id: `local:${directory}`, key: `local:${directory}`, name: "Victim", directory, targets: [] }],
+    });
+
+    assert.throws(() => skills.uninstallSkill(`local:${directory}`), /Invalid skill directory/);
+    assert.ok(fs.existsSync(path.join(outside, "victim", "keep.txt")));
+  });
+
+  it("does not restore through a symlinked SSOT parent", (t) => {
+    const directory = "ssot-restore/victim";
+    const managedRoot = path.join(sandboxHome, ".tokentracker", "skills", "managed");
+    const outside = path.join(sandboxHome, "outside-ssot-restore");
+    const trashName = "restore-copy";
+    const trashSkill = path.join(sandboxHome, ".tokentracker", "skills", ".trash", trashName);
+    fs.mkdirSync(managedRoot, { recursive: true });
+    fs.mkdirSync(outside, { recursive: true });
+    fs.mkdirSync(trashSkill, { recursive: true });
+    fs.writeFileSync(path.join(trashSkill, "SKILL.md"), "---\nname: Restore Copy\n---\n");
+    try {
+      fs.symlinkSync(outside, path.join(managedRoot, "ssot-restore"), "dir");
+    } catch (_e) {
+      t.skip("directory symlinks are not available on this platform");
+      return;
+    }
+    writeRegistry({
+      repos: [],
+      skills: [
+        {
+          id: `local:${directory}`,
+          key: `local:${directory}`,
+          name: "Victim",
+          directory,
+          targets: [],
+          trashedAt: Date.now(),
+          trashedDirectory: trashName,
+          previousTargets: [],
+        },
+      ],
+    });
+
+    assert.throws(() => skills.restoreSkill(`local:${directory}`), /Invalid skill directory/);
+    assert.ok(!fs.existsSync(path.join(outside, "victim")));
+    assert.ok(fs.existsSync(path.join(trashSkill, "SKILL.md")));
+  });
+
+  it("does not alias a local import to an existing GitHub-managed skill", () => {
+    const directory = "github-local-conflict";
+    const localDir = writeLocalSkill(".codex/skills", directory, "---\nname: Local Conflict\n---\n");
+    writeManagedSkill(directory, "---\nname: GitHub Conflict\n---\n");
+    writeRegistry({
+      repos: [],
+      skills: [
+        {
+          id: `owner/repo:skills/${directory}`,
+          key: `owner/repo:skills/${directory}`,
+          name: "GitHub Conflict",
+          directory,
+          sourceDirectory: `skills/${directory}`,
+          repoOwner: "owner",
+          repoName: "repo",
+          repoBranch: "main",
+          targets: [],
+        },
+      ],
+    });
+
+    assert.throws(() => skills.importLocalSkill(directory, ["codex"]), /already managed by another installed skill/);
+    assert.match(fs.readFileSync(path.join(localDir, "SKILL.md"), "utf8"), /Local Conflict/);
   });
 });


### PR DESCRIPTION
## Summary
- Support adopting local skills stored in nested folders, preserving their relative paths when importing, syncing, and removing them.
- Keep GitHub-sourced skill installs on the historical flat install path for compatibility.
- Harden nested local path operations against symlink-parent escapes and keep skill usage matching precise when leaf names collide.

## Problem
Some agents organize local skills under grouped folders, for example `apple/apple-notes`. The existing local skill manager only scanned one directory level and local imports only accepted a single path segment, so nested local skills could be invisible or could not be promoted into managed skills.

Allowing nested local paths also makes intermediate path components security-sensitive. A symlinked group directory under a target skills root could otherwise make delete, import, or sync operations act outside the intended skills tree.

## Solution
This PR adds a bounded recursive local-skill scan, keeps nested local skill paths intact for local imports, and cleans up empty parent directories after nested skill removal.

Local skill paths now reject unsafe lexical forms such as absolute paths, hidden segments, traversal, Windows drive paths, UNC paths, and colon-bearing path segments. Target-root filesystem operations also validate the parent path chain before delete, scan, classify, source lookup, or sync, rejecting symlinked or non-directory intermediate parents.

Usage and dashboard matching distinguish full directory keys from leaf-name fallbacks. Leaf fallback matching is only used when it is unambiguous, while a unique skill name can still match even when directory leaf names collide.

## Scope and compatibility
GitHub-sourced skill installs intentionally keep the historical flat install directory, even when `sourceDirectory` is nested. That preserves existing registry conflict behavior and compatibility with already-installed GitHub skills.

Symlinked directories can still represent a direct skill when the symlink target contains `SKILL.md`, but symlinked group directories are not traversed or adopted via nested local paths. That keeps local skill management bounded to the configured skills tree.

## Follow-up
Making nested local skills visible can make agents that ship many built-in skills, such as Hermes, occupy a large portion of the Skills manager UI. A later UI pass may need collapsed groups, stronger filters, or per-agent grouping so those built-in skills do not dominate the page.

## Test Plan
- [x] `npm test`
- [x] `npm --prefix dashboard test -- SkillsPage.test.jsx`
- [x] `npm run dashboard:build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect skill installation detection when using nested local skill directories.
  * Resolved skill matching to prevent false ambiguous skill identification.

* **Improvements**
  * Enhanced local skill discovery to support nested directory structures.
  * Strengthened path validation for more robust skill management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->