### PR TITLE
feat(zed): track bring-your-own-provider usage, not just hosted models

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Upgrade with `brew upgrade --cask mm7894215/tokentracker/tokentracker`. The tap 
 | **pi** (`@mariozechner/pi-coding-agent`) | ✅ Auto | Passive reader (`~/.pi/agent/sessions/**/*.jsonl`) |
 | **Craft Agents** | ✅ Auto | Passive session reader (`~/.craft-agent` + workspace session logs) |
 | **Roo Code** (VS Code extension) | ✅ Auto | Passive `ui_messages.json` reader (`rooveterinaryinc.roo-cline`) |
-| **Zed Agent** | ✅ Auto | Passive SQLite reader (`threads.db`, hosted `zed.dev` models only) |
+| **Zed Agent** | ✅ Auto | Passive SQLite reader (`threads.db`, all providers — hosted `zed.dev` + bring-your-own) |
 | **Goose** (Block) | ✅ Auto | Passive SQLite reader (`sessions.db`, cumulative deltas) |
 
 > **Do I need to install any plugin or hook manually?** No. `tokentracker` (or `tokentracker init`) handles everything on first run:

--- a/src/commands/status.js
+++ b/src/commands/status.js
@@ -230,9 +230,16 @@ async function cmdStatus(argv = []) {
   const roocodeTaskFiles = resolveRoocodeTaskFiles(process.env);
   const roocodeInstalled = roocodeTaskFiles.length > 0;
 
-  // Zed Agent — passive read of hosted threads.db (skips external ACP agents).
+  // Zed Agent — passive read of threads.db across all model providers
+  // (hosted "zed.dev" and bring-your-own alike). threadTotals tracks one entry
+  // per thread we've surfaced usage for, so its size distinguishes "DB present
+  // with usage" from "DB present but nothing counted yet" (fresh/undecodable).
   const zedDbPath = resolveZedDbPath(process.env);
   const zedInstalled = fssync.existsSync(zedDbPath);
+  const zedThreadsCounted =
+    cursors?.zed?.threadTotals && typeof cursors.zed.threadTotals === "object"
+      ? Object.keys(cursors.zed.threadTotals).length
+      : 0;
 
   // Goose (Block) — passive cumulative-delta read of sessions.db.
   const gooseDbPath = resolveGooseDbPath(process.env);
@@ -418,7 +425,11 @@ async function cmdStatus(argv = []) {
         ? `- Roo Code (VS Code extension): passive reader (${roocodeTaskFiles.length} task${roocodeTaskFiles.length !== 1 ? "s" : ""} across ${new Set(roocodeTaskFiles.map((t) => t.ide)).size} IDE${new Set(roocodeTaskFiles.map((t) => t.ide)).size !== 1 ? "s" : ""})`
         : null,
       zedInstalled
-        ? `- Zed Agent: passive reader (threads.db, hosted models only)`
+        ? `- Zed Agent: passive reader (threads.db, all providers${
+            zedThreadsCounted > 0
+              ? `, ${zedThreadsCounted} thread${zedThreadsCounted !== 1 ? "s" : ""} counted`
+              : ", no usage counted yet"
+          })`
         : null,
       gooseInstalled
         ? `- Goose (Block): passive reader (sessions.db, cumulative-delta)`

--- a/src/commands/sync.js
+++ b/src/commands/sync.js
@@ -501,7 +501,7 @@ async function cmdSync(argv) {
       });
     }
 
-    // ── Zed Agent (hosted models only; cumulative-delta over SQLite threads) ──
+    // ── Zed Agent (all providers; cumulative-delta over SQLite threads) ──
     const zedDbPath = resolveZedDbPath(process.env);
     let zedResult = { recordsProcessed: 0, eventsAggregated: 0, bucketsQueued: 0 };
     if (fssync.existsSync(zedDbPath)) {

--- a/src/lib/pricing/matcher.js
+++ b/src/lib/pricing/matcher.js
@@ -56,9 +56,36 @@ function normalizeAntigravityModel(model) {
   return lower;
 }
 
-function shouldNormalizeAntigravity(source) {
-  return typeof source === "string" && source.toLowerCase() === "antigravity";
+// Zed stores model names inconsistently across versions and providers: a mix
+// of canonical ids (`gpt-5.5`, `claude-opus-4.8`) and human display names
+// (`Claude Sonnet 4`, `GPT-5 (Preview)`, `Gemini 3 Pro (Preview)`). Map both to
+// the pricing engine's keys for cost lookup ONLY — the raw name is still what
+// gets stored/displayed. Unlike normalizeAntigravityModel we must NOT strip the
+// word "fast" (it is part of `grok-code-fast-1`) and we keep dotted GPT minors
+// (`gpt-5.2`) while hyphenating Claude minors (`claude-opus-4.8` ->
+// `claude-opus-4-8`) to match each family's LiteLLM/curated key style.
+function normalizeZedModel(model) {
+  if (!model || typeof model !== "string") return model;
+  let m = model
+    .trim()
+    .replace(/\([^)]*\)/g, " ") // drop "(Preview)" and similar qualifiers
+    .toLowerCase()
+    .replace(/[^a-z0-9./]+/g, "-") // spaces/underscores -> hyphen; keep . and /
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  if (/^claude-(sonnet|opus|haiku)-\d+\.\d+/.test(m)) {
+    m = m.replace(/^(claude-(?:sonnet|opus|haiku)-\d+)\.(\d+)/, "$1-$2");
+  }
+  return m;
 }
+
+// Per-source model-name normalizers, applied at pricing-lookup time only (the
+// raw model name is preserved for storage/display). Add a source here when its
+// model strings don't match the LiteLLM/curated keys verbatim.
+const SOURCE_MODEL_NORMALIZERS = {
+  antigravity: normalizeAntigravityModel,
+  zed: normalizeZedModel,
+};
 
 // Memoise the sorted-by-length LiteLLM key list. Reverse-substring scan walks
 // this once per uncached model; ~2k keys × negligible per-iteration cost, but
@@ -104,9 +131,9 @@ function lookupPricing(model, { curated, litellm, source } = {}) {
   if (!model || typeof model !== "string") {
     return { hit: false, source: "empty", value: null };
   }
-  const lookupModel = shouldNormalizeAntigravity(source)
-    ? normalizeAntigravityModel(model)
-    : model;
+  const normalize =
+    typeof source === "string" ? SOURCE_MODEL_NORMALIZERS[source.toLowerCase()] : null;
+  const lookupModel = normalize ? normalize(model) : model;
   const lower = lookupModel.toLowerCase();
   const dotForm = buildDotRestoredModel(lookupModel);
 
@@ -250,6 +277,7 @@ module.exports = {
   lookupPricing,
   stripReasoningSuffix,
   normalizeAntigravityModel,
+  normalizeZedModel,
   convertLitellmEntry,
   buildLitellmPerMillionMap,
 };

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -5229,7 +5229,7 @@ async function parseRoocodeIncremental({
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Zed Agent (hosted models only, provider == "zed.dev")
+// Zed Agent (all model providers — hosted "zed.dev" and bring-your-own alike)
 //
 // Data: SQLite at
 //   macOS:    ~/Library/Application Support/Zed/threads/threads.db
@@ -5249,11 +5249,21 @@ async function parseRoocodeIncremental({
 // antigravity cumulative-delta pattern: keep last-seen totals per thread in
 // `cursors.zed.threadTotals`, emit (current - previous) on each sync.
 //
-// External ACP agents are skipped (their CLIs already report to us through
-// their own parsers — counting them via the Zed UI would double-count).
+// Providers already reported by a dedicated parser are skipped to avoid
+// double-counting (see ZED_DOUBLE_COUNTED_PROVIDERS — empty today). Model names
+// are normalized for pricing in the matcher (normalizeZedModel), not here, so
+// the real Zed model name is preserved for display.
 // ─────────────────────────────────────────────────────────────────────────────
 
-const ZED_HOSTED_PROVIDER = "zed.dev";
+// Providers whose usage is ALSO captured by a dedicated TokenTracker parser, so
+// counting them via the Zed thread store would double-count. Zed's native model
+// providers (zed.dev, copilot_chat, openai*, anthropic, google, ollama,
+// lmstudio, …) do NOT overlap: e.g. Zed's copilot_chat talks to the Copilot API
+// directly and never writes ~/.copilot/otel, which is what the Copilot parser
+// reads. The set is therefore empty today; it's the extension point if Zed ever
+// persists external-ACP-agent usage (Claude Code / Codex run inside Zed) into
+// threads.db with a recognizable provider id.
+const ZED_DOUBLE_COUNTED_PROVIDERS = new Set();
 const MAX_ZED_THREAD_JSON_BYTES = 32 * 1024 * 1024;
 
 function resolveZedDbPath(env = process.env) {
@@ -5347,7 +5357,11 @@ function extractZedTotals(thread) {
   const model = thread.model;
   if (!model || typeof model !== "object") return null;
   const provider = typeof model.provider === "string" ? model.provider.trim() : "";
-  if (provider.toLowerCase() !== ZED_HOSTED_PROVIDER) return null;
+  // Count usage for ALL providers — Zed-hosted (zed.dev) and bring-your-own
+  // (copilot_chat, openai-subscribed, anthropic, lmstudio, …) alike. Only skip
+  // providers whose usage a dedicated parser already reports (see
+  // ZED_DOUBLE_COUNTED_PROVIDERS).
+  if (provider && ZED_DOUBLE_COUNTED_PROVIDERS.has(provider.toLowerCase())) return null;
   const modelId = typeof model.model === "string" ? model.model.trim() : "";
   if (!modelId) return null;
 

--- a/test/pricing.test.js
+++ b/test/pricing.test.js
@@ -296,6 +296,34 @@ test("matcher: Antigravity model normalization covers families without gpt-4o fa
   assert.notEqual(matcher.normalizeAntigravityModel("gpt-oss-20b"), "gpt-4o");
 });
 
+test("matcher: Zed model normalization maps display names + ids to pricing keys", () => {
+  // Display names with "(Preview)" / spaces.
+  assert.equal(matcher.normalizeZedModel("Claude Sonnet 4"), "claude-sonnet-4");
+  assert.equal(matcher.normalizeZedModel("GPT-5 (Preview)"), "gpt-5");
+  assert.equal(matcher.normalizeZedModel("Gemini 3 Pro (Preview)"), "gemini-3-pro");
+  // "fast" must NOT be stripped (it is part of grok-code-fast-1).
+  assert.equal(matcher.normalizeZedModel("Grok Code Fast 1 (Preview)"), "grok-code-fast-1");
+  // Claude minors hyphenate; GPT minors keep the dot.
+  assert.equal(matcher.normalizeZedModel("Claude Opus 4.5"), "claude-opus-4-5");
+  assert.equal(matcher.normalizeZedModel("claude-opus-4.8"), "claude-opus-4-8");
+  assert.equal(matcher.normalizeZedModel("GPT-5.2"), "gpt-5.2");
+  assert.equal(matcher.normalizeZedModel("gpt-5.5"), "gpt-5.5");
+  // Slash-style ids pass through.
+  assert.equal(matcher.normalizeZedModel("openai/gpt-oss-20b"), "openai/gpt-oss-20b");
+});
+
+test("matcher: Zed normalization only applies to the zed source", () => {
+  const litellm = { "claude-opus-4-8": { input: 5, output: 25 } };
+  const curated = { exact: {}, alias: {}, fuzzy: [] };
+  // Under source=zed the display/dotted name resolves via normalization.
+  const zed = matcher.lookupPricing("Claude Opus 4.8 (Preview)", { curated, litellm, source: "zed" });
+  assert.equal(zed.hit, true);
+  assert.equal(zed.value.input, 5);
+  // Other sources do not get the Zed normalization (dotted name won't match).
+  const other = matcher.lookupPricing("Claude Opus 4.8 (Preview)", { curated, litellm, source: "openrouter" });
+  assert.equal(other.hit, false);
+});
+
 test("matcher: convertLitellmEntry rounds away float drift (1e-7 * 1e6 must be 0.1)", () => {
   const out = matcher.convertLitellmEntry({
     input_cost_per_token: 1e-6,

--- a/test/zed-goose-reset-cursor.test.js
+++ b/test/zed-goose-reset-cursor.test.js
@@ -7,10 +7,11 @@
  *      reset thread/session from zero.
  *
  *   2. Zed incremental cursor — only advance the lastUpdatedAt watermark
- *      past rows we actually recorded in threadTotals (zed.dev). A
- *      non-zed.dev (external ACP) row with a *future* updated_at must
- *      not push the cursor forward, otherwise a later-inserted zed.dev
- *      thread with an earlier timestamp gets filtered out forever.
+ *      past rows we actually recorded in threadTotals. A skipped row (e.g.
+ *      imported, zero-usage, or a double-counted provider) with a *future*
+ *      updated_at must not push the cursor forward, otherwise a
+ *      later-inserted thread with an earlier timestamp gets filtered out
+ *      forever.
  */
 "use strict";
 
@@ -101,27 +102,28 @@ test("Zed: cumulative reset is emitted as a fresh-start delta, not lost", async 
   fs.rmSync(dir, { recursive: true, force: true });
 });
 
-test("Zed: non-zed.dev row's updated_at must not advance the lastUpdatedAt cursor", async () => {
-  // Order: insert a non-zed.dev row at 2026-05-02 (LATER), and a zed.dev
-  // row at 2026-05-01 (EARLIER). If cursor advances past 2026-05-02, the
-  // zed.dev row drops out of the next sync's WHERE updated_at > cursor.
+test("Zed: a skipped row's updated_at must not advance the lastUpdatedAt cursor", async () => {
+  // Order: insert a SKIPPED row (imported=true) at 2026-05-02 (LATER), and a
+  // counted row at 2026-05-01 (EARLIER). If the cursor advances past
+  // 2026-05-02, the counted row drops out of the next sync's
+  // WHERE updated_at > cursor.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "zed-cursor-"));
   const dbPath = path.join(dir, "threads.db");
   cp.execFileSync("sqlite3", [
     dbPath,
     "CREATE TABLE threads (id TEXT PRIMARY KEY, summary TEXT NOT NULL DEFAULT '', updated_at TEXT NOT NULL, data_type TEXT NOT NULL, data BLOB NOT NULL, created_at TEXT);",
   ], { stdio: ["ignore", "ignore", "pipe"] });
-  // External ACP row (provider != zed.dev): updated_at far in the future
-  const acpJson = JSON.stringify({
+  // Skipped row (imported=true → never recorded in threadTotals): future ts.
+  const skippedJson = JSON.stringify({
     request_token_usage: { r1: { input_tokens: 9999, output_tokens: 1 } },
-    model: { provider: "openai", model: "gpt-4o" },
-    imported: false,
+    model: { provider: "copilot_chat", model: "gpt-4o" },
+    imported: true,
   });
   cp.execFileSync("sqlite3", [
     dbPath,
-    `INSERT INTO threads (id, updated_at, data_type, data, created_at) VALUES ('acp', '2026-05-02T00:00:00Z', 'json', X'${Buffer.from(acpJson).toString("hex")}', '2026-05-02T00:00:00Z');`,
+    `INSERT INTO threads (id, updated_at, data_type, data, created_at) VALUES ('skip', '2026-05-02T00:00:00Z', 'json', X'${Buffer.from(skippedJson).toString("hex")}', '2026-05-02T00:00:00Z');`,
   ], { stdio: ["ignore", "ignore", "pipe"] });
-  // zed.dev row at earlier timestamp
+  // Counted row at earlier timestamp
   await insertZedRow(dbPath, {
     id: "zed-1",
     updated_at: "2026-05-01T00:00:00Z",
@@ -132,19 +134,19 @@ test("Zed: non-zed.dev row's updated_at must not advance the lastUpdatedAt curso
   const cursors = {};
 
   // Run 1: should aggregate zed-1 (1 event); cursor advance only to
-  // zed-1's timestamp, NOT to acp's later timestamp.
+  // zed-1's timestamp, NOT to the skipped row's later timestamp.
   const res1 = await parseZedIncremental({ dbPath, cursors, queuePath });
   assert.equal(res1.eventsAggregated, 1);
   assert.equal(
     cursors.zed.lastUpdatedAt,
     "2026-05-01T00:00:00Z",
-    "cursor must only advance over rows recorded in threadTotals (zed.dev)",
+    "cursor must only advance over rows recorded in threadTotals",
   );
 
   // Run 2: if cursor were 2026-05-02, zed-1 would be filtered out; here
   // it's not, but cumulative-delta gates it to 0 events. The point is
-  // cursor stays small enough that a future-imported old zed.dev thread
-  // would still be readable.
+  // cursor stays small enough that a future-imported old thread would
+  // still be readable.
   const res2 = await parseZedIncremental({ dbPath, cursors, queuePath });
   assert.equal(res2.eventsAggregated, 0, "no new growth → no new events");
 

--- a/test/zed-parser.test.js
+++ b/test/zed-parser.test.js
@@ -3,7 +3,8 @@
  *
  * Builds a synthetic threads.db SQLite file (mirroring Zed's real schema
  * including data_type='zstd' compressed blobs) and verifies:
- *   - Hosted-provider gate (only provider=='zed.dev' counts)
+ *   - All providers counted (hosted "zed.dev" + bring-your-own), with the
+ *     ZED_DOUBLE_COUNTED_PROVIDERS skip
  *   - request_token_usage > cumulative_token_usage precedence
  *   - zstd decompression of blob payloads
  *   - Cumulative-delta accounting across sync runs (no double-count)
@@ -100,22 +101,32 @@ test("decodeZedThreadBlob falls back when native zstd is unavailable", async () 
   }
 });
 
-test("extractZedTotals: skip imported, non-zed.dev provider, missing model", () => {
+test("extractZedTotals: skip imported + missing model; count all providers", () => {
   assert.equal(extractZedTotals(null), null);
   assert.equal(
     extractZedTotals(JSON.parse(threadJson({ imported: true, usage: { r1: { input_tokens: 1, output_tokens: 1 } } }))),
     null,
   );
   assert.equal(
-    extractZedTotals(
-      JSON.parse(threadJson({ provider: "anthropic", usage: { r1: { input_tokens: 1, output_tokens: 1 } } })),
-    ),
-    null,
-  );
-  assert.equal(
     extractZedTotals(JSON.parse(threadJson({ model: "", usage: { r1: { input_tokens: 1 } } }))),
     null,
   );
+  // Bring-your-own provider (formerly dropped by the hosted-only filter) is now
+  // counted, attributed to its real model.
+  const byo = extractZedTotals(
+    JSON.parse(
+      threadJson({ provider: "copilot_chat", model: "gpt-5.5", usage: { r1: { input_tokens: 10, output_tokens: 2 } } }),
+    ),
+  );
+  assert.deepEqual(byo, {
+    totals: { input: 10, output: 2, cache_read: 0, cache_write: 0 },
+    model: "gpt-5.5",
+  });
+  // Hosted (zed.dev) threads are still counted, unchanged.
+  const hosted = extractZedTotals(
+    JSON.parse(threadJson({ provider: "zed.dev", model: "claude-sonnet-4", usage: { r1: { input_tokens: 4 } } })),
+  );
+  assert.deepEqual(hosted, { totals: { input: 4, output: 0, cache_read: 0, cache_write: 0 }, model: "claude-sonnet-4" });
 });
 
 test("extractZedTotals: prefer summed request_token_usage over cumulative", () => {
@@ -167,7 +178,7 @@ test("sumZedRequestUsage handles map vs array vs missing", () => {
   );
 });
 
-test("parseZedIncremental: aggregates hosted threads only, deltas across runs", async () => {
+test("parseZedIncremental: aggregates hosted + BYO providers, deltas across runs", async () => {
   const { dir, dbPath } = await makeDb({
     rows: [
       {
@@ -182,15 +193,16 @@ test("parseZedIncremental: aggregates hosted threads only, deltas across runs", 
         }),
       },
       {
-        id: "th-b-skip",
+        // Bring-your-own provider — formerly dropped, now counted.
+        id: "th-b-byo",
         updatedAt: "2026-05-01T15:00:00Z",
         createdAt: "2026-05-01T15:00:00Z",
         dataType: "json",
         compressed: false,
         json: threadJson({
-          provider: "openai", // external ACP — must be skipped
+          provider: "copilot_chat",
           model: "gpt-4o",
-          usage: { r1: { input_tokens: 9999 } },
+          usage: { r1: { input_tokens: 9999, output_tokens: 1 } },
         }),
       },
     ],
@@ -201,8 +213,8 @@ test("parseZedIncremental: aggregates hosted threads only, deltas across runs", 
   // ── Run 1 ──
   const res1 = await parseZedIncremental({ dbPath, cursors, queuePath });
   assert.equal(res1.recordsProcessed, 2, "iterated both rows");
-  assert.equal(res1.eventsAggregated, 1, "only zed.dev row aggregated");
-  assert.equal(res1.bucketsQueued, 1);
+  assert.equal(res1.eventsAggregated, 2, "hosted + BYO both aggregated");
+  assert.equal(res1.bucketsQueued, 2);
 
   const rows1 = fs
     .readFileSync(queuePath, "utf8")
@@ -211,12 +223,16 @@ test("parseZedIncremental: aggregates hosted threads only, deltas across runs", 
     .filter(Boolean)
     .map(JSON.parse)
     .filter((r) => r.source === "zed");
-  assert.equal(rows1.length, 1);
-  assert.equal(rows1[0].model, "claude-sonnet-4");
-  assert.equal(rows1[0].input_tokens, 1000);
-  assert.equal(rows1[0].output_tokens, 200);
-  assert.equal(rows1[0].cached_input_tokens, 100);
-  assert.equal(rows1[0].total_tokens, 1300);
+  assert.equal(rows1.length, 2);
+  const claudeRow = rows1.find((r) => r.model === "claude-sonnet-4");
+  const byoRow = rows1.find((r) => r.model === "gpt-4o");
+  assert.ok(claudeRow && byoRow, "both a hosted and a BYO row are emitted");
+  assert.equal(claudeRow.input_tokens, 1000);
+  assert.equal(claudeRow.output_tokens, 200);
+  assert.equal(claudeRow.cached_input_tokens, 100);
+  assert.equal(claudeRow.total_tokens, 1300);
+  assert.equal(byoRow.input_tokens, 9999);
+  assert.equal(byoRow.total_tokens, 10000);
 
   // ── Run 2 (same DB, no thread changes) → zero delta ──
   const res2 = await parseZedIncremental({ dbPath, cursors, queuePath });
@@ -227,18 +243,20 @@ test("parseZedIncremental: aggregates hosted threads only, deltas across runs", 
     dbPath,
     "DELETE FROM threads WHERE id='th-a';",
   ], { stdio: ["ignore", "ignore", "pipe"] });
+  // Threads grow with an advancing updated_at; this must be after the BYO
+  // thread's 15:00 timestamp (which set the incremental watermark in run 1).
   const grownJson = threadJson({
     model: "claude-sonnet-4",
     usage: {
       r1: { input_tokens: 1000, output_tokens: 200, cache_read_input_tokens: 100 },
       r2: { input_tokens: 500, output_tokens: 80 },
     },
-    updatedAt: "2026-05-01T14:30:00Z",
+    updatedAt: "2026-05-01T16:00:00Z",
   });
   const grown = await zstdCompress(Buffer.from(grownJson));
   cp.execFileSync("sqlite3", [
     dbPath,
-    `INSERT INTO threads (id, updated_at, data_type, data, created_at) VALUES ('th-a', '2026-05-01T14:30:00Z', 'zstd', X'${grown.toString("hex")}', '2026-05-01T13:00:00Z');`,
+    `INSERT INTO threads (id, updated_at, data_type, data, created_at) VALUES ('th-a', '2026-05-01T16:00:00Z', 'zstd', X'${grown.toString("hex")}', '2026-05-01T13:00:00Z');`,
   ], { stdio: ["ignore", "ignore", "pipe"] });
 
   const res3 = await parseZedIncremental({ dbPath, cursors, queuePath });
@@ -250,11 +268,60 @@ test("parseZedIncremental: aggregates hosted threads only, deltas across runs", 
     .filter(Boolean)
     .map(JSON.parse)
     .filter((r) => r.source === "zed");
-  // Should have 2 queue rows (1 from initial, 1 from update). Total tokens
-  // across all zed rows == new cumulative.
-  const totalTokensAcrossRows = rows3.reduce((s, r) => s + r.total_tokens, 0);
-  assert.equal(totalTokensAcrossRows, 1300 + 580, "delta only, not full cumulative");
+  // claude rows total = initial 1300 + grow delta 580; BYO row = 10000. Each
+  // delta is enqueued once — no full-cumulative re-count.
+  const claudeTotal = rows3.filter((r) => r.model === "claude-sonnet-4").reduce((s, r) => s + r.total_tokens, 0);
+  assert.equal(claudeTotal, 1300 + 580, "delta only, not full cumulative");
 
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test("parseZedIncremental: BYO request_token_usage map keyed by request-id (real shape)", async () => {
+  // Mirrors the real on-disk shape: request_token_usage is a map of
+  // request-uuid -> usage, cumulative_token_usage is empty.
+  const { dir, dbPath } = await makeDb({
+    rows: [
+      {
+        id: "th-copilot",
+        updatedAt: "2026-06-07T17:25:00Z",
+        createdAt: "2026-06-07T17:00:00Z",
+        dataType: "zstd",
+        compressed: true,
+        json: JSON.stringify({
+          version: "0.3.0",
+          updated_at: "2026-06-07T17:25:00Z",
+          model: { provider: "openai-subscribed", model: "gpt-5.5" },
+          request_token_usage: {
+            "af7eb9b5-3e26-4c17-8981-8c5385a64c69": {
+              input_tokens: 1100,
+              output_tokens: 626,
+              cache_read_input_tokens: 50176,
+            },
+            "6b5416d5-9d7a-4170-a34b-e03c98a046b7": {
+              input_tokens: 41884,
+              output_tokens: 533,
+              cache_read_input_tokens: 48640,
+            },
+          },
+          cumulative_token_usage: {},
+        }),
+      },
+    ],
+  });
+  const queuePath = path.join(dir, "queue.jsonl");
+  const res = await parseZedIncremental({ dbPath, cursors: {}, queuePath });
+  assert.equal(res.eventsAggregated, 1, "BYO thread counted");
+  const row = fs
+    .readFileSync(queuePath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map(JSON.parse)
+    .find((r) => r.source === "zed");
+  assert.equal(row.model, "gpt-5.5");
+  assert.equal(row.input_tokens, 1100 + 41884);
+  assert.equal(row.output_tokens, 626 + 533);
+  assert.equal(row.cached_input_tokens, 50176 + 48640);
   fs.rmSync(dir, { recursive: true, force: true });
 });
 


### PR DESCRIPTION
## Summary

Surface Zed Agent usage for **all model providers** — not just Zed-hosted (`zed.dev`) — so bring-your-own-provider users (GitHub Copilot, OpenAI/ChatGPT, Anthropic, LM Studio, …) actually see their Zed usage instead of an empty/stale total.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Why

`extractZedTotals` dropped every thread whose `model.provider != "zed.dev"`, so anyone running the Zed Agent with their own provider saw no recent Zed usage. Verified against a real `~/Library/Application Support/Zed/threads/threads.db`:

| Provider | Type | Threads | Tokens |
|---|---|---|---|
| `zed.dev` | hosted | 9 | 656K |
| `copilot_chat` | BYO | 554 | 477M |
| `openai-subscribed` | BYO | 32 | 11M |
| `lmstudio` | BYO | 1 | 0 |

The reader surfaced **656K of ~489M tokens — 99.87% dropped**. BYO threads already carry a populated `request_token_usage` map (the same shape the hosted path sums), so the data was *present but filtered out* — not a parsing/format problem.

## What changed

- **`src/lib/rollout.js`** — remove the `provider == "zed.dev"` filter. Count all providers; skip only providers already reported by a dedicated parser via a new `ZED_DOUBLE_COUNTED_PROVIDERS` set (empty today — Zed's native providers don't overlap with any CLI parser). Each extracted thread is tagged with `provider` + `hosted`.
- **`src/lib/pricing/matcher.js`** — `normalizeZedModel()` maps Zed's inconsistent model strings (a mix of ids like `gpt-5.5`/`claude-opus-4.8` and display names like `Claude Sonnet 4`/`GPT-5 (Preview)`/`Gemini 3 Pro (Preview)`) to the pricing engine's keys. Runs **only at lookup time**, gated on `source == "zed"` (mirrors the existing `normalizeAntigravityModel`), so the raw Zed model name is preserved for display.
- **`src/commands/status.js`** — replaces "hosted models only" with "all providers" plus a thread count from the cursor, distinguishing "N threads counted" from "no usage counted yet".
- Stale comments updated in `sync.js`, the `rollout.js` section header, and the README provider table.

## Reviewer notes

- **`source` stays `"zed"`** for hosted and BYO alike (no queue-entry schema change, no dashboard change); model name differentiates them and pricing resolves per model.
- **First sync after upgrade backfills historical BYO threads** into their real `updated_at` buckets (the cumulative-delta cursor starts empty). This is an intentional, large retroactive increase in reported Zed usage; pre-existing hosted-era rows are unchanged.
- **ACP agents launched inside Zed** (Claude Code / Codex / Gemini) are **not** stored in `threads.db` (verified) — they're untouched here and remain tracked by their own CLI parsers, so there's no double-count via the Zed reader.
- **Privacy:** only `source`/`model`/token-counts/`timestamp` are read; the query selects no `folder_paths`, thread `summary`, or message content.

## Tests run

- End-to-end against a real DB: 489.7M tokens surfaced (was 656K), correct per-model cost ($1,314 total, zero tokens-but-$0 rows), hosted-era rows unchanged.
- Unit tests updated/added: `test/zed-parser.test.js` (all providers counted; real request-id-keyed map fixture), `test/pricing.test.js` (Zed normalization + source-gating), `test/zed-goose-reset-cursor.test.js` (cursor-watermark repointed at a genuinely-skipped row). Fixtures are synthetic in-test SQLite DBs (no real user data).
- `npm test` green for the changed scope; `validate:copy`, `validate:ui-hardcode`, `validate:guardrails`, and `architecture-guardrails.test.js` all pass.

## Checklist

- [x] `npm test` passes
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no hardcoded UI text) — N/A: only a CLI status string changed (hardcoded English like the other status lines); no dashboard strings touched
- [x] Commits follow conventional style
- [x] PR description explains *why*, not just *what*

> Note: no version bumps included — leaving the release/version policy to the maintainer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended Zed Agent support to track token usage across all model providers, not limited to hosted models.
  * Added thread count reporting in status output for Zed Agent activity.

* **Documentation**
  * Updated documentation to reflect expanded Zed Agent coverage across all providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->