### PR TITLE
feat(usage-limits): read GitHub Copilot token from encrypted auth.db

### DIFF
--- a/src/lib/usage-limits.js
+++ b/src/lib/usage-limits.js
@@ -1,4 +1,5 @@
 const cp = require("node:child_process");
+const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
@@ -22,6 +23,7 @@ const {
   fetchCursorUsageSummary,
 } = require("./cursor-config");
 const { fetchGrokLimits } = require("./grok-limits");
+const { readSqliteJsonRows } = require("./sqlite-reader");
 
 // 2-minute in-memory cache
 let cache = { data: null, fetchedAt: 0 };
@@ -1157,11 +1159,26 @@ function parseKiroUsageOutput(output, { now = new Date() } = {}) {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // GitHub Copilot — `GET https://api.github.com/copilot_internal/user`
-// Reuses the OAuth token from the user's existing Copilot install
-// (`~/.config/github-copilot/{apps,hosts}.json`). No device flow needed.
+// Reuses the OAuth token from the user's existing Copilot install. Older clients
+// keep it in plaintext (`~/.config/github-copilot/{apps,hosts}.json`); recent
+// copilot-language-server builds (Zed, copilot.vim) migrate it into an encrypted
+// SQLite store (`auth.db`) and leave the plaintext files behind as stale legacy
+// copies. Read the plaintext first, then fall back to the encrypted store. No
+// device flow needed either way.
 // ─────────────────────────────────────────────────────────────────────────────
 
-function readCopilotOauthToken({ home = require("node:os").homedir() } = {}) {
+const MACOS_SECURITY_BIN = "/usr/bin/security";
+// copilot-language-server stores the OAuth token as AES-256-GCM ciphertext in
+// auth.db (`oauth_tokens.token_ciphertext`) and the 32-byte key in the macOS
+// Keychain (service `copilot-language-server`, account `oauth-token-key`,
+// base64-encoded). Ciphertext layout: iv(12) ‖ ciphertext ‖ authTag(16).
+const COPILOT_LS_KEYCHAIN_SERVICE = "copilot-language-server";
+const COPILOT_LS_KEYCHAIN_ACCOUNT = "oauth-token-key";
+const COPILOT_AUTH_DB_SQL =
+  "SELECT user_login, auth_authority, scopes, hex(token_ciphertext) AS token_hex, "
+  + "last_used_at, updated_at FROM oauth_tokens ORDER BY last_used_at DESC, updated_at DESC";
+
+function readPlaintextCopilotOauthToken({ home }) {
   const candidates = [
     path.join(home, ".config", "github-copilot", "apps.json"),
     path.join(home, ".config", "github-copilot", "hosts.json"),
@@ -1190,6 +1207,96 @@ function readCopilotOauthToken({ home = require("node:os").homedir() } = {}) {
     }
   }
   return fallback;
+}
+
+function readMacosKeychainGenericPassword({ service, account, securityRunner } = {}) {
+  const runner = typeof securityRunner === "function" ? securityRunner : cp.spawnSync;
+  if (runner === cp.spawnSync && !fs.existsSync(MACOS_SECURITY_BIN)) return null;
+  const args = ["find-generic-password", "-s", service];
+  if (account) args.push("-a", account);
+  args.push("-w");
+  const result = runner(MACOS_SECURITY_BIN, args, {
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 2000,
+    encoding: "utf8",
+  });
+  if (!result || result.error || result.status !== 0) return null;
+  const stdout =
+    typeof result.stdout === "string"
+      ? result.stdout
+      : Buffer.isBuffer(result.stdout)
+        ? result.stdout.toString("utf8")
+        : "";
+  const trimmed = stdout.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function decryptCopilotAuthDbToken(keyBase64, ciphertextHex) {
+  if (typeof keyBase64 !== "string" || typeof ciphertextHex !== "string") return null;
+  let key;
+  let blob;
+  try {
+    key = Buffer.from(keyBase64, "base64");
+    blob = Buffer.from(ciphertextHex, "hex");
+  } catch (_e) {
+    return null;
+  }
+  if (key.length !== 32) return null; // AES-256 key
+  if (blob.length < 12 + 16 + 1) return null; // iv(12) + authTag(16) + >=1 byte token
+  const iv = blob.subarray(0, 12);
+  const authTag = blob.subarray(blob.length - 16);
+  const data = blob.subarray(12, blob.length - 16);
+  try {
+    const decipher = crypto.createDecipheriv("aes-256-gcm", key, iv);
+    decipher.setAuthTag(authTag);
+    const out = Buffer.concat([decipher.update(data), decipher.final()]);
+    const token = out.toString("utf8").trim();
+    return token.length > 0 ? token : null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+function readCopilotAuthDbToken({ home, platform = process.platform, securityRunner, sqliteReader } = {}) {
+  // The decryption key lives in the macOS Keychain. On Linux/Windows the
+  // copilot-language-server uses libsecret / Credential Manager instead, which we
+  // don't read yet — callers fall back to the plaintext path there.
+  if (platform !== "darwin") return null;
+  const resolvedHome = home || os.homedir();
+  const dbPath = path.join(resolvedHome, ".config", "github-copilot", "auth.db");
+  const reader = typeof sqliteReader === "function" ? sqliteReader : readSqliteJsonRows;
+  let rows;
+  try {
+    rows = reader(dbPath, COPILOT_AUTH_DB_SQL, { label: "GitHub Copilot" });
+  } catch (_e) {
+    return null;
+  }
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  // Prefer the public github.com host (mirrors the plaintext reader); rows are
+  // already ordered most-recently-used first.
+  const row =
+    rows.find((r) => String(r?.auth_authority || "").split(":")[0] === "github.com") || rows[0];
+  const ciphertextHex = typeof row?.token_hex === "string" ? row.token_hex : null;
+  if (!ciphertextHex) return null;
+  const keyBase64 = readMacosKeychainGenericPassword({
+    service: COPILOT_LS_KEYCHAIN_SERVICE,
+    account: COPILOT_LS_KEYCHAIN_ACCOUNT,
+    securityRunner,
+  });
+  if (!keyBase64) return null;
+  return decryptCopilotAuthDbToken(keyBase64, ciphertextHex);
+}
+
+function readCopilotOauthToken({
+  home = os.homedir(),
+  platform = process.platform,
+  securityRunner,
+  sqliteReader,
+} = {}) {
+  const plaintext = readPlaintextCopilotOauthToken({ home });
+  if (plaintext) return plaintext;
+  // No plaintext token found — recover the live one from the encrypted auth.db.
+  return readCopilotAuthDbToken({ home, platform, securityRunner, sqliteReader });
 }
 
 function copilotRequestHeaders(token) {
@@ -1232,7 +1339,7 @@ function buildCopilotWindow(snapshot, resetIso) {
 }
 
 function describeCopilotOtelStatus({ home, env = process.env } = {}) {
-  const resolvedHome = home || env.HOME || require("node:os").homedir();
+  const resolvedHome = home || env.HOME || os.homedir();
   const enabled = String(env.COPILOT_OTEL_ENABLED || "").toLowerCase() === "true";
   const exporterType = String(env.COPILOT_OTEL_EXPORTER_TYPE || "").toLowerCase();
   const explicitPath = typeof env.COPILOT_OTEL_FILE_EXPORTER_PATH === "string"
@@ -1255,9 +1362,21 @@ function describeCopilotOtelStatus({ home, env = process.env } = {}) {
   };
 }
 
-async function fetchCopilotLimits({ home, env = process.env, fetchImpl = fetch } = {}) {
+async function fetchCopilotLimits({
+  home,
+  env = process.env,
+  fetchImpl = fetch,
+  platform = process.platform,
+  securityRunner,
+  sqliteReader,
+} = {}) {
   const otel = describeCopilotOtelStatus({ home, env });
-  const token = readCopilotOauthToken({ home: home || (env.HOME || require("node:os").homedir()) });
+  const token = readCopilotOauthToken({
+    home: home || (env.HOME || os.homedir()),
+    platform,
+    securityRunner,
+    sqliteReader,
+  });
   if (!token) return { configured: false, ...otel };
 
   try {
@@ -2072,7 +2191,7 @@ async function fetchUsageLimitsUncached({
       .catch((reason) => ({ configured: true, error: reason?.message || "Unknown error" })),
     fetchKiroLimits({ commandRunner, now }),
     fetchAntigravityLimits({ home, commandRunner, requestFn, nowMs }),
-    withProviderTimeout(fetchCopilotLimits({ home, env, fetchImpl: providerFetch }), "GitHub Copilot", providerTimeoutMs)
+    withProviderTimeout(fetchCopilotLimits({ home, env, fetchImpl: providerFetch, platform, securityRunner }), "GitHub Copilot", providerTimeoutMs)
       .catch((reason) => ({ configured: true, error: reason?.message || "Unknown error" })),
     withProviderTimeout(fetchGrokLimits({ home, env, fetchImpl: providerFetch }), "Grok Build", providerTimeoutMs)
       .catch((reason) => ({ configured: true, error: reason?.message || "Unknown error" })),
@@ -2183,6 +2302,8 @@ module.exports = {
   fetchAntigravityLimits,
   fetchCopilotLimits,
   readCopilotOauthToken,
+  readCopilotAuthDbToken,
+  decryptCopilotAuthDbToken,
   describeCopilotOtelStatus,
   fetchGrokLimits,
 };

--- a/test/copilot-auth-db.test.js
+++ b/test/copilot-auth-db.test.js
@@ -1,0 +1,186 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  readCopilotOauthToken,
+  readCopilotAuthDbToken,
+  decryptCopilotAuthDbToken,
+} = require("../src/lib/usage-limits");
+
+// Mirror copilot-language-server's auth.db scheme: AES-256-GCM with the
+// ciphertext laid out as iv(12) ‖ ciphertext ‖ authTag(16), key base64-encoded.
+function encryptToken(token, keyBuf) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", keyBuf, iv);
+  const enc = Buffer.concat([cipher.update(token, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, enc, tag]);
+}
+
+function makeAuthDbFixture(token, { authority = "github.com" } = {}) {
+  const keyBuf = crypto.randomBytes(32);
+  const blob = encryptToken(token, keyBuf);
+  return {
+    keyBase64: keyBuf.toString("base64"),
+    tokenHex: blob.toString("hex"),
+    authority,
+  };
+}
+
+describe("decryptCopilotAuthDbToken", () => {
+  it("round-trips an AES-256-GCM token", () => {
+    const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_decrypted_example_token");
+    assert.equal(decryptCopilotAuthDbToken(keyBase64, tokenHex), "ghu_decrypted_example_token");
+  });
+
+  it("returns null when the key is the wrong length (not AES-256)", () => {
+    const { tokenHex } = makeAuthDbFixture("ghu_token");
+    const shortKey = crypto.randomBytes(16).toString("base64");
+    assert.equal(decryptCopilotAuthDbToken(shortKey, tokenHex), null);
+  });
+
+  it("returns null when the auth tag does not verify (tampered ciphertext)", () => {
+    const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_token");
+    const tampered = Buffer.from(tokenHex, "hex");
+    tampered[tampered.length - 1] ^= 0xff; // flip a tag byte
+    assert.equal(decryptCopilotAuthDbToken(keyBase64, tampered.toString("hex")), null);
+  });
+
+  it("returns null on non-string input", () => {
+    assert.equal(decryptCopilotAuthDbToken(null, null), null);
+    assert.equal(decryptCopilotAuthDbToken(undefined, "00"), null);
+  });
+});
+
+describe("readCopilotAuthDbToken", () => {
+  const okRunner = (keyBase64) => () => ({ status: 0, stdout: keyBase64 });
+
+  it("decrypts the token from auth.db via the keychain key (macOS)", () => {
+    const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_authdb_token");
+    const token = readCopilotAuthDbToken({
+      home: "/home/test",
+      platform: "darwin",
+      securityRunner: okRunner(keyBase64),
+      sqliteReader: () => [{ auth_authority: "github.com", token_hex: tokenHex }],
+    });
+    assert.equal(token, "ghu_authdb_token");
+  });
+
+  it("prefers the public github.com row over a composite/enterprise row", () => {
+    const enterprise = makeAuthDbFixture("ghu_enterprise", { authority: "github.example.com" });
+    const publicHost = makeAuthDbFixture("ghu_public", { authority: "github.com" });
+    // Both rows decrypt with their own key; the keychain returns the public one's key.
+    const token = readCopilotAuthDbToken({
+      home: "/home/test",
+      platform: "darwin",
+      securityRunner: okRunner(publicHost.keyBase64),
+      sqliteReader: () => [
+        { auth_authority: "github.example.com", token_hex: enterprise.tokenHex },
+        { auth_authority: "github.com", token_hex: publicHost.tokenHex },
+      ],
+    });
+    assert.equal(token, "ghu_public");
+  });
+
+  it("returns null on non-darwin platforms (no keychain reader yet)", () => {
+    const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_token");
+    let readerCalled = false;
+    const token = readCopilotAuthDbToken({
+      home: "/home/test",
+      platform: "linux",
+      securityRunner: okRunner(keyBase64),
+      sqliteReader: () => {
+        readerCalled = true;
+        return [{ auth_authority: "github.com", token_hex: tokenHex }];
+      },
+    });
+    assert.equal(token, null);
+    assert.equal(readerCalled, false);
+  });
+
+  it("returns null when the keychain key is unavailable", () => {
+    const { tokenHex } = makeAuthDbFixture("ghu_token");
+    const token = readCopilotAuthDbToken({
+      home: "/home/test",
+      platform: "darwin",
+      securityRunner: () => ({ status: 1, stdout: "" }),
+      sqliteReader: () => [{ auth_authority: "github.com", token_hex: tokenHex }],
+    });
+    assert.equal(token, null);
+  });
+
+  it("returns null when auth.db has no token rows", () => {
+    const token = readCopilotAuthDbToken({
+      home: "/home/test",
+      platform: "darwin",
+      securityRunner: okRunner("AAAA"),
+      sqliteReader: () => [],
+    });
+    assert.equal(token, null);
+  });
+});
+
+describe("readCopilotOauthToken precedence", () => {
+  it("returns the plaintext apps.json token without consulting auth.db", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-"));
+    try {
+      const dir = path.join(tmp, ".config", "github-copilot");
+      fs.mkdirSync(dir, { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, "apps.json"),
+        JSON.stringify({
+          "github.com:Iv1.b507a08c87ecfe98": { user: "octocat", oauth_token: "ghu_plaintext_token" },
+        }),
+      );
+      const token = readCopilotOauthToken({
+        home: tmp,
+        platform: "darwin",
+        // Would throw if the encrypted fallback were consulted.
+        securityRunner: () => {
+          throw new Error("keychain should not be read when plaintext exists");
+        },
+        sqliteReader: () => {
+          throw new Error("auth.db should not be read when plaintext exists");
+        },
+      });
+      assert.equal(token, "ghu_plaintext_token");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("falls back to the encrypted auth.db when no plaintext token exists", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-"));
+    try {
+      const { keyBase64, tokenHex } = makeAuthDbFixture("ghu_fallback_token");
+      const token = readCopilotOauthToken({
+        home: tmp, // no apps.json / hosts.json present
+        platform: "darwin",
+        securityRunner: () => ({ status: 0, stdout: keyBase64 }),
+        sqliteReader: () => [{ auth_authority: "github.com", token_hex: tokenHex }],
+      });
+      assert.equal(token, "ghu_fallback_token");
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns null when there is neither a plaintext nor an encrypted token", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "tokentracker-copilot-"));
+    try {
+      const token = readCopilotOauthToken({
+        home: tmp,
+        platform: "linux",
+        securityRunner: () => ({ status: 1, stdout: "" }),
+        sqliteReader: () => [],
+      });
+      assert.equal(token, null);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The Copilot usage-limits reader (`readCopilotOauthToken`) only reads the plaintext `oauth_token` from `~/.config/github-copilot/{apps,hosts}.json`. Recent **`copilot-language-server`** builds (used by **Zed** and modern **copilot.vim**) have migrated the OAuth token into an **encrypted SQLite store** at `~/.config/github-copilot/auth.db`, leaving the plaintext files behind as **stale legacy copies** (marked by `metadata.legacy_files_migration_done`).

Consequence: on those setups the panel keeps working only because the legacy `gho_`/`ghu_` token is long-lived — it **silently breaks the next time the user re-authenticates**, and never works for fresh installs that only ever write `auth.db`.

## Fix

`readCopilotOauthToken` now falls back to decrypting `auth.db` **when no plaintext token is found**:

- Token is `oauth_tokens.token_ciphertext` — **AES-256-GCM**, layout `iv(12) ‖ ciphertext ‖ authTag(16)`.
- The 32-byte key is read from the **macOS Keychain** (service `copilot-language-server`, account `oauth-token-key`, base64-encoded), via `/usr/bin/security` — the same mechanism the existing Claude reader uses.
- The public `github.com` authority row is preferred (mirrors the plaintext reader); rows are ordered most-recently-used first.

**Plaintext stays the primary path**, so setups that already work see **no new keychain prompt** and unchanged behavior — the change is purely additive.

### Scope / limitations
- **macOS only** for now. On Linux/Windows the language server keeps the key in libsecret / Credential Manager; those platforms fall back to the existing plaintext path. (Mirrors the macOS-gating of the Claude keychain reader.)
- **VS Code is intentionally out of scope** here (it stores the token in `state.vscdb` encrypted with the `Code Safe Storage` key via Chromium `os_crypt`) — a good candidate for a follow-up PR.

## Verification
- New `test/copilot-auth-db.test.js` (12 cases): AES-256-GCM round-trip, wrong-key/tamper rejection, `github.com` row preference, platform gating, and **plaintext-first precedence** (asserts `auth.db`/keychain are *not* consulted when plaintext exists). Fully dependency-injected (no real FS/keychain), so it runs cross-platform in CI.
- Full suite: **905/906 pass** (the one failure is a pre-existing load-sensitive timing test in `usage-limits-singleflight.test.js`, which also fails on a clean `main`).
- Architecture guardrails pass.
- Validated against real data on macOS: the encrypted token decrypts to a valid `ghu_…` token, and the existing plaintext path is unchanged.

## Notes
- Reuses the existing `readSqliteJsonRows` helper (`hex(token_ciphertext)` keeps the BLOB binary-safe through both the `sqlite3` CLI and `node:sqlite` paths).
- No new dependencies (`node:crypto` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved GitHub Copilot token resolution on macOS by using encrypted credentials from the local auth database when plaintext credentials aren’t available.

* **Bug Fixes**
  * More reliable fallback behavior for Copilot usage-limit retrieval when token sources differ or encrypted data can’t be decrypted.

* **Tests**
  * Added coverage for encrypted token decryption, source-precedence rules (plaintext vs encrypted), and macOS/non-macOS scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->