### PR TITLE
fix: drain manual cloud sync uploads

### DIFF
--- a/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
+++ b/TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift
@@ -82,8 +82,11 @@ actor APIClient {
         try await fetch("/functions/tokentracker-usage-limits")
     }
 
-    func triggerSync() async throws -> SyncResponse {
-        try await post("/functions/tokentracker-local-sync")
+    func triggerSync(drain: Bool = false) async throws -> SyncResponse {
+        try await post(
+            "/functions/tokentracker-local-sync",
+            body: drain ? Data(#"{"drain":true}"#.utf8) : Data("{}".utf8)
+        )
     }
 
     func checkServerHealth() async -> Bool {
@@ -138,7 +141,7 @@ actor APIClient {
 		withTimeZoneQueryItems(items) + [URLQueryItem(name: "account", value: "1")]
 	}
 
-    private func post<T: Decodable>(_ path: String) async throws -> T {
+    private func post<T: Decodable>(_ path: String, body: Data = Data("{}".utf8)) async throws -> T {
         guard let url = URL(string: baseURL + path) else {
             throw APIError.invalidURL
         }
@@ -148,7 +151,7 @@ actor APIClient {
         if path == "/functions/tokentracker-local-sync" {
             request.setValue(try await fetchLocalAuthToken(), forHTTPHeaderField: "x-tokentracker-local-auth")
         }
-        request.httpBody = Data("{}".utf8)
+        request.httpBody = body
         let (data, response) = try await session.data(for: request)
         try validateResponse(response)
         return try decoder.decode(T.self, from: data)

--- a/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
+++ b/TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift
@@ -253,7 +253,7 @@ class DashboardViewModel: ObservableObject {
         guard !isSyncing else { return }
         isSyncing = true
         do {
-            _ = try await APIClient.shared.triggerSync()
+            _ = try await APIClient.shared.triggerSync(drain: true)
             await loadAll()
         } catch {
             self.error = error.localizedDescription

--- a/dashboard/src/lib/cloud-sync.test.ts
+++ b/dashboard/src/lib/cloud-sync.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearCloudDeviceSession } from "./cloud-sync-prefs";
+import { runCloudUsageSyncIfDue, runCloudUsageSyncNow } from "./cloud-sync";
+
+vi.mock("./insforge-config", () => ({
+  getInsforgeAnonKey: () => "anon-key",
+  getInsforgeRemoteUrl: () => "https://cloud.example",
+}));
+
+vi.mock("./local-api-auth", () => ({
+  getLocalApiAuthHeaders: async () => ({ "x-tokentracker-local-auth": "local-token" }),
+}));
+
+function okJson(data: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => data,
+  } as Response;
+}
+
+function installFetchMock() {
+  const fetchMock = vi.fn(async (url: string) => {
+    if (url === "/functions/tokentracker-machine-id") {
+      return okJson({ machineId: "machine-abcdef12" });
+    }
+    if (url === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      return okJson({
+        token: "device-token",
+        device_id: "device-id",
+        created_at: "2026-06-13T00:00:00.000Z",
+      });
+    }
+    if (url === "/functions/tokentracker-local-sync") {
+      return okJson({ ok: true });
+    }
+    if (url === "https://cloud.example/functions/tokentracker-leaderboard-refresh") {
+      return okJson({ ok: true });
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function getLocalSyncBody(fetchMock: ReturnType<typeof vi.fn>): Record<string, unknown> {
+  const call = fetchMock.mock.calls.find(([url]) => url === "/functions/tokentracker-local-sync");
+  expect(call).toBeTruthy();
+  const init = call?.[1] as RequestInit | undefined;
+  expect(init?.method).toBe("POST");
+  return JSON.parse(String(init?.body));
+}
+
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+  });
+}
+
+describe("cloud usage sync", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    installLocalStorageMock();
+    clearCloudDeviceSession();
+  });
+
+  it("sends drain for manual sync", async () => {
+    const fetchMock = installFetchMock();
+
+    await runCloudUsageSyncNow(async () => "access-token");
+
+    expect(getLocalSyncBody(fetchMock)).toMatchObject({
+      deviceToken: "device-token",
+      drain: true,
+      insforgeBaseUrl: "https://cloud.example",
+    });
+  });
+
+  it("does not send drain for scheduled sync", async () => {
+    const fetchMock = installFetchMock();
+
+    await runCloudUsageSyncIfDue(async () => "access-token");
+
+    expect(getLocalSyncBody(fetchMock)).toEqual({
+      deviceToken: "device-token",
+      insforgeBaseUrl: "https://cloud.example",
+    });
+  });
+});

--- a/dashboard/src/lib/cloud-sync.ts
+++ b/dashboard/src/lib/cloud-sync.ts
@@ -136,9 +136,11 @@ async function issueDeviceTokenForCloud(accessToken: string): Promise<CloudDevic
 async function postLocalUsageSync(options: {
   deviceToken: string;
   insforgeBaseUrl?: string;
+  drain?: boolean;
 }): Promise<{ ok?: boolean; code?: number; stdout?: string; stderr?: string }> {
-  const { deviceToken, insforgeBaseUrl } = options;
-  const body: Record<string, string> = { deviceToken };
+  const { deviceToken, insforgeBaseUrl, drain } = options;
+  const body: Record<string, string | boolean> = { deviceToken };
+  if (drain === true) body.drain = true;
   const bu = insforgeBaseUrl || getInsforgeRemoteUrl();
   if (isRemoteHttpBase(bu)) body.insforgeBaseUrl = bu.trim();
   const authHeaders = await getLocalApiAuthHeaders();
@@ -171,7 +173,10 @@ async function resolveCloudDeviceSession(getAccessToken: () => Promise<string | 
   return issued;
 }
 
-async function syncCloudUsageWithRecovery(getAccessToken: () => Promise<string | null>): Promise<string | null> {
+async function syncCloudUsageWithRecovery(
+  getAccessToken: () => Promise<string | null>,
+  options: { drain?: boolean } = {},
+): Promise<string | null> {
   let accessToken = await getAccessToken();
   if (!accessToken) return null;
 
@@ -182,6 +187,7 @@ async function syncCloudUsageWithRecovery(getAccessToken: () => Promise<string |
     await postLocalUsageSync({
       deviceToken: session.token,
       insforgeBaseUrl: getInsforgeRemoteUrl(),
+      drain: options.drain === true,
     });
     return accessToken;
   } catch (error) {
@@ -194,6 +200,7 @@ async function syncCloudUsageWithRecovery(getAccessToken: () => Promise<string |
     await postLocalUsageSync({
       deviceToken: session.token,
       insforgeBaseUrl: getInsforgeRemoteUrl(),
+      drain: options.drain === true,
     });
     return accessToken;
   }
@@ -214,7 +221,7 @@ export async function runCloudUsageSyncIfDue(getAccessToken: () => Promise<strin
 
 /** 用户打开「同步到云端」后立即尝试一次（忽略节流） */
 export async function runCloudUsageSyncNow(getAccessToken: () => Promise<string | null>): Promise<void> {
-  const accessToken = await syncCloudUsageWithRecovery(getAccessToken);
+  const accessToken = await syncCloudUsageWithRecovery(getAccessToken, { drain: true });
   if (!accessToken) return;
   setLastCloudSyncTs(Date.now());
   await triggerLeaderboardRefresh(accessToken, "cloud-sync-now");

--- a/dashboard/vite.config.js
+++ b/dashboard/vite.config.js
@@ -225,9 +225,11 @@ function readJsonBodyVite(req) {
   });
 }
 
-async function runLocalSyncCommand(extraEnv = {}) {
+async function runLocalSyncCommand(extraEnv = {}, opts = {}) {
   return await new Promise((resolve, reject) => {
-    const child = spawn(process.platform === "win32" ? "npx.cmd" : "npx", ["tokentracker-cli", "sync"], {
+    const args = ["tokentracker-cli", "sync"];
+    if (opts.drain === true) args.push("--drain");
+    const child = spawn(process.platform === "win32" ? "npx.cmd" : "npx", args, {
       cwd: REPO_ROOT,
       env: { ...process.env, ...extraEnv },
       stdio: ["ignore", "pipe", "pipe"],
@@ -448,13 +450,14 @@ async function handleLocalApi(req, res, url) {
         body = {};
       }
       const extraEnv = {};
+      const drain = body.drain === true;
       if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
         extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
       }
       if (typeof body.insforgeBaseUrl === "string" && /^https?:\/\//i.test(body.insforgeBaseUrl.trim())) {
         extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = body.insforgeBaseUrl.trim();
       }
-      const result = await runLocalSyncCommand(extraEnv);
+      const result = await runLocalSyncCommand(extraEnv, { drain });
       try {
         const esmRequire = createRequire(import.meta.url);
         const { resetUsageLimitsCache } = esmRequire("../src/lib/usage-limits");

--- a/src/lib/local-api.js
+++ b/src/lib/local-api.js
@@ -10,7 +10,7 @@ const {
   listExcludedSources,
   normalizeUsageScope,
 } = require("./source-metadata");
-const { accountSlugFor, fetchAccountUsage } = require("./cloud-account");
+const { accountSlugFor, fetchAccountUsage, mintAccessToken } = require("./cloud-account");
 const { getOrCreateMachineId, computeStableMachineId } = require("./machine-id");
 
 const SYNC_TIMEOUT_MS = 120_000;
@@ -525,9 +525,11 @@ function readJsonBody(req) {
   });
 }
 
-function runSyncCommand(extraEnv = {}) {
+function runSyncCommand(extraEnv = {}, opts = {}) {
   return new Promise((resolve, reject) => {
-    const child = spawn(process.execPath, [TRACKER_BIN, "sync"], {
+    const args = [TRACKER_BIN, "sync"];
+    if (opts.drain === true) args.push("--drain");
+    const child = spawn(process.execPath, args, {
       env: { ...process.env, ...extraEnv },
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -937,6 +939,67 @@ function createLocalApiHandler({ queuePath }) {
       relayCookies.set(csrfRelayCookieName, cookie);
       persistRelayCookies();
     }
+  }
+
+  async function issueDeviceTokenForDrainSync(queuePathForMachineId) {
+    if (!getCloudSyncPref()) return null;
+    const refreshToken = getRefreshTokenForCloud();
+    if (!refreshToken) return null;
+
+    const runtime = resolveRuntimeConfig();
+    const baseUrl = runtime.baseUrl || DEFAULT_BASE_URL;
+    const minted = await mintAccessToken({
+      baseUrl,
+      anonKey: runtime.anonKey,
+      refreshToken,
+      timeoutMs: runtime.httpTimeoutMs,
+    });
+    if (!minted?.accessToken) return null;
+    if (minted.refreshToken) setRelayRefreshToken(minted.refreshToken);
+    if (minted.csrfToken) setRelayCsrfToken(minted.csrfToken);
+
+    const machineId = getOrCreateMachineId(queuePathForMachineId);
+    if (!machineId) return null;
+
+    const root = String(baseUrl || DEFAULT_BASE_URL).replace(/\/$/, "");
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Authorization: `Bearer ${minted.accessToken}`,
+    };
+    if (runtime.anonKey) headers.apikey = runtime.anonKey;
+
+    let timeoutId;
+    const controller = typeof AbortController !== "undefined" ? new AbortController() : null;
+    if (controller && runtime.httpTimeoutMs > 0) {
+      timeoutId = setTimeout(() => controller.abort(), runtime.httpTimeoutMs);
+    }
+
+    const dashboardPlatform =
+      process.platform === "darwin" ? "MacIntel" :
+        process.platform === "win32" ? "Win32" :
+          process.platform === "linux" ? "Linux x86_64" :
+            "web";
+
+    const res = await fetch(`${root}/functions/tokentracker-device-token-issue`, {
+      method: "POST",
+      headers,
+      signal: controller ? controller.signal : undefined,
+      body: JSON.stringify({
+        // 必须和 dashboard/src/lib/cloud-sync.ts 使用同一个设备身份。
+        // 旧云端设备按 (platform, device_name) 认领；如果这里发明
+        // local-sync 身份，会多出一个 active device，账户视图会把历史求和两次。
+        device_name: `Token Tracker (dashboard) #${machineId.slice(0, 8)}`,
+        platform: dashboardPlatform,
+        machine_id: machineId,
+      }),
+    }).finally(() => {
+      if (timeoutId) clearTimeout(timeoutId);
+    });
+    if (!res.ok) return null;
+    const data = await res.json().catch(() => null);
+    const token = typeof data?.token === "string" ? data.token.trim() : "";
+    return token || null;
   }
 
   // Returns "served" when the cross-device aggregate was written to `res`, or
@@ -1395,6 +1458,7 @@ function createLocalApiHandler({ queuePath }) {
           body = {};
         }
         const extraEnv = {};
+        const drain = body.drain === true;
         if (typeof body.deviceToken === "string" && body.deviceToken.trim()) {
           extraEnv.TOKENTRACKER_DEVICE_TOKEN = body.deviceToken.trim();
         }
@@ -1406,7 +1470,15 @@ function createLocalApiHandler({ queuePath }) {
           }
           extraEnv.TOKENTRACKER_INSFORGE_BASE_URL = allowedBaseUrl;
         }
-        const result = await runSyncCommand(extraEnv);
+        if (drain && !extraEnv.TOKENTRACKER_DEVICE_TOKEN && getCloudSyncPref() && getRefreshTokenForCloud()) {
+          const issuedToken = await issueDeviceTokenForDrainSync(qp).catch(() => null);
+          if (!issuedToken) {
+            json(res, { ok: false, error: "Unable to issue cloud device token for drain sync" }, 502);
+            return true;
+          }
+          extraEnv.TOKENTRACKER_DEVICE_TOKEN = issuedToken;
+        }
+        const result = await runSyncCommand(extraEnv, { drain });
         try {
           const { resetUsageLimitsCache } = require("./usage-limits");
           resetUsageLimitsCache();

--- a/test/cloud-sync-rotation.test.js
+++ b/test/cloud-sync-rotation.test.js
@@ -14,6 +14,7 @@ test("cloud sync source includes device-session rotation and recovery", () => {
   assert.match(src, /issuedAtMs \+ DEVICE_TOKEN_ROTATE_AFTER_MS <= nowMs/);
   assert.match(src, /clearCloudDeviceSession\(\)/);
   assert.match(src, /await postLocalUsageSync/);
+  assert.match(src, /runCloudUsageSyncNow[\s\S]*syncCloudUsageWithRecovery\(getAccessToken,\s*\{\s*drain:\s*true\s*\}\)/);
 });
 
 test("local auth helper caches the per-process token in memory", async () => {

--- a/test/local-api-security.test.js
+++ b/test/local-api-security.test.js
@@ -1,5 +1,7 @@
 const assert = require("node:assert/strict");
 const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 const { test } = require("node:test");
 
@@ -150,6 +152,240 @@ test("local sync accepts the configured insforgeBaseUrl override", async () => {
     restore();
     if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
     else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+  }
+});
+
+test("local sync drain request runs sync with --drain", async () => {
+  const calls = [];
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({
+        deviceToken: "device-token",
+        drain: true,
+      }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-3), [path.join(process.cwd(), "bin/tracker.js"), "sync", "--drain"]);
+  } finally {
+    restore();
+  }
+});
+
+test("local sync only treats boolean true as drain", async () => {
+  const cases = [
+    {},
+    { drain: false },
+    { drain: "true" },
+    { drain: 1 },
+  ];
+
+  for (const body of cases) {
+    const calls = [];
+    const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+    try {
+      const handler = mod.createLocalApiHandler({ queuePath: path.join(process.cwd(), "tmp-queue.jsonl") });
+      const localAuthToken = await getLocalAuthToken(handler);
+      const req = createRequest({
+        method: "POST",
+        headers: { "x-tokentracker-local-auth": localAuthToken },
+        body: JSON.stringify({
+          deviceToken: "device-token",
+          ...body,
+        }),
+      });
+      const res = createResponse();
+
+      const handled = await handler(
+        req,
+        res,
+        new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+      );
+
+      assert.equal(handled, true);
+      assert.equal(res.statusCode, 200);
+      assert.equal(calls.length, 1);
+      assert.deepEqual(calls[0].args.slice(-2), [path.join(process.cwd(), "bin/tracker.js"), "sync"]);
+    } finally {
+      restore();
+    }
+  }
+});
+
+test("local sync drain request mints a device token from relayed login when none is provided", async () => {
+  const calls = [];
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "tt-local-sync-drain-"));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const prevBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+  const prevFetch = global.fetch;
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+  fs.writeFileSync(path.join(trackerDir, "config.json"), JSON.stringify({ machineId: "machine-abcdef12" }));
+  fs.writeFileSync(
+    path.join(trackerDir, "relay-cookies.json"),
+    JSON.stringify({
+      insforge_refresh_token: "insforge_refresh_token=refresh-xyz; Path=/; HttpOnly; SameSite=Lax",
+    }),
+  );
+
+  const fetchCalls = [];
+  global.fetch = async (urlStr, opts = {}) => {
+    fetchCalls.push({ url: String(urlStr), opts });
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      return { ok: true, status: 200, json: async () => ({ accessToken: "access-token" }) };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      assert.equal(opts.headers.Authorization, "Bearer access-token");
+      const body = JSON.parse(String(opts.body || "{}"));
+      assert.equal(body.machine_id, "machine-abcdef12");
+      assert.equal(body.device_name, "Token Tracker (dashboard) #machine-");
+      assert.equal(
+        body.platform,
+        process.platform === "darwin" ? "MacIntel" :
+          process.platform === "win32" ? "Win32" :
+            process.platform === "linux" ? "Linux x86_64" :
+              "web",
+      );
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ token: "issued-device-token", device_id: "device-id" }),
+      };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({ drain: true }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0].args.slice(-3), [path.join(process.cwd(), "bin/tracker.js"), "sync", "--drain"]);
+    assert.equal(calls[0].options.env.TOKENTRACKER_DEVICE_TOKEN, "issued-device-token");
+    assert.ok(fetchCalls.some((c) => c.url.endsWith("/api/auth/refresh?client_type=mobile")));
+    assert.ok(fetchCalls.some((c) => c.url.endsWith("/functions/tokentracker-device-token-issue")));
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  }
+});
+
+test("local sync drain request fails when relayed device token cannot be issued", async () => {
+  const calls = [];
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "tt-local-sync-drain-fail-"));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  const prevBaseUrl = process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+  const prevFetch = global.fetch;
+  process.env.HOME = tmpHome;
+  process.env.USERPROFILE = tmpHome;
+  process.env.TOKENTRACKER_INSFORGE_BASE_URL = "https://cloud.example";
+
+  const trackerDir = path.join(tmpHome, ".tokentracker", "tracker");
+  fs.mkdirSync(trackerDir, { recursive: true });
+  fs.writeFileSync(path.join(trackerDir, "cloud-sync-pref.json"), JSON.stringify({ enabled: true }));
+  fs.writeFileSync(path.join(trackerDir, "config.json"), JSON.stringify({ machineId: "machine-abcdef12" }));
+  fs.writeFileSync(
+    path.join(trackerDir, "relay-cookies.json"),
+    JSON.stringify({
+      insforge_refresh_token: "insforge_refresh_token=refresh-xyz; Path=/; HttpOnly; SameSite=Lax",
+    }),
+  );
+
+  global.fetch = async (urlStr) => {
+    if (String(urlStr) === "https://cloud.example/api/auth/refresh?client_type=mobile") {
+      return { ok: true, status: 200, json: async () => ({ accessToken: "access-token" }) };
+    }
+    if (String(urlStr) === "https://cloud.example/functions/tokentracker-device-token-issue") {
+      return { ok: false, status: 502, json: async () => ({ error: "upstream unavailable" }) };
+    }
+    throw new Error(`unexpected fetch ${urlStr}`);
+  };
+
+  const { mod, restore } = loadLocalApiWithSpawn(createSuccessfulSpawn(calls));
+
+  try {
+    const handler = mod.createLocalApiHandler({
+      queuePath: path.join(trackerDir, "queue.jsonl"),
+    });
+    const localAuthToken = await getLocalAuthToken(handler);
+    const req = createRequest({
+      method: "POST",
+      headers: { "x-tokentracker-local-auth": localAuthToken },
+      body: JSON.stringify({ drain: true }),
+    });
+    const res = createResponse();
+
+    const handled = await handler(
+      req,
+      res,
+      new URL("http://127.0.0.1/functions/tokentracker-local-sync"),
+    );
+
+    assert.equal(handled, true);
+    assert.equal(res.statusCode, 502);
+    assert.deepEqual(JSON.parse(res.body.toString("utf8")), {
+      ok: false,
+      error: "Unable to issue cloud device token for drain sync",
+    });
+    assert.equal(calls.length, 0);
+  } finally {
+    restore();
+    global.fetch = prevFetch;
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevUserProfile;
+    if (prevBaseUrl === undefined) delete process.env.TOKENTRACKER_INSFORGE_BASE_URL;
+    else process.env.TOKENTRACKER_INSFORGE_BASE_URL = prevBaseUrl;
+    fs.rmSync(tmpHome, { recursive: true, force: true });
   }
 });
 

--- a/test/macos-sync-now-drain.test.js
+++ b/test/macos-sync-now-drain.test.js
@@ -1,0 +1,36 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { test } = require("node:test");
+
+const repoRoot = path.join(__dirname, "..");
+
+function read(relPath) {
+  return fs.readFileSync(path.join(repoRoot, relPath), "utf8");
+}
+
+test("macOS manual Sync now requests drain while launch sync stays lightweight", () => {
+  const apiClient = read("TokenTrackerBar/TokenTrackerBar/Services/APIClient.swift");
+  const viewModel = read("TokenTrackerBar/TokenTrackerBar/ViewModels/DashboardViewModel.swift");
+
+  assert.match(
+    apiClient,
+    /func triggerSync\(drain: Bool = false\) async throws -> SyncResponse/,
+    "APIClient should expose an explicit drain option with a lightweight default",
+  );
+  assert.match(
+    apiClient,
+    /body:\s*drain\s*\?\s*Data\(#"\{"drain":true\}"#\.utf8\)\s*:\s*Data\("\{}"\.utf8\)/,
+    "APIClient should send drain=true only when requested",
+  );
+  assert.match(
+    viewModel,
+    /func syncThenLoad\(\)[\s\S]*APIClient\.shared\.triggerSync\(\)/,
+    "initial launch sync should keep the lightweight default",
+  );
+  assert.match(
+    viewModel,
+    /func triggerSync\(\)[\s\S]*APIClient\.shared\.triggerSync\(drain: true\)/,
+    "manual Sync now should request drain",
+  );
+});


### PR DESCRIPTION
如果这个修改是在乱改，请直接关闭这个 PR。

## Problem

Manual Sync now can request a drain upload, but the macOS path may call the local sync endpoint without a device token. Before this change, the local API could still run `sync --drain` without a token; the sync command exits successfully with `Uploaded: skipped (no device token)`, so the UI can look successful even though nothing reached cloud sync.

The Vite dev local API also ignored `drain`, so local dashboard development did not match the packaged local API behavior.

## Why

Manual Sync now is a user-visible sync action. When cloud sync is enabled and the local API has a relayed login session, it should either obtain the device token needed for the upload or fail visibly. Silent skipped uploads make drain behavior and device-token rotation hard to verify.

## Implementation

- Pass `drain: true` from dashboard manual cloud sync and macOS manual Sync now.
- Keep launch/background sync on the lightweight default path.
- Let the local API issue a device token from the relayed refresh token when a drain request has no explicit device token.
- Return a 502 JSON error instead of running `sync --drain` when cloud sync is enabled but device-token issuance fails.
- Mirror `--drain` handling in the Vite dev local API.
- Add focused Node and Vitest coverage for drain handling, token issuance, and macOS manual-vs-launch sync behavior.

## Test Plan

- [x] `git diff --cached --check`
- [x] `node --test test/local-api-security.test.js test/cloud-sync-rotation.test.js test/macos-sync-now-drain.test.js`
- [x] `npm --prefix dashboard test -- src/lib/cloud-sync.test.ts`
- [x] `npm --prefix dashboard run build`
- [ ] `npm test` currently has one local timing failure unrelated to this diff: `test/usage-limits-singleflight.test.js` / `runs commands concurrently without blocking the event loop` reported `expected parallel execution, took 1081ms` when rerun alone and `1762ms` in the full suite on this machine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "drain" mode for sync operations—manual sync triggers now use drain mode while automatic sync continues with standard behavior.
  * Implemented cloud device token issuance to support drain sync workflows.

* **Tests**
  * Added comprehensive test coverage for drain sync behavior across local and cloud sync paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->