### PR TITLE
fix(grok): incremental byte-offset resume for updates.jsonl

### DIFF
--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7891,6 +7891,27 @@ function grokEventId(value, fallback) {
   return fallback;
 }
 
+function grokFileEndsWithNewline(filePath, size) {
+  if (!(size > 0)) return false;
+  let fd;
+  try {
+    fd = fssync.openSync(filePath, "r");
+    const buf = Buffer.alloc(1);
+    const read = fssync.readSync(fd, buf, 0, 1, size - 1);
+    return read === 1 && buf[0] === 0x0a; // trailing "\n"
+  } catch {
+    return false;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        fssync.closeSync(fd);
+      } catch {
+        /* ignore close failure */
+      }
+    }
+  }
+}
+
 async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOffsetEntry) {
   if (!updatesPath) return { events: [], offsetEntry: null };
   let stat;
@@ -7910,16 +7931,30 @@ async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOff
   const prevIno = prevOffsetEntry?.ino;
   const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
   const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
-  const offsetEntry = { size: stat.size, mtimeMs: stat.mtimeMs, ino: stat.ino };
-  if (stat.size <= startOffset) return { events: [], offsetEntry };
+  const baseOffset = { mtimeMs: stat.mtimeMs, ino: stat.ino };
+  if (stat.size <= startOffset) {
+    return { events: [], offsetEntry: { size: startOffset, ...baseOffset } };
+  }
+
+  // Only advance the stored offset to the end of the last newline-terminated
+  // line. If Grok is mid-write, the final JSONL line has no trailing "\n" yet;
+  // its bytes are left unconsumed so the next scan re-reads the line once it is
+  // complete instead of skipping it forever (which would undercount tokens).
+  const endsWithNewline = grokFileEndsWithNewline(updatesPath, stat.size);
 
   const events = [];
   let lineIndex = 0;
-  const input = fssync.createReadStream(updatesPath, { encoding: "utf8", start: startOffset });
+  let lastLine = "";
+  const input = fssync.createReadStream(updatesPath, {
+    encoding: "utf8",
+    start: startOffset,
+    end: stat.size - 1, // inclusive; bound the read to the stat'd size
+  });
   const rl = readline.createInterface({ input, crlfDelay: Infinity });
   try {
     for await (const line of rl) {
       lineIndex++;
+      lastLine = line;
       if (!line || !line.trim()) continue;
       let record;
       try {
@@ -7944,7 +7979,12 @@ async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOff
     return { events, offsetEntry: prevOffsetEntry || null };
   }
 
-  return { events, offsetEntry };
+  // When the file does not end on a newline, the final emitted line is a
+  // partial tail still being written. Exclude its bytes so the committed offset
+  // stays on a complete-line boundary and the line is re-read once finished.
+  const trailingPartialBytes = endsWithNewline ? 0 : Buffer.byteLength(lastLine, "utf8");
+  const committedSize = Math.max(startOffset, stat.size - trailingPartialBytes);
+  return { events, offsetEntry: { size: committedSize, ...baseOffset } };
 }
 
 function estimateGrokTokenDelta(totalTokens, conversationCount, options = {}) {

--- a/src/lib/rollout.js
+++ b/src/lib/rollout.js
@@ -7891,18 +7891,31 @@ function grokEventId(value, fallback) {
   return fallback;
 }
 
-async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp) {
-  if (!updatesPath) return { events: [], recordsProcessed: 0 };
+async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp, prevOffsetEntry) {
+  if (!updatesPath) return { events: [], offsetEntry: null };
+  let stat;
   try {
-    const stat = fssync.statSync(updatesPath);
-    if (!stat.isFile()) return { events: [], recordsProcessed: 0 };
+    stat = fssync.statSync(updatesPath);
+    if (!stat.isFile()) return { events: [], offsetEntry: null };
   } catch {
-    return { events: [], recordsProcessed: 0 };
+    return { events: [], offsetEntry: null };
   }
+
+  // updates.jsonl is append-only and carries cumulative totalTokens, deduped
+  // by the session high-watermark, so resuming from the last consumed byte is
+  // safe: re-read events stay below the watermark (no double count), and any
+  // bytes a write race leaves unparsed are covered by the next event's
+  // cumulative total. Re-read from 0 on truncation or inode change.
+  const prevSize = Number(prevOffsetEntry?.size) || 0;
+  const prevIno = prevOffsetEntry?.ino;
+  const inodeChanged = typeof prevIno === "number" && prevIno !== stat.ino;
+  const startOffset = stat.size < prevSize || inodeChanged ? 0 : prevSize;
+  const offsetEntry = { size: stat.size, mtimeMs: stat.mtimeMs, ino: stat.ino };
+  if (stat.size <= startOffset) return { events: [], offsetEntry };
 
   const events = [];
   let lineIndex = 0;
-  const input = fssync.createReadStream(updatesPath, { encoding: "utf8" });
+  const input = fssync.createReadStream(updatesPath, { encoding: "utf8", start: startOffset });
   const rl = readline.createInterface({ input, crlfDelay: Infinity });
   try {
     for await (const line of rl) {
@@ -7926,10 +7939,12 @@ async function readGrokUpdateTokenEvents(updatesPath, fallbackTimestamp) {
       });
     }
   } catch {
-    return { events, recordsProcessed: events.length };
+    // Stream error mid-read: keep the events we got, but do not advance the
+    // offset so the next sync retries the same range (watermark-safe).
+    return { events, offsetEntry: prevOffsetEntry || null };
   }
 
-  return { events, recordsProcessed: events.length };
+  return { events, offsetEntry };
 }
 
 function estimateGrokTokenDelta(totalTokens, conversationCount, options = {}) {
@@ -7962,6 +7977,13 @@ async function parseGrokBuildIncremental({
   const hourlyState = normalizeHourlyState(cursors?.hourly);
   const grokState = cursors.grok && typeof cursors.grok === "object" ? { ...cursors.grok } : {};
   let sessionSnapshots = normalizeGrokSessionSnapshots(grokState);
+  const prevUpdateOffsets =
+    grokState.updateOffsets && typeof grokState.updateOffsets === "object"
+      ? grokState.updateOffsets
+      : {};
+  // Rebuilt from the sessions seen this scan, so entries for deleted session
+  // dirs are pruned and the cursor stays bounded by the on-disk session count.
+  const updateOffsets = {};
   const touchedBuckets = new Set();
 
   const sessionList = Array.isArray(sessions) && sessions.length > 0
@@ -8013,7 +8035,15 @@ async function parseGrokBuildIncremental({
       return true;
     };
 
-    const updates = await readGrokUpdateTokenEvents(grokUpdatesPathForSession(sess), lastActive);
+    const updatesPath = grokUpdatesPathForSession(sess);
+    const updates = await readGrokUpdateTokenEvents(
+      updatesPath,
+      lastActive,
+      updatesPath ? prevUpdateOffsets[updatesPath] : null,
+    );
+    if (updatesPath && updates.offsetEntry) {
+      updateOffsets[updatesPath] = updates.offsetEntry;
+    }
     for (const event of updates.events) {
       observedTotal = Math.max(observedTotal, event.totalTokens);
       lastEventId = event.eventId || lastEventId;
@@ -8081,6 +8111,7 @@ async function parseGrokBuildIncremental({
     version: GROK_CURSOR_VERSION,
     sessionSnapshots,
     seenSessions: Object.keys(sessionSnapshots),
+    updateOffsets,
     updatedAt: new Date().toISOString()
   };
 

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -6447,6 +6447,56 @@ test("parseGrokBuildIncremental resumes Grok updates from the stored byte offset
   }
 });
 
+test("parseGrokBuildIncremental re-reads a partial Grok updates line once it completes", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-partial-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-partial");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:50:00.000Z",
+      }),
+      "utf8",
+    );
+
+    const fullLine = JSON.stringify({
+      method: "session/update",
+      params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:05:00.000Z"), eventId: "evt-1" } },
+    });
+    // Simulate Grok still writing: only the first half of the JSON line, no "\n".
+    const splitAt = Math.floor(fullLine.length / 2);
+    await fs.writeFile(updatesPath, fullLine.slice(0, splitAt), "utf8");
+
+    const session = { sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-partial" };
+
+    // First scan: partial line is unparseable, so nothing is aggregated AND the
+    // stored offset must NOT advance past the partial tail (regression guard).
+    const firstRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(firstRun.eventsAggregated, 0);
+    assert.equal(cursors.grok.updateOffsets[updatesPath].size, 0);
+
+    // Grok finishes writing the same line.
+    await fs.writeFile(updatesPath, fullLine + "\n", "utf8");
+
+    // Second scan: the now-complete line is parsed and queued (not skipped).
+    const secondRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(secondRun.eventsAggregated, 1);
+    assert.equal(cursors.grok.updateOffsets[updatesPath].size, Buffer.byteLength(fullLine + "\n"));
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-partial"].totalTokens, 100);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 1);
+    assert.equal(queued[0].total_tokens, 100);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseGrokBuildIncremental re-reads truncated Grok updates without double counting", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-truncate-"));
   try {

--- a/test/rollout-parser.test.js
+++ b/test/rollout-parser.test.js
@@ -6389,6 +6389,125 @@ test("parseGrokBuildIncremental reads Grok updates metadata by event timestamp",
   }
 });
 
+test("parseGrokBuildIncremental resumes Grok updates from the stored byte offset", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-offset-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-offset");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T14:50:00.000Z",
+      }),
+      "utf8",
+    );
+    const firstLine = JSON.stringify({
+      method: "session/update",
+      params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:05:00.000Z"), eventId: "evt-1" } },
+    });
+    await fs.writeFile(updatesPath, firstLine + "\n", "utf8");
+
+    const session = { sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-offset" };
+    const firstRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(firstRun.eventsAggregated, 1);
+    assert.equal(cursors.grok.updateOffsets[updatesPath].size, Buffer.byteLength(firstLine + "\n"));
+
+    // Replace the consumed head with a same-length decoy event (totalTokens
+    // 999). If the parser re-read from byte 0 it would aggregate the decoy;
+    // resuming from the stored offset must only see the appended event.
+    const decoy = JSON.stringify({
+      method: "session/update",
+      params: { _meta: { totalTokens: 999, agentTimestampMs: Date.parse("2026-04-05T14:06:00.000Z"), eventId: "evt-x" } },
+    });
+    assert.equal(decoy.length, firstLine.length);
+    const appended = JSON.stringify({
+      method: "session/update",
+      params: { _meta: { totalTokens: 250, agentTimestampMs: Date.parse("2026-04-05T14:35:00.000Z"), eventId: "evt-2" } },
+    });
+    await fs.writeFile(updatesPath, decoy + "\n" + appended + "\n", "utf8");
+
+    const secondRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(secondRun.eventsAggregated, 1);
+    const queued = await readJsonLines(queuePath);
+    assert.equal(queued.length, 2);
+    assert.equal(queued[1].hour_start, "2026-04-05T14:30:00.000Z");
+    assert.equal(queued[1].total_tokens, 150);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-offset"].totalTokens, 250);
+    assert.equal(
+      cursors.grok.updateOffsets[updatesPath].size,
+      Buffer.byteLength(decoy + "\n" + appended + "\n"),
+    );
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
+test("parseGrokBuildIncremental re-reads truncated Grok updates without double counting", async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-truncate-"));
+  try {
+    const queuePath = path.join(tmp, "queue.jsonl");
+    const cursors = { version: 1, files: {}, updatedAt: null };
+    const sessionDir = path.join(tmp, "sessions", "encoded-cwd", "grok-session-truncate");
+    await fs.mkdir(sessionDir, { recursive: true });
+    const signalsPath = path.join(sessionDir, "signals.json");
+    const updatesPath = path.join(sessionDir, "updates.jsonl");
+    await fs.writeFile(
+      signalsPath,
+      JSON.stringify({
+        primaryModelId: "grok-build",
+        lastActiveAt: "2026-04-05T15:20:00.000Z",
+      }),
+      "utf8",
+    );
+    await fs.writeFile(
+      updatesPath,
+      [
+        JSON.stringify({
+          method: "session/update",
+          params: { _meta: { totalTokens: 100, agentTimestampMs: Date.parse("2026-04-05T14:05:00.000Z"), eventId: "evt-1" } },
+        }),
+        JSON.stringify({
+          method: "session/update",
+          params: { _meta: { totalTokens: 250, agentTimestampMs: Date.parse("2026-04-05T14:35:00.000Z"), eventId: "evt-2" } },
+        }),
+      ].join("\n") + "\n",
+      "utf8",
+    );
+
+    const session = { sessionDir, updatesPath, signalsPath, summaryPath: path.join(sessionDir, "summary.json"), sessionId: "grok-session-truncate" };
+    const firstRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(firstRun.eventsAggregated, 2);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-truncate"].totalTokens, 250);
+
+    // Shrink the file (rotation/truncate): the parser must fall back to a
+    // full re-read, and the session high-watermark must keep the replayed
+    // cumulative totals from double counting.
+    await fs.writeFile(
+      updatesPath,
+      JSON.stringify({
+        method: "session/update",
+        params: { _meta: { totalTokens: 300, agentTimestampMs: Date.parse("2026-04-05T15:05:00.000Z"), eventId: "evt-3" } },
+      }) + "\n",
+      "utf8",
+    );
+
+    const secondRun = await parseGrokBuildIncremental({ sessions: [session], cursors, queuePath });
+    assert.equal(secondRun.eventsAggregated, 1);
+    const queued = await readJsonLines(queuePath);
+    const last = queued[queued.length - 1];
+    assert.equal(last.hour_start, "2026-04-05T15:00:00.000Z");
+    assert.equal(last.total_tokens, 50);
+    assert.equal(cursors.grok.sessionSnapshots["grok-session-truncate"].totalTokens, 300);
+  } finally {
+    await fs.rm(tmp, { recursive: true, force: true });
+  }
+});
+
 test("parseGrokBuildIncremental applies Grok compaction residual once", async () => {
   const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "tt-grok-compaction-"));
   try {


### PR DESCRIPTION
## Summary

Stop re-reading every Grok session's `updates.jsonl` from byte 0 on every sync: persist per-file byte offsets and resume from the last consumed byte. On a real machine (153 sessions / 474 MB) the Grok parse step drops from ~6 s warm / ~26 s cold per sync to ~295 ms — previously this cost was paid on every auto-sync (as often as every 20 s via the notify hook) and grows unboundedly with usage.

## How it works

- `readGrokUpdateTokenEvents` accepts a `prevOffsetEntry` `{size, mtimeMs, ino}` and streams from the previously consumed byte. Unchanged file (size/inode match) → stat-only fast path, no read at all. Truncation or inode change → reset to 0 so no event is missed. Mid-stream errors do not advance the offset, so the next sync retries the same range.
- `parseGrokBuildIncremental` persists offsets in `cursors.grok.updateOffsets` (keyed by `updatesPath`), rebuilt from the sessions seen each scan so entries for deleted session dirs are pruned automatically.
- Safety comes from existing semantics: `updates.jsonl` is append-only with **cumulative** `totalTokens` deduped by the session high-watermark, so re-read events can never double-count and bytes skipped by a write race are covered by the next event's cumulative total. The cursor field is additive — older versions preserve it via spread and ignore it; no migration needed.

## Tests

Two regression tests added:
- Tail-resume proven behaviorally: the consumed head is overwritten with a same-length decoy event (`totalTokens: 999`) — a full re-read would aggregate it, offset resume must only see the appended event.
- Truncation fallback: shrunken file re-reads from 0, high-watermark prevents double counting.

`node --test test/rollout-parser.test.js`: all 13 Grok tests pass.

## Scope

- [x] CLI (`src/`)
- [ ] Dashboard (`dashboard/`)
- [ ] macOS app (`TokenTrackerBar/`)
- [ ] Windows app (`TokenTrackerWin/`)
- [ ] Docs / CI / config

## Checklist

- [x] `npm test` passes (884/886; the 2 failures pre-exist on a clean tree — missing optional `@mongodb-js/zstd` native dep locally + a timing-sensitive event-loop test, both unrelated)
- [x] New user-facing strings go through `dashboard/src/content/copy.csv` (no UI strings touched)
- [x] Commits follow conventional style
- [x] PR description explains *why*, not just *what*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved incremental processing of rollout updates to resume safely after interruptions, including support for partial writes and resumable reads by byte offset
  * Ensured correct behavior after truncation/rotation of update files so cumulative totals don’t double-count or miss events
  * Strengthened per-session progress tracking for accurate cumulative reporting across sync runs and restarts
* **Tests**
  * Added coverage for incremental resumption, partial-write handling, and truncation/rotation correctness
<!-- end of auto-generated comment: release notes by coderabbit.ai -->