### PR TITLE
feat: show cross-device aggregate in native popover, aligned with dashboard

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -10,6 +10,13 @@ actor APIClient {
     private let session: URLSession
     private let decoder: JSONDecoder
 
+    /// Whether the most recent account-eligible fetch returned cross-device
+    /// ("account view") data rather than local single-machine data. Mirrors the
+    /// dashboard: the local server serves the cross-device aggregate only when
+    /// the user is signed in and cloud sync is on, and reports which it served
+    /// via the `X-TokenTracker-Account-View` response header.
+    private(set) var accountViewActive: Bool = false
+
     private init() {
         let config = URLSessionConfiguration.default
         config.timeoutIntervalForRequest = 10
@@ -24,33 +31,34 @@ actor APIClient {
     // MARK: - Public API
 
 	func fetchSummary(from: String, to: String) async throws -> UsageSummaryResponse {
-		try await fetch("/functions/tokentracker-usage-summary", queryItems: withTimeZoneQueryItems([
+		try await fetch("/functions/tokentracker-usage-summary", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
 	}
 
 	func fetchDaily(from: String, to: String) async throws -> DailyUsageResponse {
-		try await fetch("/functions/tokentracker-usage-daily", queryItems: withTimeZoneQueryItems([
+		try await fetch("/functions/tokentracker-usage-daily", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
 	}
 
 	func fetchHeatmap(weeks: Int = 52) async throws -> HeatmapResponse {
-		try await fetch("/functions/tokentracker-usage-heatmap", queryItems: withTimeZoneQueryItems([
+		try await fetch("/functions/tokentracker-usage-heatmap", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "weeks", value: String(weeks))
 		]))
 	}
 
 	func fetchModelBreakdown(from: String, to: String) async throws -> ModelBreakdownResponse {
-		try await fetch("/functions/tokentracker-usage-model-breakdown", queryItems: withTimeZoneQueryItems([
+		try await fetch("/functions/tokentracker-usage-model-breakdown", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
 	}
 
 	func fetchProjectUsage(from: String, to: String) async throws -> ProjectUsageResponse {
+		// Project breakdown has no cross-device aggregate — stays local-only.
 		try await fetch("/functions/tokentracker-project-usage-summary", queryItems: withTimeZoneQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
@@ -58,14 +66,14 @@ actor APIClient {
 	}
 
 	func fetchMonthly(from: String, to: String) async throws -> MonthlyUsageResponse {
-		try await fetch("/functions/tokentracker-usage-monthly", queryItems: withTimeZoneQueryItems([
+		try await fetch("/functions/tokentracker-usage-monthly", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "from", value: from),
 			URLQueryItem(name: "to", value: to)
 		]))
 	}
 
 	func fetchHourly(day: String) async throws -> HourlyUsageResponse {
-		try await fetch("/functions/tokentracker-usage-hourly", queryItems: withTimeZoneQueryItems([
+		try await fetch("/functions/tokentracker-usage-hourly", queryItems: withAccountQueryItems([
 			URLQueryItem(name: "day", value: day)
 		]))
 	}
@@ -105,6 +113,13 @@ actor APIClient {
         }
         let (data, response) = try await session.data(from: url)
         try validateResponse(response)
+        // Account-eligible endpoints tag whether the server served cross-device
+        // (account) data or fell back to local single-machine data. Other
+        // endpoints omit the header, so only update when it's present.
+        if let httpResponse = response as? HTTPURLResponse,
+           let raw = httpResponse.value(forHTTPHeaderField: "X-TokenTracker-Account-View") {
+            accountViewActive = (raw == "1")
+        }
         return try decoder.decode(T.self, from: data)
     }
 
@@ -113,6 +128,14 @@ actor APIClient {
 			URLQueryItem(name: "tz", value: DateHelpers.currentTimeZoneIdentifier),
 			URLQueryItem(name: "tz_offset_minutes", value: String(DateHelpers.currentUTCOffsetMinutes()))
 		]
+	}
+
+	/// Cross-device "account view": ask the local server for the same aggregate
+	/// the dashboard shows. The server returns local single-machine data instead
+	/// (X-TokenTracker-Account-View: 0) when the user isn't signed in or cloud
+	/// sync is off, so this is always safe to request.
+	private func withAccountQueryItems(_ items: [URLQueryItem]) -> [URLQueryItem] {
+		withTimeZoneQueryItems(items) + [URLQueryItem(name: "account", value: "1")]
 	}
 
     private func post<T: Decodable>(_ path: String) async throws -> T {

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -39,6 +39,10 @@ internal sealed class UsagePoller : IDisposable
     private static readonly HttpClient Http =
         new(new HttpClientHandler { UseProxy = false }) { Timeout = TimeSpan.FromSeconds(6) };
     private static readonly IReadOnlyList<TopModelStat> NoModels = Array.Empty<TopModelStat>();
+    // Request the cross-device ("account") aggregate; the local server decides
+    // whether to serve it (signed in + cloud sync on) or local data, keeping the
+    // tray/pet figures aligned with the dashboard.
+    private const string AccountQuery = "&account=1";
     private readonly Func<string> _baseUrl;
     private CancellationTokenSource? _cts;
 
@@ -88,8 +92,12 @@ internal sealed class UsagePoller : IDisposable
             var today = DateTime.Now.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var tzQuery = TimeZoneQuery();
 
+            // account=1 → the server serves the same cross-device aggregate the
+            // dashboard shows when the user is signed in with cloud sync on, and
+            // otherwise falls back to local single-machine data. Same response
+            // schema either way, so parsing below is unchanged.
             var summaryUrl = $"{_baseUrl()}/functions/tokentracker-usage-summary"
-                             + $"?from={today}&to={today}{tzQuery}";
+                             + $"?from={today}&to={today}{tzQuery}{AccountQuery}";
 
             using var resp = await Http.GetAsync(summaryUrl);
             if (!resp.IsSuccessStatusCode) return null;
@@ -151,7 +159,7 @@ internal sealed class UsagePoller : IDisposable
     {
         try
         {
-            var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}";
+            var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return (0, 0);
             await using var stream = await resp.Content.ReadAsStreamAsync();
@@ -174,7 +182,7 @@ internal sealed class UsagePoller : IDisposable
         {
             var from = DateTime.Now.AddDays(-29).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var url = $"{_baseUrl()}/functions/tokentracker-usage-model-breakdown"
-                      + $"?from={from}&to={today}{tzQuery}";
+                      + $"?from={from}&to={today}{tzQuery}{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return NoModels;
             await using var stream = await resp.Content.ReadAsStreamAsync();

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -39,10 +39,10 @@ internal sealed class UsagePoller : IDisposable
     private static readonly HttpClient Http =
         new(new HttpClientHandler { UseProxy = false }) { Timeout = TimeSpan.FromSeconds(6) };
     private static readonly IReadOnlyList<TopModelStat> NoModels = Array.Empty<TopModelStat>();
-    // Request the cross-device ("account") aggregate; the local server decides
+    // Cross-device ("account") aggregate request flag; the local server decides
     // whether to serve it (signed in + cloud sync on) or local data, keeping the
-    // tray/pet figures aligned with the dashboard.
-    private const string AccountQuery = "&account=1";
+    // tray/pet figures aligned with the dashboard. Joined with an explicit '&'.
+    private const string AccountQuery = "account=1";
     private readonly Func<string> _baseUrl;
     private CancellationTokenSource? _cts;
 
@@ -105,7 +105,7 @@ internal sealed class UsagePoller : IDisposable
             // otherwise falls back to local single-machine data. Same response
             // schema either way, so parsing below is unchanged.
             var summaryUrl = $"{_baseUrl()}/functions/tokentracker-usage-summary"
-                             + $"?from={today}&to={today}{tzQuery}{AccountQuery}";
+                             + $"?from={today}&to={today}{tzQuery}&{AccountQuery}";
 
             using var resp = await Http.GetAsync(summaryUrl);
             if (!resp.IsSuccessStatusCode) return null;
@@ -172,7 +172,7 @@ internal sealed class UsagePoller : IDisposable
     {
         try
         {
-            var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}{AccountQuery}";
+            var url = $"{_baseUrl()}/functions/tokentracker-usage-heatmap?weeks=52{tzQuery}&{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return (0, 0);
             await using var stream = await resp.Content.ReadAsStreamAsync();
@@ -195,7 +195,7 @@ internal sealed class UsagePoller : IDisposable
         {
             var from = DateTime.Now.AddDays(-29).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
             var url = $"{_baseUrl()}/functions/tokentracker-usage-model-breakdown"
-                      + $"?from={from}&to={today}{tzQuery}{AccountQuery}";
+                      + $"?from={from}&to={today}{tzQuery}&{AccountQuery}";
             using var resp = await Http.GetAsync(url);
             if (!resp.IsSuccessStatusCode) return NoModels;
             await using var stream = await resp.Content.ReadAsStreamAsync();

--- a/TokenTrackerWin/UsagePoller.cs
+++ b/TokenTrackerWin/UsagePoller.cs
@@ -53,6 +53,14 @@ internal sealed class UsagePoller : IDisposable
     /// </summary>
     public volatile bool IncludeRichStats;
 
+    /// <summary>
+    /// Whether the most recent summary fetch returned cross-device ("account view")
+    /// data rather than local single-machine data. Mirrors the macOS APIClient's
+    /// <c>accountViewActive</c>; driven by the <c>X-TokenTracker-Account-View</c>
+    /// response header the local server sets.
+    /// </summary>
+    public volatile bool AccountViewActive;
+
     /// <summary>Raised on the thread-pool with fresh stats. UI must marshal to the UI thread.</summary>
     public event Action<UsageStats>? StatsUpdated;
 
@@ -101,6 +109,11 @@ internal sealed class UsagePoller : IDisposable
 
             using var resp = await Http.GetAsync(summaryUrl);
             if (!resp.IsSuccessStatusCode) return null;
+
+            // Track whether the server served the cross-device aggregate or fell
+            // back to local data, mirroring the macOS client.
+            if (resp.Headers.TryGetValues("X-TokenTracker-Account-View", out var accountViewValues))
+                AccountViewActive = accountViewValues.FirstOrDefault() == "1";
 
             await using var stream = await resp.Content.ReadAsStreamAsync();
             using var doc = await JsonDocument.ParseAsync(stream);

--- a/dashboard/src/contexts/AccountViewContext.jsx
+++ b/dashboard/src/contexts/AccountViewContext.jsx
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 import { useInsforgeAuth } from "./InsforgeAuthContext.jsx";
-import { getCloudSyncEnabled, isLocalDashboardHost } from "../lib/cloud-sync-prefs";
+import { getCloudSyncEnabled, isLocalDashboardHost, syncCloudSyncPrefToLocalServer } from "../lib/cloud-sync-prefs";
 
 /**
  * AccountViewContext decides whether the dashboard reads aggregated cloud
@@ -40,6 +40,9 @@ export function AccountViewProvider({ children }) {
 
   useEffect(() => {
     setLocalHost(isLocalDashboardHost());
+    // Mirror the persisted cloud-sync toggle to the local CLI server so the
+    // native popover's cross-device view tracks the same preference.
+    syncCloudSyncPrefToLocalServer();
   }, []);
 
   useEffect(() => {

--- a/dashboard/src/lib/cloud-sync-prefs.ts
+++ b/dashboard/src/lib/cloud-sync-prefs.ts
@@ -20,7 +20,10 @@ function clearLegacyStoredDeviceSession(): void {
 export function isLocalDashboardHost(): boolean {
   if (typeof window === "undefined") return false;
   const h = window.location.hostname;
-  return h === "localhost" || h === "127.0.0.1";
+  // Mirror src/lib/local-api.js loopback handling (which includes IPv6) so the
+  // dashboard ↔ local-server contract — cloud-sync mirror, account view — holds
+  // on http://[::1] too. Browsers report IPv6 hostnames without brackets.
+  return h === "localhost" || h === "127.0.0.1" || h === "::1" || h === "[::1]";
 }
 
 /** 默认关闭：需用户手动开启后才同步到云端 */

--- a/dashboard/src/lib/cloud-sync-prefs.ts
+++ b/dashboard/src/lib/cloud-sync-prefs.ts
@@ -40,6 +40,11 @@ export function setCloudSyncEnabled(enabled: boolean): void {
   } catch {
     /* ignore */
   }
+  // Mirror the toggle to the local CLI server (best-effort, localhost only) so
+  // the auth-unaware native popover can gate its cross-device "account view" on
+  // the same preference. The dashboard remains the source of truth; this is a
+  // one-way push and never blocks the toggle.
+  mirrorCloudSyncPrefToLocalServer(enabled);
   // Notify the SAME tab. AccountViewContext listens for this event (and the
   // cross-tab `storage` event) to recompute accountView. Without it, toggling
   // cloud sync on localhost would not switch the dashboard to the cross-device
@@ -53,6 +58,32 @@ export function setCloudSyncEnabled(enabled: boolean): void {
   } catch {
     /* ignore */
   }
+}
+
+async function mirrorCloudSyncPrefToLocalServer(enabled: boolean): Promise<void> {
+  if (!isLocalDashboardHost()) return;
+  try {
+    const { getLocalApiAuthHeaders } = await import("./local-api-auth");
+    const authHeaders = await getLocalApiAuthHeaders();
+    await fetch("/functions/tokentracker-cloud-sync-pref", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json", ...authHeaders },
+      cache: "no-store",
+      body: JSON.stringify({ enabled }),
+    });
+  } catch {
+    /* best-effort: popover falls back to local data if the mirror is stale */
+  }
+}
+
+/**
+ * Push the dashboard's current cloud-sync preference to the local CLI server
+ * once on load, so the native popover's account view reflects the persisted
+ * toggle even when the user never re-toggles it this session. No-op off
+ * localhost. Best-effort.
+ */
+export function syncCloudSyncPrefToLocalServer(): void {
+  void mirrorCloudSyncPrefToLocalServer(getCloudSyncEnabled());
 }
 
 export function getStoredDeviceSession(): CloudDeviceSession | null {

--- a/src/lib/cloud-account.js
+++ b/src/lib/cloud-account.js
@@ -1,0 +1,214 @@
+"use strict";
+
+// Account-aggregated (cross-device) cloud reads for the local server.
+//
+// The native menu-bar / tray popover talks only to the local CLI server and
+// knows nothing about OAuth/JWT. To make the popover show the SAME cross-device
+// totals the dashboard shows in "account view", the local server mints a
+// short-lived access token from the InsForge refresh token it already relays
+// (see local-api.js cookie relay) and proxies the `tokentracker-account-*` edge
+// functions. Those functions mirror the local `tokentracker-usage-*` response
+// schema exactly, so the popover renders the cloud payload unchanged.
+
+const { DEFAULT_BASE_URL, DEFAULT_ANON_KEY } = require("./runtime-config");
+
+// usage-* (local CLI) → account-* (cloud) slug map. Only these have a
+// cross-device cloud equivalent; project-usage / usage-limits / category
+// breakdown remain local-only and are intentionally absent here.
+const USAGE_TO_ACCOUNT_SLUG = {
+  "tokentracker-usage-summary": "tokentracker-account-summary",
+  "tokentracker-usage-daily": "tokentracker-account-daily",
+  "tokentracker-usage-hourly": "tokentracker-account-hourly",
+  "tokentracker-usage-monthly": "tokentracker-account-monthly",
+  "tokentracker-usage-heatmap": "tokentracker-account-heatmap",
+  "tokentracker-usage-model-breakdown": "tokentracker-account-model-breakdown",
+};
+
+function accountSlugFor(usageSlug) {
+  return USAGE_TO_ACCOUNT_SLUG[usageSlug] || null;
+}
+
+// Mirror of dashboard/src/contexts/InsforgeAuthContext.jsx
+// `accessTokenFromRefreshPayload`: the refresh response may put the token at the
+// top level or nested under `session`, in camelCase or snake_case.
+function accessTokenFromRefreshPayload(data) {
+  if (!data || typeof data !== "object") return null;
+  const session = data.session && typeof data.session === "object" ? data.session : null;
+  const raw =
+    (typeof data.accessToken === "string" && data.accessToken) ||
+    (typeof data.access_token === "string" && data.access_token) ||
+    (session && typeof session.accessToken === "string" && session.accessToken) ||
+    (session && typeof session.access_token === "string" && session.access_token) ||
+    null;
+  return raw && raw.length > 0 ? raw : null;
+}
+
+function refreshTokenFromRefreshPayload(data) {
+  if (!data || typeof data !== "object") return null;
+  const session = data.session && typeof data.session === "object" ? data.session : null;
+  const raw =
+    (typeof data.refreshToken === "string" && data.refreshToken) ||
+    (typeof data.refresh_token === "string" && data.refresh_token) ||
+    (session && typeof session.refreshToken === "string" && session.refreshToken) ||
+    (session && typeof session.refresh_token === "string" && session.refresh_token) ||
+    null;
+  return raw && raw.length > 0 ? raw : null;
+}
+
+function decodeJwtExpMs(token) {
+  try {
+    const part = String(token || "").split(".")[1];
+    if (!part) return 0;
+    const json = Buffer.from(part.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    const payload = JSON.parse(json);
+    if (payload && Number.isFinite(payload.exp)) return payload.exp * 1000;
+  } catch {
+    /* ignore */
+  }
+  return 0;
+}
+
+// Module-level access-token cache, keyed by the refresh token that produced it.
+// The popover polls frequently, so caching avoids hammering /api/auth/refresh.
+let tokenCache = { refreshToken: null, accessToken: null, expMs: 0 };
+
+function __resetCloudAccountCacheForTests() {
+  tokenCache = { refreshToken: null, accessToken: null, expMs: 0 };
+}
+
+/**
+ * Mint (or reuse a cached) InsForge access token from a refresh token.
+ * @returns {Promise<{accessToken: string, refreshToken: string|null}|null>}
+ *   null when no refresh token is available or the refresh failed.
+ */
+async function mintAccessToken({
+  baseUrl,
+  anonKey,
+  refreshToken,
+  fetchImpl = fetch,
+  now = Date.now,
+  skewMs = 60_000,
+} = {}) {
+  if (!refreshToken) return null;
+  if (
+    tokenCache.refreshToken === refreshToken &&
+    tokenCache.accessToken &&
+    tokenCache.expMs - skewMs > now()
+  ) {
+    return { accessToken: tokenCache.accessToken, refreshToken: null };
+  }
+
+  const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+  const headers = { "Content-Type": "application/json", Accept: "application/json" };
+  if (anonKey) headers.apikey = anonKey;
+
+  let res;
+  try {
+    res = await fetchImpl(`${root}/api/auth/refresh?client_type=mobile`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ refresh_token: refreshToken }),
+    });
+  } catch {
+    return null;
+  }
+  if (!res || !res.ok) return null;
+
+  let data = null;
+  try {
+    data = await res.json();
+  } catch {
+    return null;
+  }
+
+  const accessToken = accessTokenFromRefreshPayload(data);
+  if (!accessToken) return null;
+
+  const expMs = decodeJwtExpMs(accessToken) || now() + 10 * 60_000;
+  tokenCache = { refreshToken, accessToken, expMs };
+
+  const rotated = refreshTokenFromRefreshPayload(data);
+  return {
+    accessToken,
+    refreshToken: rotated && rotated !== refreshToken ? rotated : null,
+  };
+}
+
+/**
+ * GET a `tokentracker-account-*` edge function, forwarding the popover's query
+ * params (minus `account`/`scope`, which are local-only routing knobs).
+ */
+async function fetchAccountFunction({
+  baseUrl,
+  anonKey,
+  accessToken,
+  slug,
+  searchParams,
+  fetchImpl = fetch,
+} = {}) {
+  const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+  const url = new URL(`${root}/functions/${slug}`);
+  if (searchParams && typeof searchParams.entries === "function") {
+    for (const [key, value] of searchParams.entries()) {
+      if (key === "account" || key === "scope") continue;
+      if (value != null && value !== "") url.searchParams.set(key, String(value));
+    }
+  }
+  const headers = { Accept: "application/json", Authorization: `Bearer ${accessToken}` };
+  if (anonKey) headers.apikey = anonKey;
+
+  const res = await fetchImpl(url.toString(), { method: "GET", headers });
+  if (!res || !res.ok) {
+    const err = new Error(`Account fetch failed with HTTP ${res ? res.status : "?"}`);
+    err.status = res ? res.status : 0;
+    throw err;
+  }
+  return res.json();
+}
+
+/**
+ * High-level helper used by local-api: mint a token from `refreshToken`, then
+ * fetch the cross-device aggregate matching `usageSlug`.
+ *
+ * @returns {Promise<{data: any, rotatedRefreshToken: string|null}|null>}
+ *   null when there is no cloud equivalent, no refresh token, or the refresh
+ *   failed. Throws only when the account endpoint itself errors (so callers can
+ *   distinguish "not signed in" from "cloud request failed").
+ */
+async function fetchAccountUsage({
+  usageSlug,
+  searchParams,
+  baseUrl = DEFAULT_BASE_URL,
+  anonKey = DEFAULT_ANON_KEY,
+  refreshToken,
+  fetchImpl = fetch,
+  now = Date.now,
+} = {}) {
+  const slug = accountSlugFor(usageSlug);
+  if (!slug) return null;
+
+  const minted = await mintAccessToken({ baseUrl, anonKey, refreshToken, fetchImpl, now });
+  if (!minted) return null;
+
+  const data = await fetchAccountFunction({
+    baseUrl,
+    anonKey,
+    accessToken: minted.accessToken,
+    slug,
+    searchParams,
+    fetchImpl,
+  });
+  return { data, rotatedRefreshToken: minted.refreshToken };
+}
+
+module.exports = {
+  USAGE_TO_ACCOUNT_SLUG,
+  accountSlugFor,
+  accessTokenFromRefreshPayload,
+  refreshTokenFromRefreshPayload,
+  decodeJwtExpMs,
+  mintAccessToken,
+  fetchAccountFunction,
+  fetchAccountUsage,
+  __resetCloudAccountCacheForTests,
+};

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -10,6 +10,7 @@ const {
   listExcludedSources,
   normalizeUsageScope,
 } = require("./source-metadata");
+const { accountSlugFor, fetchAccountUsage } = require("./cloud-account");
 
 const SYNC_TIMEOUT_MS = 120_000;
 const TRACKER_BIN = path.resolve(__dirname, "../../bin/tracker.js");
@@ -936,6 +937,87 @@ function createLocalApiHandler({ queuePath }) {
     if (changed) persistRelayCookies();
   }
 
+  // --- Account (cross-device) view for the native popover ---------------
+  // The popover follows the dashboard: it shows aggregated cross-device data
+  // only when the user is signed in (a relayed refresh token exists) AND cloud
+  // sync is on. Cloud sync is a dashboard (WebView) preference persisted in
+  // localStorage; the dashboard mirrors it here via POST
+  // /functions/tokentracker-cloud-sync-pref so the auth-unaware popover can key
+  // off the same flag. Defaults OFF, exactly like the dashboard toggle.
+  const cloudSyncPrefPath = path.join(trackerDataDir, "cloud-sync-pref.json");
+  let cloudSyncPrefCache;
+  function getCloudSyncPref() {
+    if (cloudSyncPrefCache === undefined) {
+      try {
+        cloudSyncPrefCache = JSON.parse(fs.readFileSync(cloudSyncPrefPath, "utf8"))?.enabled === true;
+      } catch {
+        cloudSyncPrefCache = false;
+      }
+    }
+    return cloudSyncPrefCache;
+  }
+  function setCloudSyncPref(enabled) {
+    cloudSyncPrefCache = Boolean(enabled);
+    try {
+      if (!fs.existsSync(trackerDataDir)) fs.mkdirSync(trackerDataDir, { recursive: true });
+      fs.writeFileSync(
+        cloudSyncPrefPath,
+        JSON.stringify({ enabled: cloudSyncPrefCache, updatedAt: new Date().toISOString() }),
+        { encoding: "utf8", mode: 0o600 },
+      );
+    } catch (e) {
+      console.error("[LocalAPI] Failed to persist cloud sync pref:", e.message);
+    }
+  }
+
+  function getRefreshTokenForCloud() {
+    return getRelayCookieValue("insforge_refresh_token", { decode: true });
+  }
+  function setRelayRefreshToken(token) {
+    if (!token || typeof token !== "string") return;
+    const cookie = `insforge_refresh_token=${encodeURIComponent(token)}; Path=/; HttpOnly; SameSite=Lax`;
+    if (relayCookies.get("insforge_refresh_token") !== cookie) {
+      relayCookies.set("insforge_refresh_token", cookie);
+      persistRelayCookies();
+    }
+  }
+
+  // Returns "served" when the cross-device aggregate was written to `res`, or
+  // "fallthrough" when the caller should serve the local single-machine data.
+  // Any failure (not signed in, cloud sync off, network/auth error) falls
+  // through so the popover always renders something.
+  async function tryServeAccountView(usageSlug, url, res) {
+    if (!getCloudSyncPref()) return "fallthrough";
+    const refreshToken = getRefreshTokenForCloud();
+    if (!refreshToken) return "fallthrough";
+    const runtime = resolveRuntimeConfig();
+    try {
+      const out = await fetchAccountUsage({
+        usageSlug,
+        searchParams: url.searchParams,
+        baseUrl: runtime.baseUrl || DEFAULT_BASE_URL,
+        anonKey: runtime.anonKey,
+        refreshToken,
+      });
+      if (!out || out.data == null) return "fallthrough";
+      if (out.rotatedRefreshToken) setRelayRefreshToken(out.rotatedRefreshToken);
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-TokenTracker-Account-View": "1",
+      });
+      res.end(JSON.stringify(out.data));
+      return "served";
+    } catch (e) {
+      // Signed in + cloud sync on, but the cloud read failed (offline, token
+      // rejected, edge error). Fall back to local data rather than erroring.
+      if (resolveRuntimeConfig().debug) {
+        console.warn(`[LocalAPI] account view fallback for ${usageSlug}:`, e?.message || e);
+      }
+      return "fallthrough";
+    }
+  }
+
   function normalizeCookieHeader(value) {
     if (Array.isArray(value)) return value.filter(Boolean).join("; ");
     return typeof value === "string" ? value : "";
@@ -1346,6 +1428,20 @@ function createLocalApiHandler({ queuePath }) {
       return true;
     }
 
+    // --- account (cross-device) view proxy for the native popover ---
+    // When ?account=1 and the user is signed in with cloud sync on, serve the
+    // same cross-device aggregate the dashboard shows; otherwise tag the
+    // response (X-TokenTracker-Account-View: 0) so the popover knows it got
+    // local single-machine data, and fall through to the local handler below.
+    if (url.searchParams.get("account") === "1") {
+      const usageSlug = p.startsWith("/functions/") ? p.slice("/functions/".length) : "";
+      if (accountSlugFor(usageSlug)) {
+        const result = await tryServeAccountView(usageSlug, url, res);
+        if (result === "served") return true;
+        res.setHeader("X-TokenTracker-Account-View", "0");
+      }
+    }
+
     // --- usage-summary ---
     if (p === "/functions/tokentracker-usage-summary") {
       const from = url.searchParams.get("from") || "";
@@ -1681,7 +1777,46 @@ function createLocalApiHandler({ queuePath }) {
         user_id: "local-user", email: "local@localhost", name: "Local User", is_public: false,
         created_at: new Date().toISOString(),
         pro: { active: true, sources: ["local"], expires_at: null, partial: false, as_of: new Date().toISOString() },
+        // Cross-device popover state: whether account aggregation can be served
+        // (signed in) and whether the dashboard's cloud-sync toggle is on.
+        account: {
+          available: Boolean(getRefreshTokenForCloud()),
+          cloud_sync_enabled: getCloudSyncPref(),
+          account_view: Boolean(getRefreshTokenForCloud()) && getCloudSyncPref(),
+        },
       });
+      return true;
+    }
+
+    // --- cloud-sync preference mirror ---
+    // The dashboard's Settings → Account → Cloud sync toggle (a WebView
+    // localStorage flag) is mirrored here so the auth-unaware native popover can
+    // gate its account (cross-device) view on the same preference.
+    if (p === "/functions/tokentracker-cloud-sync-pref") {
+      const method = String(req.method || "GET").toUpperCase();
+      if (method === "GET") {
+        json(res, {
+          enabled: getCloudSyncPref(),
+          account_available: Boolean(getRefreshTokenForCloud()),
+        });
+        return true;
+      }
+      if (method === "POST" || method === "PUT") {
+        if (!isAuthorizedLocalMutation(req)) {
+          json(res, { ok: false, error: "Unauthorized" }, 401);
+          return true;
+        }
+        let body = {};
+        try {
+          body = await readJsonBody(req);
+        } catch {
+          body = {};
+        }
+        setCloudSyncPref(Boolean(body?.enabled));
+        json(res, { ok: true, enabled: getCloudSyncPref() });
+        return true;
+      }
+      json(res, { error: "Method Not Allowed" }, 405);
       return true;
     }
 

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -1812,7 +1812,14 @@ function createLocalApiHandler({ queuePath }) {
         } catch {
           body = {};
         }
-        setCloudSyncPref(Boolean(body?.enabled));
+        // Reject malformed payloads rather than silently coercing them to a
+        // persisted `false` — this file is the shared cloud-sync preference, so
+        // a bad write would desync the popover from the dashboard.
+        if (typeof body?.enabled !== "boolean") {
+          json(res, { ok: false, error: "enabled must be a boolean" }, 400);
+          return true;
+        }
+        setCloudSyncPref(body.enabled);
         json(res, { ok: true, enabled: getCloudSyncPref() });
         return true;
       }

--- a/src/lib/runtime-config.js
+++ b/src/lib/runtime-config.js
@@ -1,6 +1,11 @@
 const DEFAULT_BASE_URL = "https://srctyff5.us-east.insforge.app";
 const DEFAULT_DASHBOARD_URL = "https://www.tokentracker.cc";
 const DEFAULT_HTTP_TIMEOUT_MS = 20_000;
+// Public InsForge anon/publishable key. Mirrors dashboard/src/lib/insforge-config.ts
+// (PROD_INSFORGE_ANON_KEY) — it is public by design (ships in the browser bundle
+// and appears in .github/workflows/*.yml). The local server needs it to call the
+// cross-device `tokentracker-account-*` edge functions on the popover's behalf.
+const DEFAULT_ANON_KEY = "ik_9f35735991b684f7cf57fa00bb4d0487";
 
 function resolveRuntimeConfig({ cli = {}, config = {}, env = process.env, defaults = {} } = {}) {
   const baseUrl = pickString(
@@ -9,6 +14,13 @@ function resolveRuntimeConfig({ cli = {}, config = {}, env = process.env, defaul
     env?.TOKENTRACKER_INSFORGE_BASE_URL,
     defaults.baseUrl,
     DEFAULT_BASE_URL,
+  );
+  const anonKey = pickString(
+    cli.anonKey,
+    config.anonKey,
+    env?.TOKENTRACKER_INSFORGE_ANON_KEY,
+    defaults.anonKey,
+    DEFAULT_ANON_KEY,
   );
   const dashboardUrl = pickString(
     cli.dashboardUrl,
@@ -42,6 +54,7 @@ function resolveRuntimeConfig({ cli = {}, config = {}, env = process.env, defaul
 
   return {
     baseUrl: baseUrl.value,
+    anonKey: anonKey.value,
     dashboardUrl: dashboardUrl.value,
     deviceToken: deviceToken.value,
     httpTimeoutMs: httpTimeoutMs.value,
@@ -49,6 +62,7 @@ function resolveRuntimeConfig({ cli = {}, config = {}, env = process.env, defaul
     autoRetryNoSpawn: autoRetryNoSpawn.value,
     sources: {
       baseUrl: baseUrl.source,
+      anonKey: anonKey.source,
       dashboardUrl: dashboardUrl.source,
       deviceToken: deviceToken.source,
       httpTimeoutMs: httpTimeoutMs.source,
@@ -116,6 +130,7 @@ function clampInt(value, min, max) {
 
 module.exports = {
   DEFAULT_BASE_URL,
+  DEFAULT_ANON_KEY,
   DEFAULT_DASHBOARD_URL,
   DEFAULT_HTTP_TIMEOUT_MS,
   resolveRuntimeConfig,

--- a/test/cloud-account.test.js
+++ b/test/cloud-account.test.js
@@ -1,0 +1,208 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { test } = require("node:test");
+
+const {
+  accountSlugFor,
+  accessTokenFromRefreshPayload,
+  refreshTokenFromRefreshPayload,
+  decodeJwtExpMs,
+  mintAccessToken,
+  fetchAccountFunction,
+  fetchAccountUsage,
+  __resetCloudAccountCacheForTests,
+} = require("../src/lib/cloud-account");
+
+function b64url(obj) {
+  return Buffer.from(JSON.stringify(obj)).toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function makeJwt({ expSeconds }) {
+  return `${b64url({ alg: "HS256", typ: "JWT" })}.${b64url({ sub: "u1", exp: expSeconds })}.sig`;
+}
+
+function jsonResponse(body, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+test("accountSlugFor maps usage slugs to account slugs, null for non-cloud", () => {
+  assert.equal(accountSlugFor("tokentracker-usage-summary"), "tokentracker-account-summary");
+  assert.equal(accountSlugFor("tokentracker-usage-model-breakdown"), "tokentracker-account-model-breakdown");
+  assert.equal(accountSlugFor("tokentracker-project-usage-summary"), null);
+  assert.equal(accountSlugFor("tokentracker-usage-limits"), null);
+});
+
+test("accessTokenFromRefreshPayload reads camel/snake, top-level and nested", () => {
+  assert.equal(accessTokenFromRefreshPayload({ accessToken: "a" }), "a");
+  assert.equal(accessTokenFromRefreshPayload({ access_token: "b" }), "b");
+  assert.equal(accessTokenFromRefreshPayload({ session: { accessToken: "c" } }), "c");
+  assert.equal(accessTokenFromRefreshPayload({ session: { access_token: "d" } }), "d");
+  assert.equal(accessTokenFromRefreshPayload({}), null);
+  assert.equal(accessTokenFromRefreshPayload(null), null);
+});
+
+test("refreshTokenFromRefreshPayload reads rotated refresh token", () => {
+  assert.equal(refreshTokenFromRefreshPayload({ refreshToken: "r1" }), "r1");
+  assert.equal(refreshTokenFromRefreshPayload({ session: { refresh_token: "r2" } }), "r2");
+  assert.equal(refreshTokenFromRefreshPayload({}), null);
+});
+
+test("decodeJwtExpMs decodes exp in ms, 0 on garbage", () => {
+  assert.equal(decodeJwtExpMs(makeJwt({ expSeconds: 1000 })), 1000 * 1000);
+  assert.equal(decodeJwtExpMs("not-a-jwt"), 0);
+  assert.equal(decodeJwtExpMs(""), 0);
+});
+
+test("mintAccessToken returns null without a refresh token", async () => {
+  __resetCloudAccountCacheForTests();
+  const out = await mintAccessToken({ refreshToken: "", fetchImpl: async () => jsonResponse({}) });
+  assert.equal(out, null);
+});
+
+test("mintAccessToken posts refresh token and returns access token", async () => {
+  __resetCloudAccountCacheForTests();
+  const calls = [];
+  const access = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  const fetchImpl = async (urlStr, opts) => {
+    calls.push({ urlStr, opts });
+    return jsonResponse({ accessToken: access });
+  };
+  const out = await mintAccessToken({
+    baseUrl: "https://cloud.example",
+    anonKey: "ik_test",
+    refreshToken: "refresh-1",
+    fetchImpl,
+  });
+  assert.equal(out.accessToken, access);
+  assert.equal(out.refreshToken, null);
+  assert.equal(calls.length, 1);
+  assert.match(calls[0].urlStr, /\/api\/auth\/refresh\?client_type=mobile$/);
+  assert.equal(calls[0].opts.headers.apikey, "ik_test");
+  assert.deepEqual(JSON.parse(calls[0].opts.body), { refresh_token: "refresh-1" });
+});
+
+test("mintAccessToken caches by refresh token and skips re-fetch until near expiry", async () => {
+  __resetCloudAccountCacheForTests();
+  let fetchCount = 0;
+  const access = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  const fetchImpl = async () => {
+    fetchCount += 1;
+    return jsonResponse({ accessToken: access });
+  };
+  const args = { baseUrl: "https://cloud.example", refreshToken: "refresh-cache", fetchImpl };
+  const a = await mintAccessToken(args);
+  const b = await mintAccessToken(args);
+  assert.equal(a.accessToken, access);
+  assert.equal(b.accessToken, access);
+  assert.equal(fetchCount, 1, "second call should hit cache");
+
+  // A different refresh token must bypass the cache.
+  await mintAccessToken({ ...args, refreshToken: "refresh-other" });
+  assert.equal(fetchCount, 2);
+});
+
+test("mintAccessToken returns null on non-ok refresh and on network error", async () => {
+  __resetCloudAccountCacheForTests();
+  assert.equal(
+    await mintAccessToken({ refreshToken: "x", fetchImpl: async () => jsonResponse({}, false, 401) }),
+    null,
+  );
+  __resetCloudAccountCacheForTests();
+  assert.equal(
+    await mintAccessToken({ refreshToken: "x", fetchImpl: async () => { throw new Error("offline"); } }),
+    null,
+  );
+});
+
+test("mintAccessToken surfaces a rotated refresh token", async () => {
+  __resetCloudAccountCacheForTests();
+  const access = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  const out = await mintAccessToken({
+    refreshToken: "old",
+    fetchImpl: async () => jsonResponse({ accessToken: access, refreshToken: "new" }),
+  });
+  assert.equal(out.refreshToken, "new");
+});
+
+test("fetchAccountFunction forwards query params except account/scope, sets auth headers", async () => {
+  const captured = {};
+  const fetchImpl = async (urlStr, opts) => {
+    captured.urlStr = urlStr;
+    captured.opts = opts;
+    return jsonResponse({ ok: 1 });
+  };
+  const searchParams = new URLSearchParams("from=2026-01-01&to=2026-01-02&tz=UTC&account=1&scope=all");
+  const body = await fetchAccountFunction({
+    baseUrl: "https://cloud.example/",
+    anonKey: "ik_x",
+    accessToken: "jwt-abc",
+    slug: "tokentracker-account-summary",
+    searchParams,
+    fetchImpl,
+  });
+  assert.deepEqual(body, { ok: 1 });
+  const u = new URL(captured.urlStr);
+  assert.equal(u.pathname, "/functions/tokentracker-account-summary");
+  assert.equal(u.searchParams.get("from"), "2026-01-01");
+  assert.equal(u.searchParams.get("tz"), "UTC");
+  assert.equal(u.searchParams.get("account"), null, "account must be stripped");
+  assert.equal(u.searchParams.get("scope"), null, "scope must be stripped");
+  assert.equal(captured.opts.headers.Authorization, "Bearer jwt-abc");
+  assert.equal(captured.opts.headers.apikey, "ik_x");
+});
+
+test("fetchAccountFunction throws with status on non-ok", async () => {
+  await assert.rejects(
+    () => fetchAccountFunction({
+      accessToken: "x",
+      slug: "tokentracker-account-summary",
+      searchParams: new URLSearchParams(),
+      fetchImpl: async () => jsonResponse({}, false, 500),
+    }),
+    (err) => err.status === 500,
+  );
+});
+
+test("fetchAccountUsage returns null for slugs without a cloud equivalent", async () => {
+  __resetCloudAccountCacheForTests();
+  const out = await fetchAccountUsage({
+    usageSlug: "tokentracker-usage-limits",
+    searchParams: new URLSearchParams(),
+    refreshToken: "r",
+    fetchImpl: async () => jsonResponse({}),
+  });
+  assert.equal(out, null);
+});
+
+test("fetchAccountUsage returns null when not signed in (no refresh token)", async () => {
+  __resetCloudAccountCacheForTests();
+  const out = await fetchAccountUsage({
+    usageSlug: "tokentracker-usage-summary",
+    searchParams: new URLSearchParams(),
+    refreshToken: "",
+    fetchImpl: async () => jsonResponse({}),
+  });
+  assert.equal(out, null);
+});
+
+test("fetchAccountUsage mints a token then returns the account payload", async () => {
+  __resetCloudAccountCacheForTests();
+  const access = makeJwt({ expSeconds: Math.floor(Date.now() / 1000) + 3600 });
+  const payload = { from: "2026-01-01", to: "2026-01-01", totals: { total_tokens: 4242 } };
+  const fetchImpl = async (urlStr) => {
+    if (urlStr.includes("/api/auth/refresh")) return jsonResponse({ accessToken: access });
+    if (urlStr.includes("/functions/tokentracker-account-summary")) return jsonResponse(payload);
+    throw new Error(`unexpected url ${urlStr}`);
+  };
+  const out = await fetchAccountUsage({
+    usageSlug: "tokentracker-usage-summary",
+    searchParams: new URLSearchParams("from=2026-01-01&to=2026-01-01"),
+    baseUrl: "https://cloud.example",
+    anonKey: "ik_x",
+    refreshToken: "r",
+    fetchImpl,
+  });
+  assert.deepEqual(out.data, payload);
+  assert.equal(out.rotatedRefreshToken, null);
+});

--- a/test/local-api-account-view.test.js
+++ b/test/local-api-account-view.test.js
@@ -1,0 +1,231 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { Readable } = require("node:stream");
+const { test, beforeEach, afterEach } = require("node:test");
+
+// The handler reads/writes ~/.tokentracker/tracker/. Redirect HOME to a temp
+// dir so these tests never touch the developer's real relay cookies or pref.
+let tmpHome;
+let prevHome;
+let prevUserProfile;
+
+beforeEach(() => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "tt-account-view-home-"));
+  prevHome = process.env.HOME;
+  prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  delete require.cache[require.resolve("../src/lib/cloud-account")];
+});
+
+afterEach(() => {
+  if (prevHome === undefined) delete process.env.HOME;
+  else process.env.HOME = prevHome;
+  if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+  else process.env.USERPROFILE = prevUserProfile;
+  try {
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function freshHandler(queuePath) {
+  // Re-require so module-level state (token cache) and the trackerDataDir
+  // resolved at construction reflect the temp HOME.
+  delete require.cache[require.resolve("../src/lib/local-api")];
+  const { createLocalApiHandler } = require("../src/lib/local-api");
+  return createLocalApiHandler({ queuePath });
+}
+
+function makeReq({ method = "GET", urlObj, headers = {}, body } = {}) {
+  const base = Readable.from(body != null ? [Buffer.from(body)] : []);
+  base.method = method;
+  base.url = urlObj.pathname + urlObj.search;
+  base.headers = { host: "localhost", ...headers };
+  return base;
+}
+
+function makeRes() {
+  const chunks = [];
+  const headers = {};
+  return {
+    statusCode: 200,
+    _headers: headers,
+    setHeader(k, v) {
+      headers[k.toLowerCase()] = v;
+    },
+    writeHead(status, hdrs) {
+      this.statusCode = status;
+      if (hdrs) for (const [k, v] of Object.entries(hdrs)) headers[k.toLowerCase()] = v;
+    },
+    end(body) {
+      if (body) chunks.push(body);
+    },
+    body() {
+      return chunks.join("");
+    },
+    json() {
+      return JSON.parse(chunks.join(""));
+    },
+  };
+}
+
+async function call(handler, opts) {
+  const urlObj = new URL(`http://localhost${opts.endpoint}`);
+  const req = makeReq({ ...opts, urlObj });
+  const res = makeRes();
+  const handled = await handler(req, res, urlObj);
+  assert.ok(handled, `endpoint must be handled: ${opts.endpoint}`);
+  return res;
+}
+
+function writeQueue(queuePath, rows) {
+  fs.writeFileSync(queuePath, rows.map((r) => JSON.stringify(r)).join("\n") + "\n");
+}
+
+const SAMPLE_ROW = {
+  source: "claude",
+  model: "claude-sonnet-4-6",
+  hour_start: "2026-04-20T10:00:00.000Z",
+  input_tokens: 100,
+  cached_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+  output_tokens: 20,
+  reasoning_output_tokens: 0,
+  total_tokens: 120,
+  conversation_count: 1,
+};
+
+test("cloud-sync-pref defaults to disabled and reports account unavailable", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const handler = freshHandler(queuePath);
+  const res = await call(handler, { endpoint: "/functions/tokentracker-cloud-sync-pref" });
+  assert.deepEqual(res.json(), { enabled: false, account_available: false });
+});
+
+test("user-status exposes account aggregation state", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const handler = freshHandler(queuePath);
+  const res = await call(handler, { endpoint: "/functions/tokentracker-user-status" });
+  const body = res.json();
+  assert.deepEqual(body.account, {
+    available: false,
+    cloud_sync_enabled: false,
+    account_view: false,
+  });
+});
+
+test("POST cloud-sync-pref requires local auth, then persists and is reflected", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  const handler = freshHandler(queuePath);
+
+  // Without the local-auth token the mutation is rejected.
+  const denied = await call(handler, {
+    method: "POST",
+    endpoint: "/functions/tokentracker-cloud-sync-pref",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ enabled: true }),
+  });
+  assert.equal(denied.statusCode, 401);
+
+  // Fetch the token the dashboard would use.
+  const authRes = await call(handler, { endpoint: "/api/local-auth" });
+  const { token } = authRes.json();
+  assert.ok(token);
+
+  const ok = await call(handler, {
+    method: "POST",
+    endpoint: "/functions/tokentracker-cloud-sync-pref",
+    headers: { "content-type": "application/json", "x-tokentracker-local-auth": token },
+    body: JSON.stringify({ enabled: true }),
+  });
+  assert.deepEqual(ok.json(), { ok: true, enabled: true });
+
+  // Persisted to disk and reflected by a subsequent GET (new handler instance).
+  const prefFile = path.join(tmpHome, ".tokentracker", "tracker", "cloud-sync-pref.json");
+  assert.equal(JSON.parse(fs.readFileSync(prefFile, "utf8")).enabled, true);
+
+  const handler2 = freshHandler(queuePath);
+  const get2 = await call(handler2, { endpoint: "/functions/tokentracker-cloud-sync-pref" });
+  assert.equal(get2.json().enabled, true);
+});
+
+test("usage-summary?account=1 falls back to local data when not signed in", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+  // Enable the pref but provide no relay refresh token → not signed in.
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+
+  const handler = freshHandler(queuePath);
+  const res = await call(handler, {
+    endpoint: "/functions/tokentracker-usage-summary?from=2026-04-20&to=2026-04-20&tz=UTC&account=1",
+  });
+  // Local (single-machine) data served, tagged as not-account-view.
+  assert.equal(res._headers["x-tokentracker-account-view"], "0");
+  const body = res.json();
+  assert.equal(body.scope, "all");
+  assert.equal(body.totals.total_tokens, 120);
+});
+
+test("usage-summary?account=1 serves the cross-device aggregate when signed in + cloud sync on", async () => {
+  const queuePath = path.join(tmpHome, "queue.jsonl");
+  writeQueue(queuePath, [SAMPLE_ROW]);
+
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+  // Seed a relayed refresh token (what the auth proxy would have captured).
+  fs.writeFileSync(
+    path.join(trackerDir, "relay-cookies.json"),
+    JSON.stringify({
+      insforge_refresh_token: "insforge_refresh_token=refresh-xyz; Path=/; HttpOnly; SameSite=Lax",
+    }),
+  );
+
+  // Mock the network: token refresh, then the account-summary aggregate.
+  const accessJwt = `${Buffer.from(JSON.stringify({ alg: "HS256" })).toString("base64url")}.${Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 }),
+  ).toString("base64url")}.sig`;
+  const accountPayload = {
+    from: "2026-04-20",
+    to: "2026-04-20",
+    scope: "all",
+    totals: { total_tokens: 999999, total_cost_usd: "1.50" },
+  };
+  const realFetch = global.fetch;
+  const seen = [];
+  global.fetch = async (urlStr, opts) => {
+    seen.push(String(urlStr));
+    if (String(urlStr).includes("/api/auth/refresh")) {
+      return { ok: true, status: 200, json: async () => ({ accessToken: accessJwt }) };
+    }
+    if (String(urlStr).includes("/functions/tokentracker-account-summary")) {
+      assert.equal(opts.headers.Authorization, `Bearer ${accessJwt}`);
+      return { ok: true, status: 200, json: async () => accountPayload };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  try {
+    const handler = freshHandler(queuePath);
+    const res = await call(handler, {
+      endpoint: "/functions/tokentracker-usage-summary?from=2026-04-20&to=2026-04-20&tz=UTC&account=1",
+    });
+    assert.equal(res._headers["x-tokentracker-account-view"], "1");
+    assert.deepEqual(res.json(), accountPayload);
+    assert.ok(seen.some((u) => u.includes("/api/auth/refresh")));
+    assert.ok(seen.some((u) => u.includes("/functions/tokentracker-account-summary")));
+  } finally {
+    global.fetch = realFetch;
+  }
+});

--- a/test/local-api-account-view.test.js
+++ b/test/local-api-account-view.test.js
@@ -156,6 +156,17 @@ test("POST cloud-sync-pref requires local auth, then persists and is reflected",
   const handler2 = freshHandler(queuePath);
   const get2 = await call(handler2, { endpoint: "/functions/tokentracker-cloud-sync-pref" });
   assert.equal(get2.json().enabled, true);
+
+  // A non-boolean payload is rejected (400) and must NOT overwrite the pref.
+  const token2 = (await call(handler2, { endpoint: "/api/local-auth" })).json().token;
+  const bad = await call(handler2, {
+    method: "POST",
+    endpoint: "/functions/tokentracker-cloud-sync-pref",
+    headers: { "content-type": "application/json", "x-tokentracker-local-auth": token2 },
+    body: JSON.stringify({ enabled: "yes" }),
+  });
+  assert.equal(bad.statusCode, 400);
+  assert.equal(JSON.parse(fs.readFileSync(prefFile, "utf8")).enabled, true, "pref must be unchanged");
 });
 
 test("usage-summary?account=1 falls back to local data when not signed in", async () => {


### PR DESCRIPTION
The menu-bar/tray popover talked only to the local CLI server and showed
single-machine data, while the dashboard WebView aggregates across devices
when signed in with cloud sync on. The two surfaces disagreed.

Make the popover follow the dashboard:

- src/lib/cloud-account.js: server-side cross-device reads. Mints a
  short-lived InsForge access token from the refresh token the local server
  already relays, then proxies the tokentracker-account-* edge functions
  (identical schema to the local tokentracker-usage-* endpoints). Cached,
  injectable fetch for tests.
- src/lib/local-api.js: usage endpoints accept ?account=1. When the user is
  signed in (relayed refresh token) AND cloud sync is on, serve the same
  cross-device aggregate the dashboard shows (X-TokenTracker-Account-View: 1);
  otherwise fall back to local data tagged 0. New tokentracker-cloud-sync-pref
  endpoint mirrors the dashboard toggle so the auth-unaware popover gates on
  the same preference; user-status reports account availability.
- runtime-config.js: expose the public InsForge anon key for account reads.
- dashboard: mirror the cloud-sync toggle to the local server (on toggle and
  once on load) so the popover tracks it.
- macOS APIClient + Windows UsagePoller: request account=1 on cloud-eligible
  endpoints; macOS captures the account-view header.

Data aligns by construction: the popover hits the same account-* endpoints
the dashboard uses. Defaults off (local), exactly like the dashboard toggle.

https://claude.ai/code/session_01AMdNJvmP9Avd5jbsUrcDgm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-device "account view" for aggregated usage when signed in and cloud sync enabled; responses indicate whether account view was served.
  * Dashboard cloud-sync toggle now mirrors to the local/native client on initial load.
  * Local server can proxy account-level usage, rotate relay tokens, and exposes an endpoint to mirror cloud-sync preference.

* **Tests**
  * Added unit and integration tests covering token refresh/minting, account view flows, and local API behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->