### PR TITLE
fix(limits): make Claude usage limits resilient to rate limits

### DIFF
--- a/dashboard/src/hooks/use-usage-limits.test.tsx
+++ b/dashboard/src/hooks/use-usage-limits.test.tsx
@@ -59,7 +59,8 @@ describe("useUsageLimits", () => {
 
     await waitFor(() => expect(result.current.data).toEqual(freshLimits));
 
-    expect(getUsageLimits).toHaveBeenCalledWith({ refresh: true });
+    // Mount fetch reads the server cache (no forced upstream refresh).
+    expect(getUsageLimits).toHaveBeenCalledWith();
     expect(publishUsageLimitsPreloadState).toHaveBeenCalledWith(freshLimits, {
       source: "page-load",
     });
@@ -75,7 +76,7 @@ describe("useUsageLimits", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(getUsageLimits).toHaveBeenCalledWith({ refresh: true });
+    expect(getUsageLimits).toHaveBeenCalledWith();
     expect(result.current.data).toEqual(freshLimits);
     expect(result.current.error).toBeNull();
   });

--- a/dashboard/src/hooks/use-usage-limits.ts
+++ b/dashboard/src/hooks/use-usage-limits.ts
@@ -63,7 +63,10 @@ export function useUsageLimits(options?: UseUsageLimitsOptions) {
     let cancelled = false;
     (async () => {
       try {
-        const res = await getUsageLimits(initialRefresh ? { refresh: true } : {});
+        // Mount fetch reads the server's cache (in-memory + disk-backed) rather than forcing
+        // a live upstream call on every navigation — that repeated forcing is what tripped
+        // Claude's OAuth usage endpoint rate limit. Only the manual refresh() forces upstream.
+        const res = await getUsageLimits();
         if (cancelled) return;
         const nextData = res && typeof res === "object" ? res as UsageLimitsData : null;
         setData(nextData);

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -36,6 +36,13 @@ const ANTIGRAVITY_LIMITS_CACHE_UNKNOWN_RESET_TTL_MS = 12 * 60 * 60 * 1000;
 // file with only its own key, so a shared file would clobber).
 const CLAUDE_LIMITS_CACHE_FILE = "claude-usage-limits-cache.json";
 const CLAUDE_LIMITS_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+// A 429 from the usage endpoint carries a long `retry-after` (often 20+ minutes). Persist
+// the cooldown so every surface — this process, the menu bar app's embedded server, a later
+// restart — stops calling until it expires. Hammering during the cooldown just renews the
+// penalty, which is what kept the panel stuck on the error.
+const CLAUDE_RATE_LIMIT_FILE = "claude-usage-rate-limit.json";
+const CLAUDE_RATE_LIMIT_DEFAULT_COOLDOWN_SEC = 5 * 60;
+const CLAUDE_RATE_LIMIT_MAX_COOLDOWN_SEC = 60 * 60;
 
 function clampPercent(value) {
   if (value === null || value === undefined || value === "") return null;
@@ -105,6 +112,20 @@ function withProviderTimeout(promise, label, timeoutMs) {
   return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
+function parseRetryAfterSeconds(headers) {
+  const ra = headers?.get ? headers.get("retry-after") : null;
+  const sec = ra ? Number.parseInt(ra, 10) : NaN;
+  return Number.isFinite(sec) && sec > 0 ? sec : null;
+}
+
+function formatClaudeRateLimitMessage(retryAfterSec) {
+  if (Number.isFinite(retryAfterSec) && retryAfterSec > 0) {
+    const mins = Math.ceil(retryAfterSec / 60);
+    return `Claude API rate limited (429) — retry in ~${mins}m.`;
+  }
+  return "Claude API rate limited (429) — retry shortly.";
+}
+
 async function fetchClaudeUsageLimits(accessToken, { fetchImpl = fetch, maxAttempts = 3 } = {}) {
   const url = "https://api.anthropic.com/api/oauth/usage";
   const headers = {
@@ -126,9 +147,11 @@ async function fetchClaudeUsageLimits(accessToken, { fetchImpl = fetch, maxAttem
     }
     if (!res.ok) {
       if (res.status === 429) {
-        throw new Error(
-          "Claude API rate limited (429) — wait ~1 minute and refresh.",
-        );
+        const retryAfterSec = parseRetryAfterSeconds(res.headers);
+        const err = new Error(formatClaudeRateLimitMessage(retryAfterSec));
+        err.code = "RATE_LIMITED";
+        err.retryAfterSec = retryAfterSec;
+        throw err;
       }
       throw new Error(`Claude API returned ${res.status}`);
     }
@@ -1344,6 +1367,40 @@ function writeClaudeLimitsCache(limits, { home, nowMs = Date.now() } = {}) {
   } catch (_error) {}
 }
 
+function resolveClaudeRateLimitPath({ home } = {}) {
+  return path.join(home || os.homedir(), ".tokentracker", "tracker", CLAUDE_RATE_LIMIT_FILE);
+}
+
+// Returns the cooldown expiry in ms if a 429 cooldown is still active, else null.
+function readClaudeRateLimitRetryAtMs({ home, nowMs = Date.now() } = {}) {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(resolveClaudeRateLimitPath({ home }), "utf8"));
+    const retryAtMs = parseTimeMs(parsed?.retry_at);
+    if (retryAtMs !== null && retryAtMs > nowMs) return retryAtMs;
+  } catch (_error) {}
+  return null;
+}
+
+function writeClaudeRateLimitCooldown(retryAfterSec, { home, nowMs = Date.now() } = {}) {
+  const sec = Number.isFinite(retryAfterSec) && retryAfterSec > 0
+    ? Math.min(retryAfterSec, CLAUDE_RATE_LIMIT_MAX_COOLDOWN_SEC)
+    : CLAUDE_RATE_LIMIT_DEFAULT_COOLDOWN_SEC;
+  const cachePath = resolveClaudeRateLimitPath({ home });
+  const payload = { retry_at: new Date(nowMs + sec * 1000).toISOString() };
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    const tmpPath = `${cachePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, cachePath);
+  } catch (_error) {}
+}
+
+function clearClaudeRateLimitCooldown({ home } = {}) {
+  try {
+    fs.unlinkSync(resolveClaudeRateLimitPath({ home }));
+  } catch (_error) {}
+}
+
 function resolveLsofBinary({ commandRunner } = {}) {
   for (const candidate of ["/usr/sbin/lsof", "/usr/bin/lsof"]) {
     if (fs.existsSync(candidate)) return candidate;
@@ -1771,9 +1828,13 @@ async function getUsageLimits({
   const codexAccountId = codexAuthRefreshed?.accountId || null;
   const codexPlanType = codexAuthRefreshed?.planType || null;
 
+  // Skip the upstream Claude call entirely while a 429 cooldown is active — calling again
+  // just renews the penalty. The result handling below serves cache or a cooldown message.
+  const claudeRetryAtMs = claudeToken ? readClaudeRateLimitRetryAtMs({ home, nowMs }) : null;
+
   const providerFetch = withFetchTimeout(fetchImpl, providerTimeoutMs);
   const [claudeResult, codexResult, cursor, kimi, gemini, kiro, antigravity, copilot, grok] = await Promise.all([
-    claudeToken
+    claudeToken && !claudeRetryAtMs
       ? withProviderTimeout(fetchClaudeUsageLimits(claudeToken, { fetchImpl: providerFetch, maxAttempts: 1 }), "Claude", providerTimeoutMs).then(
           (value) => ({ status: "fulfilled", value }),
           (reason) => ({ status: "rejected", reason }),
@@ -1806,14 +1867,7 @@ async function getUsageLimits({
   let claude;
   if (!claudeToken) {
     claude = { configured: false };
-  } else if (!claudeResult || claudeResult.status === "rejected") {
-    // Live fetch failed (e.g. a transient 429 against the OAuth usage endpoint). Serve the
-    // last successful read so the bars stay visible; only show the red error if there's no
-    // usable cached fallback.
-    claude =
-      readClaudeLimitsCache({ home, nowMs })
-      || { configured: true, error: claudeResult?.reason?.message || "Unknown error" };
-  } else {
+  } else if (claudeResult && claudeResult.status === "fulfilled") {
     claude = {
       configured: true,
       error: null,
@@ -1823,6 +1877,27 @@ async function getUsageLimits({
       extra_usage: claudeResult.value.extra_usage,
     };
     writeClaudeLimitsCache(claude, { home, nowMs });
+    clearClaudeRateLimitCooldown({ home });
+  } else {
+    // Either a fresh 429 (record its cooldown) or a call we skipped because a cooldown was
+    // already active. Serve the last successful read so the bars stay visible; otherwise
+    // surface an accurate "retry in ~Nm" message rather than the misleading hardcoded one.
+    const reason = claudeResult?.reason;
+    if (reason?.code === "RATE_LIMITED") {
+      writeClaudeRateLimitCooldown(reason.retryAfterSec, { home, nowMs });
+    }
+    const cached = readClaudeLimitsCache({ home, nowMs });
+    if (cached) {
+      claude = cached;
+    } else {
+      const retryAtMs = readClaudeRateLimitRetryAtMs({ home, nowMs }) || claudeRetryAtMs;
+      claude = {
+        configured: true,
+        error: retryAtMs
+          ? formatClaudeRateLimitMessage(Math.round((retryAtMs - nowMs) / 1000))
+          : reason?.message || "Unknown error",
+      };
+    }
   }
 
   let codex;

--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -30,6 +30,12 @@ const DEFAULT_PROVIDER_TIMEOUT_MS = 15_000;
 const ANTIGRAVITY_LIMITS_CACHE_FILE = "usage-limits-cache.json";
 const ANTIGRAVITY_LIMITS_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const ANTIGRAVITY_LIMITS_CACHE_UNKNOWN_RESET_TTL_MS = 12 * 60 * 60 * 1000;
+// Claude shares its OAuth usage endpoint budget with Claude Code itself, so a transient
+// 429 is common. Persist the last successful read so the panel can keep showing it instead
+// of flashing a red error. Separate file from Antigravity's (whose writer rewrites the whole
+// file with only its own key, so a shared file would clobber).
+const CLAUDE_LIMITS_CACHE_FILE = "claude-usage-limits-cache.json";
+const CLAUDE_LIMITS_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 
 function clampPercent(value) {
   if (value === null || value === undefined || value === "") return null;
@@ -1271,6 +1277,73 @@ function writeAntigravityLimitsCache(limits, { home, nowMs = Date.now() } = {}) 
   } catch (_error) {}
 }
 
+function resolveClaudeLimitsCachePath({ home } = {}) {
+  return path.join(home || os.homedir(), ".tokentracker", "tracker", CLAUDE_LIMITS_CACHE_FILE);
+}
+
+// Claude windows carry their own `resets_at`; a window whose reset has already passed is
+// stale data, not a usable fallback, so drop it. Windows without a reset stamp are kept
+// (the overall cached_at max-age gate already bounds them).
+function isClaudeCacheWindowUsable(window, { nowMs } = {}) {
+  if (!window || typeof window !== "object") return false;
+  const resetAtMs = parseTimeMs(window.resets_at);
+  if (resetAtMs === null) return true;
+  return resetAtMs > nowMs;
+}
+
+function hasClaudeWindow(limits) {
+  return Boolean(limits?.five_hour || limits?.seven_day || limits?.seven_day_opus);
+}
+
+function normalizeClaudeCachedLimits(raw, { nowMs = Date.now() } = {}) {
+  const cachedAtMs = parseTimeMs(raw?.cached_at);
+  if (!Number.isFinite(cachedAtMs)) return null;
+  if (cachedAtMs > nowMs + 60_000) return null;
+  if (nowMs - cachedAtMs > CLAUDE_LIMITS_CACHE_MAX_AGE_MS) return null;
+
+  const cached = {
+    configured: true,
+    error: null,
+    five_hour: isClaudeCacheWindowUsable(raw?.five_hour, { nowMs }) ? raw.five_hour : null,
+    seven_day: isClaudeCacheWindowUsable(raw?.seven_day, { nowMs }) ? raw.seven_day : null,
+    seven_day_opus: isClaudeCacheWindowUsable(raw?.seven_day_opus, { nowMs }) ? raw.seven_day_opus : null,
+    extra_usage: raw?.extra_usage ?? null,
+    stale: true,
+    cached_at: raw.cached_at,
+  };
+  return hasClaudeWindow(cached) ? cached : null;
+}
+
+function readClaudeLimitsCache({ home, nowMs = Date.now() } = {}) {
+  const cachePath = resolveClaudeLimitsCachePath({ home });
+  try {
+    const parsed = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+    return normalizeClaudeCachedLimits(parsed?.claude, { nowMs });
+  } catch (_error) {
+    return null;
+  }
+}
+
+function writeClaudeLimitsCache(limits, { home, nowMs = Date.now() } = {}) {
+  if (!limits?.configured || limits.error || !hasClaudeWindow(limits)) return;
+  const cachePath = resolveClaudeLimitsCachePath({ home });
+  const payload = {
+    claude: {
+      five_hour: limits.five_hour || null,
+      seven_day: limits.seven_day || null,
+      seven_day_opus: limits.seven_day_opus || null,
+      extra_usage: limits.extra_usage || null,
+      cached_at: new Date(nowMs).toISOString(),
+    },
+  };
+  try {
+    fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+    const tmpPath = `${cachePath}.${process.pid}.tmp`;
+    fs.writeFileSync(tmpPath, JSON.stringify(payload, null, 2), { encoding: "utf8", mode: 0o600 });
+    fs.renameSync(tmpPath, cachePath);
+  } catch (_error) {}
+}
+
 function resolveLsofBinary({ commandRunner } = {}) {
   for (const candidate of ["/usr/sbin/lsof", "/usr/bin/lsof"]) {
     if (fs.existsSync(candidate)) return candidate;
@@ -1734,7 +1807,12 @@ async function getUsageLimits({
   if (!claudeToken) {
     claude = { configured: false };
   } else if (!claudeResult || claudeResult.status === "rejected") {
-    claude = { configured: true, error: claudeResult?.reason?.message || "Unknown error" };
+    // Live fetch failed (e.g. a transient 429 against the OAuth usage endpoint). Serve the
+    // last successful read so the bars stay visible; only show the red error if there's no
+    // usable cached fallback.
+    claude =
+      readClaudeLimitsCache({ home, nowMs })
+      || { configured: true, error: claudeResult?.reason?.message || "Unknown error" };
   } else {
     claude = {
       configured: true,
@@ -1744,6 +1822,7 @@ async function getUsageLimits({
       seven_day_opus: claudeResult.value.seven_day_opus,
       extra_usage: claudeResult.value.extra_usage,
     };
+    writeClaudeLimitsCache(claude, { home, nowMs });
   }
 
   let codex;

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -1323,3 +1323,137 @@ describe("getUsageLimits plan_label", () => {
     }
   });
 });
+
+describe("getUsageLimits Claude stale fallback", () => {
+  const FUTURE_RESET = "2099-01-01T00:00:00.000Z";
+
+  function makeClaudeHome(tmp) {
+    const claudeDir = path.join(tmp, ".claude");
+    fs.mkdirSync(claudeDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(claudeDir, ".credentials.json"),
+      JSON.stringify({ claudeAiOauth: { accessToken: "claude-token" } }),
+    );
+  }
+
+  function runLimits(tmp, claudeResponder) {
+    return getUsageLimits({
+      home: tmp,
+      platform: "linux",
+      providerTimeoutMs: 1000,
+      securityRunner() {
+        return { status: 1, stdout: "" };
+      },
+      commandRunner() {
+        return { status: 1, stdout: "" };
+      },
+      fetchImpl(url) {
+        if (url === "https://api.anthropic.com/api/oauth/usage") return claudeResponder();
+        return new Promise(() => {});
+      },
+    });
+  }
+
+  it("serves the last successful read when a later fetch is rate limited", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-stale-"));
+    try {
+      makeClaudeHome(tmp);
+
+      const ok = await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            five_hour: { utilization: 11, resets_at: FUTURE_RESET },
+            seven_day: { utilization: 81, resets_at: FUTURE_RESET },
+            seven_day_opus: null,
+          }),
+        }),
+      );
+      assert.equal(ok.claude.error, null);
+      assert.equal(ok.claude.five_hour.utilization, 11);
+      assert.notEqual(ok.claude.stale, true);
+
+      // Drop the in-memory cache so the next call actually re-fetches and hits the 429.
+      resetUsageLimitsCache();
+
+      const limited = await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: { get: () => null },
+        }),
+      );
+      // Bars stay visible from disk cache instead of flipping to a red error.
+      assert.equal(limited.claude.configured, true);
+      assert.equal(limited.claude.error, null);
+      assert.equal(limited.claude.stale, true);
+      assert.equal(limited.claude.five_hour.utilization, 11);
+      assert.equal(limited.claude.seven_day.utilization, 81);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("surfaces the error when a fetch fails and there is no cached fallback", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-nocache-"));
+    try {
+      makeClaudeHome(tmp);
+
+      const limited = await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: { get: () => null },
+        }),
+      );
+      assert.equal(limited.claude.configured, true);
+      assert.match(limited.claude.error, /rate limited \(429\)/);
+      assert.notEqual(limited.claude.stale, true);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("drops cached windows whose reset has already passed", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-expired-"));
+    try {
+      makeClaudeHome(tmp);
+
+      const ok = await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            five_hour: { utilization: 50, resets_at: "2000-01-01T00:00:00.000Z" },
+            seven_day: { utilization: 81, resets_at: FUTURE_RESET },
+            seven_day_opus: null,
+          }),
+        }),
+      );
+      assert.equal(ok.claude.error, null);
+
+      resetUsageLimitsCache();
+
+      const limited = await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: { get: () => null },
+        }),
+      );
+      assert.equal(limited.claude.stale, true);
+      // Expired 5h window is dropped; the still-valid 7d window survives.
+      assert.equal(limited.claude.five_hour, null);
+      assert.equal(limited.claude.seven_day.utilization, 81);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/usage-limits.test.js
+++ b/test/usage-limits.test.js
@@ -1419,6 +1419,76 @@ describe("getUsageLimits Claude stale fallback", () => {
     }
   });
 
+  it("records a cooldown on 429 and stops calling the endpoint until it expires", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-cooldown-"));
+    try {
+      makeClaudeHome(tmp);
+
+      let claudeCalls = 0;
+      const responder = () => {
+        claudeCalls += 1;
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: { get: (h) => (h === "retry-after" ? "600" : null) },
+        });
+      };
+
+      const first = await runLimits(tmp, responder);
+      assert.equal(claudeCalls, 1);
+      assert.match(first.claude.error, /retry in ~10m/);
+
+      // Cooldown is active — the next call must not touch the endpoint again.
+      resetUsageLimitsCache();
+      const second = await runLimits(tmp, responder);
+      assert.equal(claudeCalls, 1, "endpoint must not be called again during cooldown");
+      assert.match(second.claude.error, /retry in ~\d+m/);
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("clears the cooldown and resumes once a fetch succeeds", async () => {
+    resetUsageLimitsCache();
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-recover-"));
+    try {
+      makeClaudeHome(tmp);
+
+      await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: { get: (h) => (h === "retry-after" ? "600" : null) },
+        }),
+      );
+      const cooldownPath = path.join(tmp, ".tokentracker", "tracker", "claude-usage-rate-limit.json");
+      assert.ok(fs.existsSync(cooldownPath), "cooldown file should be written on 429");
+
+      // A test can't wait out a 10m cooldown, so clear it to simulate expiry, then succeed.
+      fs.unlinkSync(cooldownPath);
+      resetUsageLimitsCache();
+      const ok = await runLimits(tmp, () =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({
+            five_hour: { utilization: 5, resets_at: FUTURE_RESET },
+            seven_day: { utilization: 9, resets_at: FUTURE_RESET },
+            seven_day_opus: null,
+          }),
+        }),
+      );
+      assert.equal(ok.claude.error, null);
+      assert.equal(ok.claude.five_hour.utilization, 5);
+      assert.equal(fs.existsSync(cooldownPath), false, "cooldown file should be cleared on success");
+    } finally {
+      resetUsageLimitsCache();
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("drops cached windows whose reset has already passed", async () => {
     resetUsageLimitsCache();
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-limits-claude-expired-"));


### PR DESCRIPTION
## Problem

The Claude card in the usage-limits panel was frequently stuck on `Error: Claude API rate limited (429) — wait ~1 minute and refresh.`

Root cause (verified against the live endpoint): `GET https://api.anthropic.com/api/oauth/usage` is shared by the CLI, the menu bar app's embedded server, **and Claude Code itself** — all using the same OAuth token. When the limit trips it returns `429` with a long `retry-after` (observed **~22 minutes**, not "~1 minute"). Every dashboard navigation forced a fresh upstream call, and every restart immediately re-hit the endpoint — which *renews* the penalty instead of letting it drain. There was no fallback, so a single failure blanked the bars.

## Changes

Three independent commits:

1. **`serve cached Claude usage when the API rate-limits`** — persist the last successful read to a disk cache (separate file from Antigravity's, whose writer rewrites the whole file). On a failed fetch, serve the cached read (marked `stale`, with already-expired windows dropped) so the bars stay visible; the error only surfaces when there's no usable fallback.

2. **`read server cache on mount instead of forcing a refresh`** — the Limits page no longer forces a live upstream call on every navigation; the mount fetch reads the server's cache (in-memory + disk-backed). Only the manual refresh path still forces upstream.

3. **`back off and respect retry-after when Claude usage rate-limits`** — on a 429, persist a cooldown (real `retry-after`, capped at 60m) to a shared file under the tracker dir and **skip the upstream call until it expires**, so every surface stops hammering and the limit can drain. Serve cached data while cooling down, else an accurate `retry in ~Nm` message. Clear the cooldown on the next success.

## Verification

- `node --test test/usage-limits.test.js` — 46 pass (new tests: stale fallback served, error-when-no-cache, cooldown recorded + skips endpoint, cooldown cleared on success, expired windows dropped).
- Dashboard vitest (hook + LimitsPage) — 8 pass; `npm run dashboard:build` ✓; `npm run validate:guardrails` ✓.
- Confirmed live: 429 with `retry-after` → accurate `retry in ~17m` + cooldown written; a second call did **not** touch the endpoint; on recovery the success cache is written and the cooldown auto-cleared.

## Notes

- `src/` + `dashboard/` scope → release-eligible (npm + DMG + Windows). The shared cooldown file under `~/.tokentracker/tracker/` lets the CLI and the app's embedded server coordinate once both run this code.
- Expired-token (`401`) handling is unchanged by design — that requires the user to re-auth via Claude Code; auto-refresh was deliberately avoided to not risk desyncing Claude Code's own credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced rate limit handling with persistent caching and cooldown tracking.
  * Reduces unnecessary upstream API calls during navigation.
  * Serves previously cached data during rate-limited periods instead of failing.

* **Tests**
  * Added comprehensive test coverage for rate limit scenarios and cache fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->